### PR TITLE
chore: 빌드 캐시 자동 삭제 활성화

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,12 @@ pluginManagement {
     }
 }
 
+buildCache {
+    local {
+        removeUnusedEntriesAfterDays = 7
+    }
+}
+
 include(
     ":data",
     ":domain",


### PR DESCRIPTION
## Overview (Required)

- 7일동안 한 번도 사용되지 않은 그레이들 캐시는 자동 삭제하도록 설정
