### PR TITLE
문제 만들기 API 추가

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementations(
         libs.login.kakao,
         libs.kotlin.coroutines,
+        libs.bundles.ktor,
         projects.domain,
         projects.utilKotlin,
     )

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     id(ConventionEnum.AndroidLibrary)
     id(ConventionEnum.JvmJUnit4)
     id(ConventionEnum.JvmDokka)
+    id(ConventionEnum.AndroidHilt)
     id(libs.plugins.util.secrets.get().pluginId)
 }
 

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
@@ -8,19 +8,63 @@
 package team.duckie.app.android.data.exam.datasource.remote
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.request
 import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import team.duckie.app.android.data.exam.mapper.toDomain
+import team.duckie.app.android.data.exam.model.ExamRequest
+import team.duckie.app.android.data.exam.model.ExamResponse
+import team.duckie.app.android.data.exam.model.TagData
+import team.duckie.app.android.data.user.model.UserData
+import java.util.Date
 import javax.inject.Inject
 
 class ExamDataSource @Inject constructor(
     private val client: HttpClient
 ) {
-
-    suspend fun postExams(){
-        val request = client.post {
-            setBody()
-            header("authorization", "accessToken")
-        }
+    suspend fun postExams(examRequest: ExamRequest): ExamResponse {
+        val request = client
+            .post {
+                url("/exams")
+                setBody(examRequest)
+                header("authorization", "AT") //TODO [Evergreen] access token 자동화 방안 마련 필요
+            }
+        val body: ExamResponse = request.body()
+        //return body
+        return dummyResponse
     }
 }
+
+val dummyResponse = ExamResponse(
+    title = "Test Title 2",
+    description = "Test Description 2",
+    thumbnailUrl = "Test Image Url",
+    certifyingStatement = "Test 필적 확인 문구1",
+    buttonTitle = "Test Button Title 1",
+    isPublic = true,
+    tags = listOf(
+        TagData(0, "tag1"),
+        TagData(1, "tag2")
+    ),
+    UserData(
+        id = 1,
+        nickName = "goddoro",
+        accountEnabled = true,
+        profileUrl = "asdf",
+        tier = 1,
+        createdAt = Date(),
+        updatedAt = Date(),
+        deletedAt = null,
+        bannedAt = null,
+    ),
+    deletedAt = null,
+    id = 11,
+    createdAt = Date(),
+    updatedAt = Date(),
+    solvedCount = 0,
+    answerRate = 0.0f,
+    canRetry = true
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
@@ -38,7 +38,7 @@ class ExamDataSource @Inject constructor(
     }
 }
 
-val dummyResponse = ExamResponse(
+private val dummyResponse = ExamResponse(
     title = "Test Title 2",
     description = "Test Description 2",
     thumbnailUrl = "Test Image Url",

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.exam.datasource.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import javax.inject.Inject
+
+class ExamDataSource @Inject constructor(
+    private val client: HttpClient
+) {
+
+    suspend fun postExams(){
+        val request = client.post {
+            setBody()
+            header("authorization", "accessToken")
+        }
+    }
+}

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
@@ -26,14 +26,14 @@ class ExamDataSource @Inject constructor(
     private val client: HttpClient
 ) {
     suspend fun postExams(examRequest: ExamRequest): ExamResponse {
-        val request = client
+       /* val request = client
             .post {
                 url("/exams")
                 setBody(examRequest)
                 header("authorization", "AT") //TODO [Evergreen] access token 자동화 방안 마련 필요
             }
         val body: ExamResponse = request.body()
-        //return body
+        return body*/
         return dummyResponse
     }
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
@@ -66,5 +66,5 @@ private val dummyResponse = ExamResponse(
     updatedAt = Date(),
     solvedCount = 0,
     answerRate = 0.0f,
-    canRetry = true
+    canRetry = true,
 )

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -41,23 +41,48 @@ fun ExamParam.toData() = ExamRequest(
 
 fun ProblemItem.toData() = ProblemItemData(
     questionObject = when (questionObject) {
-        Question.Text -> QuestionData.Text
-        is Question.Video -> QuestionData.Video(videoUrl = (questionObject as Question.Video).videoUrl)
-        is Question.Image -> QuestionData.Image(imageUrl = (questionObject as Question.Image).imageUrl)
-        is Question.Audio -> QuestionData.Audio(audioUrl = (questionObject as Question.Audio).audioUrl)
+        is Question.Text -> QuestionData.Text(
+            type = questionObject.type,
+            text = questionObject.text
+        )
+
+        is Question.Video -> QuestionData.Video(
+            videoUrl = (questionObject as Question.Video).videoUrl,
+            type = questionObject.type,
+            text = questionObject.text
+        )
+
+        is Question.Image -> QuestionData.Image(
+            imageUrl = (questionObject as Question.Image).imageUrl,
+            type = questionObject.type,
+            text = questionObject.text
+        )
+
+        is Question.Audio -> QuestionData.Audio(
+            audioUrl = (questionObject as Question.Audio).audioUrl,
+            type = questionObject.type,
+            text = questionObject.text
+        )
     },
     answerObject = when (answerObject) {
-        is Answer.ShortAnswer -> AnswerData.ShortAnswer(shortAnswer = (answerObject as Answer.ShortAnswer).shortAnswer)
+        is Answer.ShortAnswer -> AnswerData.ShortAnswer(
+            shortAnswer = (answerObject as Answer.ShortAnswer).shortAnswer,
+            type = answerObject.type,
+        )
+
         is Answer.Choice -> AnswerData.Choice(
             choices = (answerObject as Answer.Choice).choices.map {
                 it.toData()
-            }
+            },
+            type = answerObject.type,
         )
+
 
         is Answer.ImageChoice -> AnswerData.ImageChoice(
             imageChoice = (answerObject as Answer.ImageChoice).imageChoice.map {
                 it.toData()
-            }
+            },
+            type = answerObject.type,
         )
     },
     correctAnswer = correctAnswer,

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -30,12 +30,13 @@ fun ExamParam.toData() = ExamRequest(
     description = description,
     mainTag = mainTag.toData(),
     subTag = subTag?.map { it.toData() },
+    userId = userId,
     certifyingStatement = certifyingStatement,
     thumbnailImageUrl = thumbnailImageUrl,
     thumbnailType = thumbnailType,
     problems = problems.toData(),
     isPublic = isPublic,
-    buttonText = buttonText
+    buttonText = buttonText,
 )
 
 fun ProblemItem.toData() = ProblemItemData(

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -36,7 +36,7 @@ fun ExamParam.toData() = ExamRequest(
     thumbnailType = thumbnailType,
     problems = problems.toData(),
     isPublic = isPublic,
-    buttonText = buttonText,
+    buttonTitle = buttonTitle,
 )
 
 fun ProblemItem.toData() = ProblemItemData(

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -1,0 +1,102 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.exam.mapper
+
+import team.duckie.app.android.data.exam.model.AnswerData
+import team.duckie.app.android.data.exam.model.ChoiceData
+import team.duckie.app.android.data.exam.model.ExamRequest
+import team.duckie.app.android.data.exam.model.ExamResponse
+import team.duckie.app.android.data.exam.model.ImageChoiceData
+import team.duckie.app.android.data.exam.model.ProblemItemData
+import team.duckie.app.android.data.exam.model.QuestionData
+import team.duckie.app.android.data.exam.model.TagData
+import team.duckie.app.android.data.user.mapper.toDomain
+import team.duckie.app.android.domain.exam.model.Answer
+import team.duckie.app.android.domain.exam.model.ChoiceModel
+import team.duckie.app.android.domain.exam.model.Exam
+import team.duckie.app.android.domain.exam.model.ExamParam
+import team.duckie.app.android.domain.exam.model.ImageChoiceModel
+import team.duckie.app.android.domain.exam.model.ProblemItem
+import team.duckie.app.android.domain.exam.model.Question
+import team.duckie.app.android.domain.exam.model.Tag
+
+fun ExamParam.toData() = ExamRequest(
+    title = title,
+    description = description,
+    mainTag = mainTag.toData(),
+    subTag = subTag?.map { it.toData() },
+    certifyingStatement = certifyingStatement,
+    thumbnailImageUrl = thumbnailImageUrl,
+    thumbnailType = thumbnailType,
+    problems = problems.toData(),
+    isPublic = isPublic,
+    buttonText = buttonText
+)
+
+fun ProblemItem.toData() = ProblemItemData(
+    questionObject = when (questionObject) {
+        Question.Text -> QuestionData.Text
+        is Question.Video -> QuestionData.Video(videoUrl = (questionObject as Question.Video).videoUrl)
+        is Question.Image -> QuestionData.Image(imageUrl = (questionObject as Question.Image).imageUrl)
+        is Question.Audio -> QuestionData.Audio(audioUrl = (questionObject as Question.Audio).audioUrl)
+    },
+    answerObject = when (answerObject) {
+        is Answer.ShortAnswer -> AnswerData.ShortAnswer(shortAnswer = (answerObject as Answer.ShortAnswer).shortAnswer)
+        is Answer.Choice -> AnswerData.Choice(
+            choices = (answerObject as Answer.Choice).choices.map {
+                it.toData()
+            }
+        )
+
+        is Answer.ImageChoice -> AnswerData.ImageChoice(
+            imageChoice = (answerObject as Answer.ImageChoice).imageChoice.map {
+                it.toData()
+            }
+        )
+    },
+    correctAnswer = correctAnswer,
+    hint = hint,
+    memo = memo
+)
+
+fun ChoiceModel.toData() = ChoiceData(
+    text = text
+)
+
+fun ImageChoiceModel.toData() = ImageChoiceData(
+    text = text,
+    imageUrl = imageUrl
+)
+
+fun Tag.toData() = TagData(
+    id = id,
+    name = name
+)
+
+fun TagData.toDomain() = Tag(
+    id = id,
+    name = name,
+)
+
+fun ExamResponse.toDomain() = Exam(
+    title = title,
+    description = description,
+    thumbnailUrl = thumbnailUrl,
+    certifyingStatement = certifyingStatement,
+    buttonTitle = buttonTitle,
+    isPublic = isPublic,
+    tags = tags.map { it.toDomain() },
+    user = user.toDomain(),
+    deletedAt = deletedAt,
+    id = id,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    solvedCount = solvedCount,
+    answerRate = answerRate,
+    canRetry = canRetry,
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -25,7 +25,7 @@ import team.duckie.app.android.domain.exam.model.ProblemItem
 import team.duckie.app.android.domain.exam.model.Question
 import team.duckie.app.android.domain.exam.model.Tag
 
-fun ExamParam.toData() = ExamRequest(
+internal fun ExamParam.toData() = ExamRequest(
     title = title,
     description = description,
     mainTag = mainTag.toData(),
@@ -39,7 +39,7 @@ fun ExamParam.toData() = ExamRequest(
     buttonTitle = buttonTitle,
 )
 
-fun ProblemItem.toData() = ProblemItemData(
+internal fun ProblemItem.toData() = ProblemItemData(
     questionObject = when (questionObject) {
         is Question.Text -> QuestionData.Text(
             type = questionObject.type,
@@ -90,26 +90,26 @@ fun ProblemItem.toData() = ProblemItemData(
     memo = memo
 )
 
-fun ChoiceModel.toData() = ChoiceData(
+internal fun ChoiceModel.toData() = ChoiceData(
     text = text
 )
 
-fun ImageChoiceModel.toData() = ImageChoiceData(
+internal fun ImageChoiceModel.toData() = ImageChoiceData(
     text = text,
     imageUrl = imageUrl
 )
 
-fun Tag.toData() = TagData(
+internal fun Tag.toData() = TagData(
     id = id,
     name = name
 )
 
-fun TagData.toDomain() = Tag(
+internal fun TagData.toDomain() = Tag(
     id = id,
     name = name,
 )
 
-fun ExamResponse.toDomain() = Exam(
+internal fun ExamResponse.toDomain() = Exam(
     title = title,
     description = description,
     thumbnailUrl = thumbnailUrl,

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
@@ -9,7 +9,7 @@ package team.duckie.app.android.data.exam.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-internal data class ExamRequest(
+data class ExamRequest(
     @field:JsonProperty("title")
     val title: String,
     @field:JsonProperty("description")

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
@@ -7,34 +7,27 @@
 
 package team.duckie.app.android.data.exam.model
 
-import team.duckie.app.android.data.exam.model.QuestionRequest.Text.text
-import team.duckie.app.android.data.exam.model.QuestionRequest.Text.type
+import com.fasterxml.jackson.annotation.JsonProperty
 
 data class ExamRequest(
+    @field:JsonProperty("title")
     val title: String,
+    @field:JsonProperty("description")
     val description: String,
-    val mainTag: Tag,
-    val subTag: List<Tag>,
+    @field:JsonProperty("mainTag")
+    val mainTag: TagData,
+    @field:JsonProperty("subTags")
+    val subTag: List<TagData>?,
+    @field:JsonProperty("certifyingStatement")
     val certifyingStatement: String,
-    val thumbnailImageUrl: String,
-    //val problems
-)
-
-sealed class QuestionRequest(
-    val type: String,
-    val text: String,
-){
-    object Text: QuestionRequest(type, text)
-    data class Image(val imageUrl: String) : QuestionRequest(type,text)
-    data class Audio(val audioUrl: String) : QuestionRequest(type,text)
-    data class Video(val videoUrl: String) : QuestionRequest(type,text)
-}
-
-data class Tag(
-    val tag: Int,
-    val name: String
-)
-
-data class ProblemItem(
-    val type: String
+    @field:JsonProperty("thumbnailImageUrl")
+    val thumbnailImageUrl: String?,
+    @field:JsonProperty("thumbnailType")
+    val thumbnailType: String,
+    @field:JsonProperty("problems")
+    val problems: ProblemItemData,
+    @field:JsonProperty("isPublic")
+    val isPublic: Boolean?,
+    @field:JsonProperty("buttonText")
+    val buttonText: String?,
 )

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
@@ -18,6 +18,8 @@ data class ExamRequest(
     val mainTag: TagData,
     @field:JsonProperty("subTags")
     val subTag: List<TagData>?,
+    @field:JsonProperty("userId")
+    val userId: Int,
     @field:JsonProperty("certifyingStatement")
     val certifyingStatement: String,
     @field:JsonProperty("thumbnailImageUrl")
@@ -29,5 +31,5 @@ data class ExamRequest(
     @field:JsonProperty("isPublic")
     val isPublic: Boolean?,
     @field:JsonProperty("buttonText")
-    val buttonText: String?,
+    val buttonTitle: String?,
 )

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
@@ -1,0 +1,40 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.exam.model
+
+import team.duckie.app.android.data.exam.model.QuestionRequest.Text.text
+import team.duckie.app.android.data.exam.model.QuestionRequest.Text.type
+
+data class ExamRequest(
+    val title: String,
+    val description: String,
+    val mainTag: Tag,
+    val subTag: List<Tag>,
+    val certifyingStatement: String,
+    val thumbnailImageUrl: String,
+    //val problems
+)
+
+sealed class QuestionRequest(
+    val type: String,
+    val text: String,
+){
+    object Text: QuestionRequest(type, text)
+    data class Image(val imageUrl: String) : QuestionRequest(type,text)
+    data class Audio(val audioUrl: String) : QuestionRequest(type,text)
+    data class Video(val videoUrl: String) : QuestionRequest(type,text)
+}
+
+data class Tag(
+    val tag: Int,
+    val name: String
+)
+
+data class ProblemItem(
+    val type: String
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamRequest.kt
@@ -9,7 +9,7 @@ package team.duckie.app.android.data.exam.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class ExamRequest(
+internal data class ExamRequest(
     @field:JsonProperty("title")
     val title: String,
     @field:JsonProperty("description")

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamResponse.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamResponse.kt
@@ -1,0 +1,45 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.exam.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import team.duckie.app.android.data.user.model.UserData
+import java.util.Date
+
+data class ExamResponse(
+    @field:JsonProperty("title")
+    val title: String,
+    @field:JsonProperty("description")
+    val description: String,
+    @field:JsonProperty("thumbnailUrl")
+    val thumbnailUrl: String?,
+    @field:JsonProperty("certifyingStatement")
+    val certifyingStatement: String,
+    @field:JsonProperty("buttonTitle")
+    val buttonTitle: String,
+    @field:JsonProperty("isPublic")
+    val isPublic: Boolean,
+    @field:JsonProperty("tags")
+    val tags: List<TagData>,
+    @field:JsonProperty("user")
+    val user: UserData,
+    @field:JsonProperty("deletedAt")
+    val deletedAt: Date? = null,
+    @field:JsonProperty("id")
+    val id: Int,
+    @field:JsonProperty("createdAt")
+    val createdAt: Date,
+    @field:JsonProperty("updatedAt")
+    val updatedAt: Date,
+    @field:JsonProperty("solvedCount")
+    val solvedCount: Int,
+    @field:JsonProperty("answerRate")
+    val answerRate: Float,
+    @field:JsonProperty("canRetry")
+    val canRetry: Boolean,
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamResponse.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamResponse.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import team.duckie.app.android.data.user.model.UserData
 import java.util.Date
 
-data class ExamResponse(
+internal data class ExamResponse(
     @field:JsonProperty("title")
     val title: String,
     @field:JsonProperty("description")

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -9,7 +9,7 @@ package team.duckie.app.android.data.exam.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class ProblemItemData(
+internal data class ProblemItemData(
     @field:JsonProperty("question")
     val questionObject: QuestionData,
     @field:JsonProperty("answer")
@@ -22,7 +22,7 @@ data class ProblemItemData(
     val memo: String?
 )
 
-sealed class QuestionData(
+internal sealed class QuestionData(
     @field:JsonProperty("type")
     open val type: String,
     @field:JsonProperty("text")
@@ -55,14 +55,14 @@ sealed class QuestionData(
     ) : QuestionData(type, text)
 }
 
-data class TagData(
+internal data class TagData(
     @field:JsonProperty("id")
     val id: Int,
     @field:JsonProperty("name")
     val name: String
 )
 
-sealed class AnswerData(
+internal sealed class AnswerData(
     @field:JsonProperty("type")
     open val type: String
 ) {
@@ -86,12 +86,12 @@ sealed class AnswerData(
 }
 
 @JvmInline
-value class ChoiceData(
+internal value class ChoiceData(
     @field:JsonProperty("text")
     val text: String
 )
 
-data class ImageChoiceData(
+internal data class ImageChoiceData(
     @field:JsonProperty("text")
     val text: String,
     @field:JsonProperty("imageUrl")

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -1,0 +1,89 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.exam.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import team.duckie.app.android.data.exam.model.QuestionData.Text.text
+import team.duckie.app.android.data.exam.model.QuestionData.Text.type
+
+data class ProblemItemData(
+    @field:JsonProperty("question")
+    val questionObject: QuestionData,
+    @field:JsonProperty("answer")
+    val answerObject: AnswerData,
+    @field:JsonProperty("correctAnswer")
+    val correctAnswer: String,
+    @field:JsonProperty("hint")
+    val hint: String?,
+    @field:JsonProperty("memo")
+    val memo: String?
+)
+
+sealed class QuestionData(
+    @field:JsonProperty("type")
+    val type: String,
+    @field:JsonProperty("text")
+    val text: String,
+) {
+    object Text : QuestionData(type, text)
+
+    data class Image(
+        @field:JsonProperty("imageUrl")
+        val imageUrl: String
+    ) : QuestionData(type, text)
+
+    data class Audio(
+        @field:JsonProperty("audioUrl")
+        val audioUrl: String
+    ) : QuestionData(type, text)
+
+    data class Video(
+        @field:JsonProperty("videoUrl")
+        val videoUrl: String
+    ) : QuestionData(type, text)
+}
+
+data class TagData(
+    @field:JsonProperty("id")
+    val id: Int,
+    @field:JsonProperty("name")
+    val name: String
+)
+
+sealed class AnswerData(
+    @field:JsonProperty("type")
+    val type: String
+) {
+    data class ShortAnswer(
+        @field:JsonProperty("shortAnswer")
+        val shortAnswer: String
+    ) : AnswerData(type)
+
+    data class Choice(
+        @field:JsonProperty("choice")
+        val choices: List<ChoiceData>
+    ) : AnswerData(type)
+
+    data class ImageChoice(
+        @field:JsonProperty("imageChoice")
+        val imageChoice: List<ImageChoiceData>
+    ) : AnswerData(type)
+}
+
+@JvmInline
+value class ChoiceData(
+    @field:JsonProperty("text")
+    val text: String
+)
+
+data class ImageChoiceData(
+    @field:JsonProperty("text")
+    val text: String,
+    @field:JsonProperty("imageUrl")
+    val imageUrl: String
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -8,8 +8,6 @@
 package team.duckie.app.android.data.exam.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import team.duckie.app.android.data.exam.model.QuestionData.Text.text
-import team.duckie.app.android.data.exam.model.QuestionData.Text.type
 
 data class ProblemItemData(
     @field:JsonProperty("question")
@@ -26,25 +24,34 @@ data class ProblemItemData(
 
 sealed class QuestionData(
     @field:JsonProperty("type")
-    val type: String,
+    open val type: String,
     @field:JsonProperty("text")
-    val text: String,
+    open val text: String,
 ) {
-    object Text : QuestionData(type, text)
+    data class Text(
+        override val type: String,
+        override val text: String,
+    ) : QuestionData(type, text)
 
     data class Image(
         @field:JsonProperty("imageUrl")
-        val imageUrl: String
+        val imageUrl: String,
+        override val type: String,
+        override val text: String,
     ) : QuestionData(type, text)
 
     data class Audio(
         @field:JsonProperty("audioUrl")
-        val audioUrl: String
+        val audioUrl: String,
+        override val type: String,
+        override val text: String,
     ) : QuestionData(type, text)
 
     data class Video(
         @field:JsonProperty("videoUrl")
-        val videoUrl: String
+        val videoUrl: String,
+        override val type: String,
+        override val text: String,
     ) : QuestionData(type, text)
 }
 
@@ -57,21 +64,24 @@ data class TagData(
 
 sealed class AnswerData(
     @field:JsonProperty("type")
-    val type: String
+    open val type: String
 ) {
     data class ShortAnswer(
         @field:JsonProperty("shortAnswer")
-        val shortAnswer: String
+        val shortAnswer: String,
+        override val type: String,
     ) : AnswerData(type)
 
     data class Choice(
         @field:JsonProperty("choice")
-        val choices: List<ChoiceData>
+        val choices: List<ChoiceData>,
+        override val type: String,
     ) : AnswerData(type)
 
     data class ImageChoice(
         @field:JsonProperty("imageChoice")
-        val imageChoice: List<ImageChoiceData>
+        val imageChoice: List<ImageChoiceData>,
+        override val type: String,
     ) : AnswerData(type)
 }
 

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -9,7 +9,7 @@ package team.duckie.app.android.data.exam.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-internal data class ProblemItemData(
+data class ProblemItemData(
     @field:JsonProperty("question")
     val questionObject: QuestionData,
     @field:JsonProperty("answer")
@@ -22,7 +22,7 @@ internal data class ProblemItemData(
     val memo: String?
 )
 
-internal sealed class QuestionData(
+sealed class QuestionData(
     @field:JsonProperty("type")
     open val type: String,
     @field:JsonProperty("text")
@@ -55,14 +55,14 @@ internal sealed class QuestionData(
     ) : QuestionData(type, text)
 }
 
-internal data class TagData(
+data class TagData(
     @field:JsonProperty("id")
     val id: Int,
     @field:JsonProperty("name")
     val name: String
 )
 
-internal sealed class AnswerData(
+sealed class AnswerData(
     @field:JsonProperty("type")
     open val type: String
 ) {
@@ -86,12 +86,12 @@ internal sealed class AnswerData(
 }
 
 @JvmInline
-internal value class ChoiceData(
+value class ChoiceData(
     @field:JsonProperty("text")
     val text: String
 )
 
-internal data class ImageChoiceData(
+data class ImageChoiceData(
     @field:JsonProperty("text")
     val text: String,
     @field:JsonProperty("imageUrl")

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.exam.repository
+
+import team.duckie.app.android.data.exam.datasource.remote.ExamDataSource
+import team.duckie.app.android.data.exam.mapper.toData
+import team.duckie.app.android.data.exam.mapper.toDomain
+import team.duckie.app.android.domain.exam.model.Exam
+import team.duckie.app.android.domain.exam.model.ExamParam
+import team.duckie.app.android.domain.exam.repository.ExamRepository
+import javax.inject.Inject
+
+class ExamRepositoryImpl @Inject constructor(
+    private val examDataSource: ExamDataSource,
+) : ExamRepository {
+    override suspend fun makeExam(examParam: ExamParam): Exam {
+        return examDataSource.postExams(examParam.toData()).toDomain()
+    }
+}

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/mapper/mapper.kt
@@ -1,0 +1,30 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.user.mapper
+
+import team.duckie.app.android.data.user.model.UserData
+import team.duckie.app.android.domain.user.model.User
+
+fun UserData.toDomain() = User(
+    id = id,
+    nickName = nickName,
+    accountEnabled = accountEnabled,
+    profileUrl = profileUrl,
+    tier = tier,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    deletedAt = deletedAt,
+    bannedAt = bannedAt
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/mapper/mapper.kt
@@ -17,7 +17,7 @@ package team.duckie.app.android.data.user.mapper
 import team.duckie.app.android.data.user.model.UserData
 import team.duckie.app.android.domain.user.model.User
 
-fun UserData.toDomain() = User(
+internal fun UserData.toDomain() = User(
     id = id,
     nickName = nickName,
     accountEnabled = accountEnabled,

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/model/UserData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/model/UserData.kt
@@ -10,7 +10,7 @@ package team.duckie.app.android.data.user.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.Date
 
-data class UserData(
+internal data class UserData(
     @field:JsonProperty("id")
     val id: Int,
     @field:JsonProperty("nickName")

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/model/UserData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/model/UserData.kt
@@ -1,0 +1,32 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.user.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.Date
+
+data class UserData(
+    @field:JsonProperty("id")
+    val id: Int,
+    @field:JsonProperty("nickName")
+    val nickName: String,
+    @field:JsonProperty("accountEnabled")
+    val accountEnabled: Boolean,
+    @field:JsonProperty("profileUrl")
+    val profileUrl: String,
+    @field:JsonProperty("tier")
+    val tier: Int,
+    @field:JsonProperty("createdAt")
+    val createdAt: Date,
+    @field:JsonProperty("updatedAt")
+    val updatedAt: Date,
+    @field:JsonProperty("deletedAt")
+    val deletedAt: Date? = null,
+    @field:JsonProperty("bannedAt")
+    val bannedAt: Date? = null,
+)

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -20,5 +20,6 @@ dependencies {
     implementations(
         projects.data,
         projects.domain,
+        libs.bundles.ktor
     )
 }

--- a/di/src/main/kotlin/team/duckie/app/android/di/datasource/NetworkModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/datasource/NetworkModule.kt
@@ -1,0 +1,57 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.di.datasource
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.cio.endpoint
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.ANDROID
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.jackson.jackson
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal class NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideKtorClient(): HttpClient = HttpClient(CIO) {
+        expectSuccess = true
+        engine {
+            endpoint {
+                connectTimeout = MaxTimeoutMillis
+                connectAttempts = MaxRetryCount
+            }
+        }
+        defaultRequest {
+            url(BaseUrl)
+        }
+        install(plugin = ContentNegotiation) {
+            jackson()
+        }
+        install(plugin = Logging) {
+            logger = Logger.ANDROID
+            level = LogLevel.ALL
+        }
+    }
+
+    private companion object {
+        const val MaxTimeoutMillis = 3000L
+        const val MaxRetryCount = 3
+        const val BaseUrl = "https://api.publicapis.org/entries"
+    }
+}

--- a/di/src/main/kotlin/team/duckie/app/android/di/datasource/NetworkModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/datasource/NetworkModule.kt
@@ -52,6 +52,6 @@ internal class NetworkModule {
     private companion object {
         const val MaxTimeoutMillis = 3000L
         const val MaxRetryCount = 3
-        const val BaseUrl = "https://api.publicapis.org/entries"
+        const val BaseUrl = ""// TODO [Evergreen] add base url
     }
 }

--- a/di/src/main/kotlin/team/duckie/app/android/di/repository/ExamRepositoryModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/repository/ExamRepositoryModule.kt
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.di.repository
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import team.duckie.app.android.data.exam.repository.ExamRepositoryImpl
+import team.duckie.app.android.domain.exam.repository.ExamRepository
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ExamRepositoryModule {
+
+    @Binds
+    abstract fun provideExamRepository(
+        examRepositoryImpl: ExamRepositoryImpl,
+    ): ExamRepository
+
+}

--- a/di/src/main/kotlin/team/duckie/app/android/di/usecase/exam/ExamUseCaseModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/usecase/exam/ExamUseCaseModule.kt
@@ -1,0 +1,25 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.di.usecase.exam
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import team.duckie.app.android.domain.exam.repository.ExamRepository
+import team.duckie.app.android.domain.exam.usecase.MakeExamUseCase
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ExamUseCaseModule {
+
+    @Provides
+    fun provideMakeExamUseCase(repository: ExamRepository): MakeExamUseCase {
+        return MakeExamUseCase(repository)
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementations(
         libs.compose.runtime, // needs for Stability
         libs.kotlin.collections.immutable,
+        libs.di.inject,
         projects.utilKotlin,
     )
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
@@ -1,0 +1,29 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.model
+
+import team.duckie.app.android.domain.user.model.User
+import java.util.Date
+
+data class Exam(
+    val title: String,
+    val description: String,
+    val thumbnailUrl: String?,
+    val certifyingStatement: String,
+    val buttonTitle: String,
+    val isPublic: Boolean,
+    val tags: List<Tag>,
+    val user: User,
+    val deletedAt: Date? = null,
+    val id: Int,
+    val createdAt: Date,
+    val updatedAt: Date,
+    val solvedCount: Int,
+    val answerRate: Float,
+    val canRetry: Boolean,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
@@ -7,9 +7,11 @@
 
 package team.duckie.app.android.domain.exam.model
 
+import androidx.compose.runtime.Immutable
 import team.duckie.app.android.domain.user.model.User
 import java.util.Date
 
+@Immutable
 data class Exam(
     val title: String,
     val description: String,

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
@@ -8,6 +8,7 @@
 package team.duckie.app.android.domain.exam.model
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 import team.duckie.app.android.domain.user.model.User
 import java.util.Date
 
@@ -19,7 +20,7 @@ data class Exam(
     val certifyingStatement: String,
     val buttonTitle: String,
     val isPublic: Boolean,
-    val tags: List<Tag>,
+    val tags: ImmutableList<Tag>,
     val user: User,
     val deletedAt: Date? = null,
     val id: Int,

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
@@ -1,0 +1,21 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.model
+
+data class ExamParam(
+    val title: String,
+    val description: String,
+    val mainTag: Tag,
+    val subTag: List<Tag>?,
+    val certifyingStatement: String,
+    val thumbnailImageUrl: String?,
+    val thumbnailType: String,
+    val problems: ProblemItem,
+    val isPublic: Boolean?,
+    val buttonText: String?,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
@@ -7,6 +7,9 @@
 
 package team.duckie.app.android.domain.exam.model
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class ExamParam(
     val title: String,
     val description: String,

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
@@ -12,10 +12,11 @@ data class ExamParam(
     val description: String,
     val mainTag: Tag,
     val subTag: List<Tag>?,
+    val userId: Int,
     val certifyingStatement: String,
     val thumbnailImageUrl: String?,
     val thumbnailType: String,
     val problems: ProblemItem,
     val isPublic: Boolean?,
-    val buttonText: String?,
+    val buttonTitle: String?,
 )

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamParam.kt
@@ -8,13 +8,15 @@
 package team.duckie.app.android.domain.exam.model
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Immutable
 data class ExamParam(
     val title: String,
     val description: String,
     val mainTag: Tag,
-    val subTag: List<Tag>?,
+    val subTag: ImmutableList<Tag> = emptyList<Tag>().toImmutableList(),
     val userId: Int,
     val certifyingStatement: String,
     val thumbnailImageUrl: String?,

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
@@ -8,6 +8,7 @@
 package team.duckie.app.android.domain.exam.model
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 
 @Immutable
 data class ProblemItem(
@@ -64,13 +65,13 @@ sealed class Answer(
     @Immutable
     data class Choice(
         override val type: String,
-        val choices: List<ChoiceModel>,
+        val choices: ImmutableList<ChoiceModel>,
     ) : Answer(type)
 
     @Immutable
     data class ImageChoice(
         override val type: String,
-        val imageChoice: List<ImageChoiceModel>,
+        val imageChoice: ImmutableList<ImageChoiceModel>,
     ) : Answer(type)
 }
 

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
@@ -7,9 +7,6 @@
 
 package team.duckie.app.android.domain.exam.model
 
-import team.duckie.app.android.domain.exam.model.Question.Text.text
-import team.duckie.app.android.domain.exam.model.Question.Text.type
-
 data class ProblemItem(
     val questionObject: Question,
     val answerObject: Answer,
@@ -19,35 +16,48 @@ data class ProblemItem(
 )
 
 sealed class Question(
-    val type: String,
-    val text: String,
+    open val type: String,
+    open val text: String,
 ) {
-    object Text : Question(type, text)
+    data class Text(
+        override val text: String,
+        override val type: String,
+    ) : Question(type, text)
+
     data class Image(
+        override val text: String,
+        override val type: String,
         val imageUrl: String,
     ) : Question(type, text)
 
     data class Audio(
+        override val text: String,
+        override val type: String,
         val audioUrl: String,
     ) : Question(type, text)
 
     data class Video(
+        override val text: String,
+        override val type: String,
         val videoUrl: String,
     ) : Question(type, text)
 }
 
 sealed class Answer(
-    val type: String,
+    open val type: String,
 ) {
     data class ShortAnswer(
+        override val type: String,
         val shortAnswer: String,
     ) : Answer(type)
 
     data class Choice(
+        override val type: String,
         val choices: List<ChoiceModel>,
     ) : Answer(type)
 
     data class ImageChoice(
+        override val type: String,
         val imageChoice: List<ImageChoiceModel>,
     ) : Answer(type)
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
@@ -1,0 +1,63 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.model
+
+import team.duckie.app.android.domain.exam.model.Question.Text.text
+import team.duckie.app.android.domain.exam.model.Question.Text.type
+
+data class ProblemItem(
+    val questionObject: Question,
+    val answerObject: Answer,
+    val correctAnswer: String,
+    val hint: String?,
+    val memo: String?,
+)
+
+sealed class Question(
+    val type: String,
+    val text: String,
+) {
+    object Text : Question(type, text)
+    data class Image(
+        val imageUrl: String,
+    ) : Question(type, text)
+
+    data class Audio(
+        val audioUrl: String,
+    ) : Question(type, text)
+
+    data class Video(
+        val videoUrl: String,
+    ) : Question(type, text)
+}
+
+sealed class Answer(
+    val type: String,
+) {
+    data class ShortAnswer(
+        val shortAnswer: String,
+    ) : Answer(type)
+
+    data class Choice(
+        val choices: List<ChoiceModel>,
+    ) : Answer(type)
+
+    data class ImageChoice(
+        val imageChoice: List<ImageChoiceModel>,
+    ) : Answer(type)
+}
+
+@JvmInline
+value class ChoiceModel(
+    val text: String,
+)
+
+data class ImageChoiceModel(
+    val text: String,
+    val imageUrl: String,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ProblemItem.kt
@@ -7,6 +7,9 @@
 
 package team.duckie.app.android.domain.exam.model
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class ProblemItem(
     val questionObject: Question,
     val answerObject: Answer,
@@ -15,27 +18,32 @@ data class ProblemItem(
     val memo: String?,
 )
 
+@Immutable
 sealed class Question(
     open val type: String,
     open val text: String,
 ) {
+    @Immutable
     data class Text(
         override val text: String,
         override val type: String,
     ) : Question(type, text)
 
+    @Immutable
     data class Image(
         override val text: String,
         override val type: String,
         val imageUrl: String,
     ) : Question(type, text)
 
+    @Immutable
     data class Audio(
         override val text: String,
         override val type: String,
         val audioUrl: String,
     ) : Question(type, text)
 
+    @Immutable
     data class Video(
         override val text: String,
         override val type: String,
@@ -43,30 +51,36 @@ sealed class Question(
     ) : Question(type, text)
 }
 
+@Immutable
 sealed class Answer(
     open val type: String,
 ) {
+    @Immutable
     data class ShortAnswer(
         override val type: String,
         val shortAnswer: String,
     ) : Answer(type)
 
+    @Immutable
     data class Choice(
         override val type: String,
         val choices: List<ChoiceModel>,
     ) : Answer(type)
 
+    @Immutable
     data class ImageChoice(
         override val type: String,
         val imageChoice: List<ImageChoiceModel>,
     ) : Answer(type)
 }
 
+@Immutable
 @JvmInline
 value class ChoiceModel(
     val text: String,
 )
 
+@Immutable
 data class ImageChoiceModel(
     val text: String,
     val imageUrl: String,

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Tag.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Tag.kt
@@ -7,6 +7,9 @@
 
 package team.duckie.app.android.domain.exam.model
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class Tag(
     val id: Int,
     val name: String,

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Tag.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Tag.kt
@@ -1,0 +1,13 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.model
+
+data class Tag(
+    val id: Int,
+    val name: String,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/repository/ExamRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/repository/ExamRepository.kt
@@ -7,9 +7,11 @@
 
 package team.duckie.app.android.domain.exam.repository
 
+import androidx.compose.runtime.Immutable
 import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.exam.model.ExamParam
 
+@Immutable
 interface ExamRepository {
     suspend fun makeExam(examParam: ExamParam): Exam
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/repository/ExamRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/repository/ExamRepository.kt
@@ -1,0 +1,15 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.repository
+
+import team.duckie.app.android.domain.exam.model.Exam
+import team.duckie.app.android.domain.exam.model.ExamParam
+
+interface ExamRepository {
+    suspend fun makeExam(examParam: ExamParam): Exam
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/MakeExamUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/MakeExamUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.usecase
+
+import team.duckie.app.android.domain.exam.model.ExamParam
+import team.duckie.app.android.domain.exam.repository.ExamRepository
+
+class MakeExamUseCase(
+    private val examRepository: ExamRepository,
+) {
+    suspend operator fun invoke(examParam: ExamParam) = runCatching {
+        examRepository.makeExam(examParam)
+    }
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/MakeExamUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/MakeExamUseCase.kt
@@ -9,8 +9,9 @@ package team.duckie.app.android.domain.exam.usecase
 
 import team.duckie.app.android.domain.exam.model.ExamParam
 import team.duckie.app.android.domain.exam.repository.ExamRepository
+import javax.inject.Inject
 
-class MakeExamUseCase(
+class MakeExamUseCase @Inject constructor(
     private val examRepository: ExamRepository,
 ) {
     suspend operator fun invoke(examParam: ExamParam) = runCatching {

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/MakeExamUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/MakeExamUseCase.kt
@@ -7,10 +7,11 @@
 
 package team.duckie.app.android.domain.exam.usecase
 
+import androidx.compose.runtime.Immutable
 import team.duckie.app.android.domain.exam.model.ExamParam
 import team.duckie.app.android.domain.exam.repository.ExamRepository
 import javax.inject.Inject
-
+@Immutable
 class MakeExamUseCase @Inject constructor(
     private val examRepository: ExamRepository,
 ) {

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/user/model/User.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/user/model/User.kt
@@ -1,0 +1,22 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.user.model
+
+import java.util.Date
+
+data class User(
+    val id: Int,
+    val nickName: String,
+    val accountEnabled: Boolean,
+    val profileUrl: String,
+    val tier: Int,
+    val createdAt: Date,
+    val updatedAt: Date,
+    val deletedAt: Date? = null,
+    val bannedAt: Date? = null,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/user/model/User.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/user/model/User.kt
@@ -7,8 +7,10 @@
 
 package team.duckie.app.android.domain.user.model
 
+import androidx.compose.runtime.Immutable
 import java.util.Date
 
+@Immutable
 data class User(
     val id: Int,
     val nickName: String,

--- a/feature-ui-create-problem/build.gradle.kts
+++ b/feature-ui-create-problem/build.gradle.kts
@@ -1,3 +1,5 @@
+import DependencyHandler.Extensions.implementations
+
 /*
  * Designed and developed by Duckie Team, 2022
  *
@@ -16,4 +18,18 @@ plugins {
 
 android {
     namespace = "team.duckie.app.android.feature.ui.create.problem"
+}
+
+dependencies {
+    implementations(
+        projects.di,
+        projects.domain,
+        projects.utilUi,
+        projects.utilKotlin,
+        projects.utilCompose,
+        projects.utilViewmodel,
+        libs.ktx.lifecycle,
+        libs.compose.ktx.lifecycle,
+        libs.quack.ui.components,
+    )
 }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -1,0 +1,28 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.create.problem
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import team.duckie.app.android.feature.ui.create.problem.screen.CreateProblemScreen
+import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
+import team.duckie.app.android.util.ui.BaseActivity
+import javax.inject.Inject
+
+class CreateProblemActivity : BaseActivity() {
+
+    @Inject
+    lateinit var viewModel: CreateProblemViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CreateProblemScreen(viewModel = viewModel)
+        }
+    }
+}

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -9,11 +9,13 @@ package team.duckie.app.android.feature.ui.create.problem
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import dagger.hilt.android.AndroidEntryPoint
 import team.duckie.app.android.feature.ui.create.problem.screen.CreateProblemScreen
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
 import team.duckie.app.android.util.ui.BaseActivity
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class CreateProblemActivity : BaseActivity() {
 
     @Inject

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/empty.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/empty.kt
@@ -1,9 +1,0 @@
-/*
- * Designed and developed by Duckie Team, 2022
- *
- * Licensed under the MIT.
- * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
- */
-
-package team.duckie.app.android.feature.ui.create.problem
-

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -1,0 +1,21 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.create.problem.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
+
+@Composable
+internal fun CreateProblemScreen(
+    viewModel: CreateProblemViewModel
+){
+    LaunchedEffect(Unit){
+        viewModel.makeExam()
+    }
+}

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -13,7 +13,7 @@ import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblem
 
 @Composable
 internal fun CreateProblemScreen(
-    viewModel: CreateProblemViewModel
+    viewModel: CreateProblemViewModel,
 ){
     LaunchedEffect(Unit){
         viewModel.makeExam()

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -24,13 +24,13 @@ class CreateProblemViewModel @Inject constructor(
     private val TAG = CreateProblemViewModel::class.simpleName
 
     suspend fun makeExam() {
-        makeExamUseCase(dummyParmam).onSuccess { exam ->
+        makeExamUseCase(dummyParam).onSuccess { exam ->
             Log.d(TAG, exam.toString()+"성공")
         }
     }
 }
 
-private val dummyParmam = ExamParam(
+private val dummyParam = ExamParam(
     title = "Test Title 2",
     description = "Test Description 2",
     mainTag = Tag(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -14,17 +14,18 @@ import team.duckie.app.android.domain.exam.model.ProblemItem
 import team.duckie.app.android.domain.exam.model.Question
 import team.duckie.app.android.domain.exam.model.Tag
 import team.duckie.app.android.domain.exam.usecase.MakeExamUseCase
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class CreateProblemViewModel(
+class CreateProblemViewModel @Inject constructor(
     private val makeExamUseCase: MakeExamUseCase
 ) {
     private val TAG = CreateProblemViewModel::class.simpleName
 
     suspend fun makeExam() {
         makeExamUseCase(dummyParmam).onSuccess { exam ->
-            Log.d(TAG, exam.toString())
+            Log.d(TAG, exam.toString()+"성공")
         }
     }
 }
@@ -49,9 +50,13 @@ val dummyParmam = ExamParam(
     buttonTitle = "Test Button Title 1",
     isPublic = true,
     problems = ProblemItem(
-        questionObject = Question.Text,
+        questionObject = Question.Text(
+            text = "",
+            type = "",
+        ),
         answerObject = Answer.ShortAnswer(
-            shortAnswer = "바보"
+            shortAnswer = "바보",
+            type = "",
         ),
         memo = "test memo 1",
         hint = "test hint 1",

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -30,7 +30,7 @@ class CreateProblemViewModel @Inject constructor(
     }
 }
 
-val dummyParmam = ExamParam(
+private val dummyParmam = ExamParam(
     title = "Test Title 2",
     description = "Test Description 2",
     mainTag = Tag(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -1,0 +1,60 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.create.problem.viewmodel
+
+import android.util.Log
+import team.duckie.app.android.domain.exam.model.Answer
+import team.duckie.app.android.domain.exam.model.ExamParam
+import team.duckie.app.android.domain.exam.model.ProblemItem
+import team.duckie.app.android.domain.exam.model.Question
+import team.duckie.app.android.domain.exam.model.Tag
+import team.duckie.app.android.domain.exam.usecase.MakeExamUseCase
+import javax.inject.Singleton
+
+@Singleton
+class CreateProblemViewModel(
+    private val makeExamUseCase: MakeExamUseCase
+) {
+    private val TAG = CreateProblemViewModel::class.simpleName
+
+    suspend fun makeExam() {
+        makeExamUseCase(dummyParmam).onSuccess { exam ->
+            Log.d(TAG, exam.toString())
+        }
+    }
+}
+
+val dummyParmam = ExamParam(
+    title = "Test Title 2",
+    description = "Test Description 2",
+    mainTag = Tag(
+        id = 1,
+        "1"
+    ),
+    subTag = listOf(
+        Tag(
+            2,
+            "2",
+        )
+    ),
+    thumbnailImageUrl = "Test Image Url",
+    userId = 1,
+    certifyingStatement = "Test 필적 확인 문구1",
+    thumbnailType = "image",
+    buttonTitle = "Test Button Title 1",
+    isPublic = true,
+    problems = ProblemItem(
+        questionObject = Question.Text,
+        answerObject = Answer.ShortAnswer(
+            shortAnswer = "바보"
+        ),
+        memo = "test memo 1",
+        hint = "test hint 1",
+        correctAnswer = "3",
+    )
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # plugin - build
 plugin-build-gradle-android = "8.0.0-alpha09"
-plugin-build-google-service = "4.3.10"
+plugin-build-google-service = "4.3.14"
 
 # plugin - code
 plugin-code-ktlint-core = "11.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # plugin - build
-plugin-build-gradle-android = "8.0.0-alpha08"
-plugin-build-google-service = "4.3.3"
+plugin-build-gradle-android = "8.0.0-alpha09"
+plugin-build-google-service = "4.3.10"
 
 # plugin - code
 plugin-code-ktlint-core = "11.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # plugin - build
-plugin-build-gradle-android = "8.0.0-alpha09"
-plugin-build-google-service = "4.3.14"
+plugin-build-gradle-android = "8.0.0-alpha08"
+plugin-build-google-service = "4.3.3"
 
 # plugin - code
 plugin-code-ktlint-core = "11.0.0"

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
         projects.utilKotlin,
         projects.featureDatastore,
         projects.featureUiOnboard,
+        projects.featureUiCreateProblem,
         libs.androidx.splash,
         libs.quack.ui.components,
     )

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name="team.duckie.app.android.feature.ui.create.problem.CreateProblemActivity" />
+        
     </application>
 
 </manifest>

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         </activity>
 
         <activity android:name="team.duckie.app.android.feature.ui.create.problem.CreateProblemActivity" />
-        
+
     </application>
 
 </manifest>


### PR DESCRIPTION
## Overview (Required)
backend 세팅이 완료되지 않아 주석을 지우면 호출이 가능하도록 작성하였습니다
DI 
-  Ktor Client를 주입할 수 있는 Module 생성
-  Repository, Usecase Modeul 생성

Data
- model, repository, datasource 작성

Domain
- Usecase 작성

Presentation
- ui-create-problem 모듈에 viewModel로 더미 데이터 받아올 수 있도록 작성

## TODO
![image](https://user-images.githubusercontent.com/70064912/205954083-cdf9ca0f-196b-4d15-a280-efa81975547f.png)

