### PR TITLE
문제 만들기 1단계 UX 개선

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/datasource/remote/ExamDataSource.kt
@@ -24,9 +24,9 @@ class ExamDataSource @Inject constructor(
             .post {
                 url("/exams")
                 setBody(examRequest)
-                //header("authorization", "AT") //TODO(Evergreen): access token 자동화 방안 마련 필요
+                // header("authorization", "AT") //TODO(Evergreen): access token 자동화 방안 마련 필요
             }
         val body: PostResponse = request.body()
-        return body.success?: false
+        return body.success ?: false
     }
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
@@ -9,7 +9,6 @@ package team.duckie.app.android.data.exam.repository
 
 import team.duckie.app.android.data.exam.datasource.remote.ExamDataSource
 import team.duckie.app.android.data.exam.mapper.toData
-import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.exam.model.ExamParam
 import team.duckie.app.android.domain.exam.repository.ExamRepository
 import javax.inject.Inject
@@ -17,7 +16,7 @@ import javax.inject.Inject
 class ExamRepositoryImpl @Inject constructor(
     private val examDataSource: ExamDataSource,
 ) : ExamRepository {
-    override suspend fun makeExam(examParam: ExamParam): Boolean{
+    override suspend fun makeExam(examParam: ExamParam): Boolean {
         return examDataSource.postExams(examParam.toData())
     }
 }

--- a/di/src/main/kotlin/team/duckie/app/android/di/datasource/NetworkModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/datasource/NetworkModule.kt
@@ -17,7 +17,6 @@ import io.ktor.client.engine.cio.endpoint
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.ANDROID
-import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/repository/ExamRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/repository/ExamRepository.kt
@@ -8,7 +8,6 @@
 package team.duckie.app.android.domain.exam.repository
 
 import androidx.compose.runtime.Immutable
-import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.exam.model.ExamParam
 
 @Immutable

--- a/feature-ui-create-problem/build.gradle.kts
+++ b/feature-ui-create-problem/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
         projects.utilKotlin,
         projects.utilCompose,
         projects.utilViewmodel,
+        projects.sharedUiCompose,
         libs.ktx.lifecycle,
         libs.compose.ktx.lifecycle,
         libs.compose.ui.material, // needs for Scaffold

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -5,13 +5,18 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
-@file:OptIn(ExperimentalLifecycleComposeApi::class)
+@file:OptIn(
+    ExperimentalLifecycleComposeApi::class,
+    ExperimentalFoundationApi::class,
+)
 
 package team.duckie.app.android.feature.ui.create.problem
 
 import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
@@ -43,7 +48,8 @@ class CreateProblemActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            val createProblemStep = viewModel.state.collectAsStateWithLifecycle().value.createProblemStep
+            val createProblemStep =
+                viewModel.state.collectAsStateWithLifecycle().value.createProblemStep
 
             BackHandler {
                 when (createProblemStep) {
@@ -59,7 +65,10 @@ class CreateProblemActivity : BaseActivity() {
                     .launchIn(this)
             }
 
-            CompositionLocalProvider(LocalViewModel provides viewModel) {
+            CompositionLocalProvider(
+                LocalViewModel provides viewModel,
+                LocalOverscrollConfiguration provides null,
+            ) {
                 QuackAnimatedContent(
                     modifier = Modifier
                         .fillMaxSize()

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -16,7 +16,6 @@ import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -37,6 +37,7 @@ import team.duckie.app.android.util.ui.BaseActivity
 import team.duckie.app.android.util.ui.finishWithAnimation
 import team.duckie.quackquack.ui.animation.QuackAnimatedContent
 import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -64,21 +65,22 @@ class CreateProblemActivity : BaseActivity() {
                     .launchIn(this)
             }
 
-            CompositionLocalProvider(
-                LocalViewModel provides viewModel,
-                LocalOverscrollConfiguration provides null,
-            ) {
-                QuackAnimatedContent(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(color = QuackColor.White.composeColor),
-                    targetState = createProblemStep,
-                ) { step: CreateProblemStep ->
-                    when (step) {
-                        CreateProblemStep.ExamInformation -> ExamInformationScreen()
-                        CreateProblemStep.FindExamArea -> FindExamAreaScreen()
-                        CreateProblemStep.CreateProblem -> {}
-                        CreateProblemStep.AdditionalInformation -> {}
+            QuackTheme {
+                CompositionLocalProvider(
+                    LocalViewModel provides viewModel,
+                ) {
+                    QuackAnimatedContent(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(color = QuackColor.White.composeColor),
+                        targetState = createProblemStep,
+                    ) { step: CreateProblemStep ->
+                        when (step) {
+                            CreateProblemStep.ExamInformation -> ExamInformationScreen()
+                            CreateProblemStep.FindExamArea -> FindExamAreaScreen()
+                            CreateProblemStep.CreateProblem -> {}
+                            CreateProblemStep.AdditionalInformation -> {}
+                        }
                     }
                 }
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -48,8 +48,7 @@ class CreateProblemActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            val createProblemStep =
-                viewModel.state.collectAsStateWithLifecycle().value.createProblemStep
+            val createProblemStep = viewModel.state.collectAsStateWithLifecycle().value.createProblemStep
 
             BackHandler {
                 when (createProblemStep) {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/FadeAnimatedVisibility.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/FadeAnimatedVisibility.kt
@@ -1,0 +1,25 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.create.problem.common
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun FadeAnimatedVisibility(
+    visible: Boolean,
+    content: @Composable (AnimatedVisibilityScope.() -> Unit),
+) = AnimatedVisibility(
+    visible = visible,
+    enter = fadeIn(),
+    exit = fadeOut(),
+    content = content,
+)

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/FindTagItem.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/FindTagItem.kt
@@ -8,7 +8,9 @@
 package team.duckie.app.android.feature.ui.create.problem.common
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import team.duckie.quackquack.ui.component.QuackBody1
 
@@ -17,6 +19,7 @@ internal fun SearchResultText(
     text: String,
     onClick: () -> Unit,
 ) = QuackBody1(
+    modifier = Modifier.fillMaxWidth(),
     padding = PaddingValues(vertical = 12.dp),
     text = text,
     onClick = onClick,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -38,10 +38,13 @@ import team.duckie.app.android.util.compose.CoroutineScopeContent
 import team.duckie.app.android.util.compose.LocalViewModel
 import team.duckie.app.android.util.compose.component.DuckieGridLayout
 import team.duckie.app.android.util.compose.launch
+import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
 import team.duckie.quackquack.ui.component.QuackBasicTextArea
 import team.duckie.quackquack.ui.component.QuackBasicTextField
+import team.duckie.quackquack.ui.component.QuackCircleTag
 import team.duckie.quackquack.ui.component.QuackMediumToggleButton
 import team.duckie.quackquack.ui.component.QuackReviewTextArea
+import team.duckie.quackquack.ui.component.QuackSingeLazyRowTag
 import team.duckie.quackquack.ui.icon.QuackIcon
 
 @Composable
@@ -88,18 +91,27 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                 }
             }
             TitleAndComponent(stringResource = R.string.exam_area) {
-                QuackBasicTextField(
-                    leadingIcon = QuackIcon.Search,
-                    text = state.examArea,
-                    onTextChanged = {
-                        /*
-                        * TODO(EvergreenTree97): Box로도 해당 영역 Clickable이 잡히지 않음
-                        * 시험 영역 찾기 Screen으로 넘어가는 UX 개선사항 필요
-                        * */
-                        viewModel.navigateStep(CreateProblemStep.FindExamArea)
-                    },
-                    placeholderText = stringResource(id = R.string.find_exam_area),
-                )
+                if (state.isExamAreaSelected) {
+                    QuackCircleTag(
+                        text = state.examArea,
+                        trailingIcon = QuackIcon.Close,
+                        isSelected = false,
+                        onClick = { viewModel.onClickCloseTag(false) },
+                    )
+                } else {
+                    QuackBasicTextField(
+                        leadingIcon = QuackIcon.Search,
+                        text = state.examArea,
+                        onTextChanged = {
+                            /*
+                            * TODO(EvergreenTree97): Box로도 해당 영역 Clickable이 잡히지 않음
+                            * 시험 영역 찾기 Screen으로 넘어가는 UX 개선사항 필요
+                            * */
+                            viewModel.navigateStep(CreateProblemStep.FindExamArea)
+                        },
+                        placeholderText = stringResource(id = R.string.find_exam_area),
+                    )
+                }
             }
             TitleAndComponent(stringResource = R.string.exam_title) {
                 QuackBasicTextField(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -11,6 +11,7 @@ package team.duckie.app.android.feature.ui.create.problem.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -51,7 +52,9 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
     val lazyListState = rememberLazyListState()
 
     Scaffold(
-        modifier = Modifier.statusBarsPadding(),
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding(),
         topBar = {
             PrevAndNextTopAppBar(
                 onLeadingIconClick = {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -20,7 +20,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -52,6 +56,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
     val state = viewModel.state.collectAsStateWithLifecycle().value.examInformation
     val focusManager = LocalFocusManager.current
     val lazyListState = rememberLazyListState()
+    val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(key1 = state.scrollPosition) {
         lazyListState.scrollToItem(index = state.scrollPosition)
@@ -130,12 +135,18 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
             }
             TitleAndComponent(stringResource = R.string.exam_description) {
                 QuackReviewTextArea(
-                    modifier = Modifier.heightIn(140.dp),
+                    modifier = Modifier
+                        .heightIn(140.dp)
+                        .focusRequester(focusRequester = focusRequester)
+                        .onFocusChanged { state ->
+                            viewModel.onExamAreaFocusChanged(state.isFocused)
+                        },
                     text = state.examDescription,
                     onTextChanged = viewModel::setExamDescription,
                     placeholderText = stringResource(id = R.string.input_exam_description),
                     imeAction = ImeAction.Next,
                     keyboardActions = moveDownFocus(focusManager),
+                    focused = state.examDescriptionFocused,
                 )
             } // TODO(EvergreenTree97): 컴포넌트 필요
             TitleAndComponent(stringResource = R.string.certifying_statement) {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -59,8 +59,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
 
     Scaffold(
         modifier = Modifier
-            .statusBarsPadding()
-            .navigationBarsPadding(),
+            .statusBarsPadding(),
         topBar = {
             PrevAndNextTopAppBar(
                 onLeadingIconClick = {
@@ -143,6 +142,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
             } // TODO(EvergreenTree97): 컴포넌트 필요
             TitleAndComponent(stringResource = R.string.certifying_statement) {
                 QuackBasicTextArea(
+                    modifier = Modifier.padding(bottom = 16.dp),
                     text = state.certifyingStatement,
                     onTextChanged = viewModel::setCertifyingStatement,
                     placeholderText = stringResource(id = R.string.input_certifying_statement),

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -9,6 +9,9 @@
 
 package team.duckie.app.android.feature.ui.create.problem.screen
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -98,7 +98,12 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                         isSelected = false,
                         onClick = { viewModel.onClickCloseTag(false) },
                     )
-                } else {
+                }
+                AnimatedVisibility(
+                    visible = !state.isExamAreaSelected,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
                     QuackBasicTextField(
                         leadingIcon = QuackIcon.Search,
                         text = state.examArea,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -49,6 +49,7 @@ import team.duckie.quackquack.ui.component.QuackCircleTag
 import team.duckie.quackquack.ui.component.QuackMediumToggleButton
 import team.duckie.quackquack.ui.component.QuackReviewTextArea
 import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.ui.modifier.quackClickable
 
 @Composable
 internal fun ExamInformationScreen() = CoroutineScopeContent {
@@ -111,16 +112,14 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                 }
                 FadeAnimatedVisibility(visible = !state.isExamAreaSelected) {
                     QuackBasicTextField(
-                        leadingIcon = QuackIcon.Search,
-                        text = state.examArea,
-                        onTextChanged = {
-                            /*
-                            * TODO(EvergreenTree97): Box로도 해당 영역 Clickable이 잡히지 않음
-                            * 시험 영역 찾기 Screen으로 넘어가는 UX 개선사항 필요
-                            * */
+                        modifier = Modifier.quackClickable {
                             viewModel.onClickExamArea(lazyListState.firstVisibleItemIndex)
                         },
+                        leadingIcon = QuackIcon.Search,
+                        text = state.examArea,
+                        onTextChanged = {},
                         placeholderText = stringResource(id = R.string.find_exam_area),
+                        enabled = false,
                     )
                 }
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -80,7 +80,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                             height = 40.dp,
                         ),
                         text = item,
-                        selected = state.categoriesSelection[index],
+                        selected = state.categorySelection == index,
                         onClick = {
                             viewModel.onClickCategory(index)
                         },

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -39,9 +39,9 @@ import team.duckie.app.android.feature.ui.create.problem.common.TitleAndComponen
 import team.duckie.app.android.feature.ui.create.problem.common.moveDownFocus
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateProblemStep
+import team.duckie.app.android.shared.ui.compose.DuckieGridLayout
 import team.duckie.app.android.util.compose.CoroutineScopeContent
 import team.duckie.app.android.util.compose.LocalViewModel
-import team.duckie.app.android.util.compose.component.DuckieGridLayout
 import team.duckie.app.android.util.compose.launch
 import team.duckie.quackquack.ui.component.QuackBasicTextArea
 import team.duckie.quackquack.ui.component.QuackBasicTextField

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -53,7 +53,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
     val focusManager = LocalFocusManager.current
     val lazyListState = rememberLazyListState()
 
-    LaunchedEffect(key1 = state.scrollPosition){
+    LaunchedEffect(key1 = state.scrollPosition) {
         lazyListState.scrollToItem(index = state.scrollPosition)
     }
 

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -9,12 +9,8 @@
 
 package team.duckie.app.android.feature.ui.create.problem.screen
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -23,6 +19,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -31,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.feature.ui.create.problem.R
+import team.duckie.app.android.feature.ui.create.problem.common.FadeAnimatedVisibility
 import team.duckie.app.android.feature.ui.create.problem.common.ImeActionNext
 import team.duckie.app.android.feature.ui.create.problem.common.PrevAndNextTopAppBar
 import team.duckie.app.android.feature.ui.create.problem.common.TitleAndComponent
@@ -41,13 +39,11 @@ import team.duckie.app.android.util.compose.CoroutineScopeContent
 import team.duckie.app.android.util.compose.LocalViewModel
 import team.duckie.app.android.util.compose.component.DuckieGridLayout
 import team.duckie.app.android.util.compose.launch
-import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
 import team.duckie.quackquack.ui.component.QuackBasicTextArea
 import team.duckie.quackquack.ui.component.QuackBasicTextField
 import team.duckie.quackquack.ui.component.QuackCircleTag
 import team.duckie.quackquack.ui.component.QuackMediumToggleButton
 import team.duckie.quackquack.ui.component.QuackReviewTextArea
-import team.duckie.quackquack.ui.component.QuackSingeLazyRowTag
 import team.duckie.quackquack.ui.icon.QuackIcon
 
 @Composable
@@ -57,9 +53,12 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
     val focusManager = LocalFocusManager.current
     val lazyListState = rememberLazyListState()
 
+    LaunchedEffect(key1 = state.scrollPosition){
+        lazyListState.scrollToItem(index = state.scrollPosition)
+    }
+
     Scaffold(
-        modifier = Modifier
-            .statusBarsPadding(),
+        modifier = Modifier.statusBarsPadding(),
         topBar = {
             PrevAndNextTopAppBar(
                 onLeadingIconClick = {
@@ -73,7 +72,11 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
         LazyColumn(
             modifier = Modifier
                 .padding(contentPadding)
-                .padding(16.dp),
+                .padding(
+                    top = 16.dp,
+                    start = 16.dp,
+                    end = 16.dp
+                ),
             state = lazyListState,
             verticalArrangement = Arrangement.spacedBy(space = 48.dp),
         ) { // TODO(EvergreenTree97): 컴포넌트 필요
@@ -101,11 +104,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                         onClick = { viewModel.onClickCloseTag(false) },
                     )
                 }
-                AnimatedVisibility(
-                    visible = !state.isExamAreaSelected,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                ) {
+                FadeAnimatedVisibility(visible = !state.isExamAreaSelected) {
                     QuackBasicTextField(
                         leadingIcon = QuackIcon.Search,
                         text = state.examArea,
@@ -114,7 +113,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                             * TODO(EvergreenTree97): Box로도 해당 영역 Clickable이 잡히지 않음
                             * 시험 영역 찾기 Screen으로 넘어가는 UX 개선사항 필요
                             * */
-                            viewModel.navigateStep(CreateProblemStep.FindExamArea)
+                            viewModel.onClickExamArea(lazyListState.firstVisibleItemIndex)
                         },
                         placeholderText = stringResource(id = R.string.find_exam_area),
                     )
@@ -129,7 +128,6 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                     keyboardActions = moveDownFocus(focusManager),
                 )
             }
-
             TitleAndComponent(stringResource = R.string.exam_description) {
                 QuackReviewTextArea(
                     modifier = Modifier.heightIn(140.dp),

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
@@ -78,9 +78,7 @@ internal fun FindExamAreaScreen() {
                                 id = R.string.add_also,
                                 state.examArea,
                             ),
-                            onClick = {
-                                viewModel.navigateStep(CreateProblemStep.ExamInformation)
-                            },
+                            onClick = viewModel::onClickSearchListHeader,
                         )
                     }
                     itemsIndexed(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
@@ -88,7 +88,7 @@ internal fun FindExamAreaScreen() {
                         SearchResultText(
                             text = item,
                             onClick = {
-                                viewModel.clickSearchList(index)
+                                viewModel.onClickSearchList(index)
                             }
                         )
                     }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
@@ -68,7 +68,7 @@ internal fun FindExamAreaScreen() {
                 leadingIcon = QuackIcon.Search,
                 text = state.examArea,
                 onTextChanged = viewModel::setExamArea,
-                placeholderText = stringResource(id = R.string.find_exam_area),
+                placeholderText = stringResource(id = R.string.search_exam_area_tag),
             )
             QuackAnimatedVisibility(visible = state.examArea.isNotEmpty()) {
                 LazyColumn {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -69,6 +70,9 @@ internal fun FindExamAreaScreen() {
                 text = state.examArea,
                 onTextChanged = viewModel::setExamArea,
                 placeholderText = stringResource(id = R.string.search_exam_area_tag),
+                keyboardActions = KeyboardActions(
+                    onDone = { viewModel.onClickSearchListHeader() }
+                )
             )
             QuackAnimatedVisibility(visible = state.examArea.isNotEmpty()) {
                 LazyColumn {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -22,6 +22,10 @@ import team.duckie.app.android.util.viewmodel.BaseViewModel
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val ExamTitleMaxLength = 12
+private const val ExamDescriptionMaxLength = 30
+private const val CertifyingStatementMaxLength = 16
+
 @Singleton
 class CreateProblemViewModel @Inject constructor(
     private val makeExamUseCase: MakeExamUseCase,
@@ -73,32 +77,38 @@ class CreateProblemViewModel @Inject constructor(
     }
 
     fun setExamTitle(examTitle: String) {
-        updateState { prevState ->
-            prevState.copy(
-                examInformation = prevState.examInformation.copy(
-                    examTitle = examTitle,
-                ),
-            )
+        if (examTitle.length <= ExamTitleMaxLength) {
+            updateState { prevState ->
+                prevState.copy(
+                    examInformation = prevState.examInformation.copy(
+                        examTitle = examTitle,
+                    ),
+                )
+            }
         }
     }
 
     fun setExamDescription(examDescription: String) {
-        updateState { prevState ->
-            prevState.copy(
-                examInformation = prevState.examInformation.copy(
-                    examDescription = examDescription,
-                ),
-            )
+        if (examDescription.length <= ExamDescriptionMaxLength) {
+            updateState { prevState ->
+                prevState.copy(
+                    examInformation = prevState.examInformation.copy(
+                        examDescription = examDescription,
+                    ),
+                )
+            }
         }
     }
 
     fun setCertifyingStatement(certifyingStatement: String) {
-        updateState { prevState ->
-            prevState.copy(
-                examInformation = prevState.examInformation.copy(
-                    certifyingStatement = certifyingStatement,
-                ),
-            )
+        if (certifyingStatement.length <= CertifyingStatementMaxLength) {
+            updateState { prevState ->
+                prevState.copy(
+                    examInformation = prevState.examInformation.copy(
+                        certifyingStatement = certifyingStatement,
+                    ),
+                )
+            }
         }
     }
 

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -129,7 +129,7 @@ class CreateProblemViewModel @Inject constructor(
     }
 
 
-    fun clickSearchList(index: Int) {
+    fun onClickSearchList(index: Int) {
         updateState { prevState ->
             prevState.copy(
                 createProblemStep = CreateProblemStep.ExamInformation,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -56,10 +56,10 @@ class CreateProblemViewModel @Inject constructor(
         }
     }
 
-    fun onClickExamArea(scrollPosition: Int){
+    fun onClickExamArea(scrollPosition: Int) {
         updateState { prevState ->
             prevState.copy(
-                examInformation =  prevState.examInformation.copy(
+                examInformation = prevState.examInformation.copy(
                     scrollPosition = scrollPosition,
                 )
             )
@@ -148,9 +148,14 @@ class CreateProblemViewModel @Inject constructor(
     fun onClickCloseTag(isExamAreaSelected: Boolean) {
         updateState { prevState ->
             prevState.copy(
-                examInformation = prevState.examInformation.copy(
-                    isExamAreaSelected = isExamAreaSelected
-                )
+                examInformation = prevState.examInformation.run {
+                    copy(
+                        isExamAreaSelected = isExamAreaSelected,
+                        foundExamArea = foundExamArea.copy(
+                            examArea = ""
+                        ),
+                    )
+                }
             )
         }
     }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -146,7 +146,7 @@ class CreateProblemViewModel @Inject constructor(
 
     fun isAllFieldsNotEmpty(): Boolean {
         return with(currentState.examInformation) {
-            categorySelection >= 0 && examArea.isNotEmpty() && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()
+            categorySelection >= 0 && isExamAreaSelected && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()
         }
     }
 }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -50,9 +50,7 @@ class CreateProblemViewModel @Inject constructor(
         updateState { prevState ->
             prevState.copy(
                 examInformation = prevState.examInformation.copy(
-                    categoriesSelection = prevState.examInformation.categoriesSelection.copy {
-                        this[index] = !this[index]
-                    }.toImmutableList(),
+                    categorySelection = index
                 ),
             )
         }
@@ -125,12 +123,13 @@ class CreateProblemViewModel @Inject constructor(
 
     fun isAllFieldsNotEmpty(): Boolean {
         return with(currentState.examInformation) {
-            categoriesSelection.fastAny { it } && examArea.isNotEmpty() && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()
+            categorySelection >= 0 && examArea.isNotEmpty() && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()
         }
     }
 }
 
-private val dummyParam = ExamParam( //TODO(EvergreenTree97): 문제 만들기 3단계 작업 시 테스트 후 삭제 필요
+private val dummyParam = ExamParam(
+    //TODO(EvergreenTree97): 문제 만들기 3단계 작업 시 테스트 후 삭제 필요
     title = "제 1회 도로 패션영역",
     description = "도로의 패션을 파헤쳐보자 ㅋㅋ",
     mainTagId = 3,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -166,6 +166,16 @@ class CreateProblemViewModel @Inject constructor(
         }
     }
 
+    fun onExamAreaFocusChanged(isFocused: Boolean) {
+        updateState { prevState ->
+            prevState.copy(
+                examInformation = prevState.examInformation.copy(
+                    examDescriptionFocused = isFocused,
+                )
+            )
+        }
+    }
+
     fun isAllFieldsNotEmpty(): Boolean {
         return with(currentState.examInformation) {
             categorySelection >= 0 && isExamAreaSelected && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -10,7 +10,6 @@
 package team.duckie.app.android.feature.ui.create.problem.viewmodel
 
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.ExamParam
 import team.duckie.app.android.domain.exam.model.Problem
@@ -19,8 +18,6 @@ import team.duckie.app.android.domain.exam.usecase.MakeExamUseCase
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.sideeffect.CreateProblemSideEffect
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateProblemState
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateProblemStep
-import team.duckie.app.android.util.kotlin.copy
-import team.duckie.app.android.util.kotlin.fastAny
 import team.duckie.app.android.util.viewmodel.BaseViewModel
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -32,7 +29,7 @@ class CreateProblemViewModel @Inject constructor(
 
     suspend fun makeExam() {
         makeExamUseCase(dummyParam).onSuccess { isSuccess: Boolean ->
-            print(isSuccess) //TODO(EvergreenTree97) 문제 만들기 3단계에서 사용 가능
+            print(isSuccess) // TODO(EvergreenTree97) 문제 만들기 3단계에서 사용 가능
         }.onFailure {
             it.printStackTrace()
         }
@@ -128,7 +125,6 @@ class CreateProblemViewModel @Inject constructor(
         navigateStep(CreateProblemStep.ExamInformation)
     }
 
-
     fun onClickSearchList(index: Int) {
         updateState { prevState ->
             prevState.copy(
@@ -168,7 +164,7 @@ class CreateProblemViewModel @Inject constructor(
 }
 
 private val dummyParam = ExamParam(
-    //TODO(EvergreenTree97): 문제 만들기 3단계 작업 시 테스트 후 삭제 필요
+    // TODO(EvergreenTree97): 문제 만들기 3단계 작업 시 테스트 후 삭제 필요
     title = "제 1회 도로 패션영역",
     description = "도로의 패션을 파헤쳐보자 ㅋㅋ",
     mainTagId = 3,
@@ -192,7 +188,8 @@ private val dummyParam = ExamParam(
             memo = "test memo 1",
             hint = "test hint 1",
             correctAnswer = "3",
-        ), Problem(
+        ),
+        Problem(
             question = Question.Text(
                 text = "",
                 type = "",

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -56,6 +56,17 @@ class CreateProblemViewModel @Inject constructor(
         }
     }
 
+    fun onClickExamArea(scrollPosition: Int){
+        updateState { prevState ->
+            prevState.copy(
+                examInformation =  prevState.examInformation.copy(
+                    scrollPosition = scrollPosition,
+                )
+            )
+        }
+        navigateStep(CreateProblemStep.FindExamArea)
+    }
+
     fun navigateStep(step: CreateProblemStep) {
         updateState { prevState ->
             prevState.copy(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -106,17 +106,40 @@ class CreateProblemViewModel @Inject constructor(
         }
     }
 
+    fun onClickSearchListHeader() {
+        updateState { prevState ->
+            prevState.copy(
+                examInformation = prevState.examInformation.copy(
+                    isExamAreaSelected = true,
+                ),
+            )
+        }
+        navigateStep(CreateProblemStep.ExamInformation)
+    }
+
+
     fun clickSearchList(index: Int) {
         updateState { prevState ->
             prevState.copy(
                 createProblemStep = CreateProblemStep.ExamInformation,
                 examInformation = prevState.examInformation.run {
                     copy(
+                        isExamAreaSelected = true,
                         foundExamArea = foundExamArea.copy(
                             examArea = foundExamArea.searchResults[index]
                         )
                     )
                 },
+            )
+        }
+    }
+
+    fun onClickCloseTag(isExamAreaSelected: Boolean) {
+        updateState { prevState ->
+            prevState.copy(
+                examInformation = prevState.examInformation.copy(
+                    isExamAreaSelected = isExamAreaSelected
+                )
             )
         }
     }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -30,6 +30,7 @@ data class CreateProblemState(
         val certifyingStatement: String = "",
         val foundExamArea: FoundExamArea = FoundExamArea(),
         val scrollPosition: Int = 0,
+        val examDescriptionFocused: Boolean = false,
     ) {
         val examArea: String
             get() = foundExamArea.examArea

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -25,6 +25,7 @@ data class CreateProblemState(
             "밀리터리"
         ),
         val categorySelection: Int = -1,
+        val isExamAreaSelected: Boolean = false,
         val examTitle: String = "",
         val examDescription: String = "",
         val certifyingStatement: String = "",

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -9,7 +9,6 @@ package team.duckie.app.android.feature.ui.create.problem.viewmodel.state
 
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 
 data class CreateProblemState(
     val createProblemStep: CreateProblemStep = CreateProblemStep.ExamInformation,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -30,12 +30,14 @@ data class CreateProblemState(
         val examDescription: String = "",
         val certifyingStatement: String = "",
         val foundExamArea: FoundExamArea = FoundExamArea(),
+        val scrollPosition: Int = 0,
     ) {
         val examArea: String
             get() = foundExamArea.examArea
 
         data class FoundExamArea(
-            val searchResults: ImmutableList<String> = persistentListOf( // TODO(EvergreenTree97): Server Request
+            val searchResults: ImmutableList<String> = persistentListOf(
+                // TODO(EvergreenTree97): Server Request
                 "도로",
                 "도로 주행",
                 "도로 셀카",

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -24,7 +24,7 @@ data class CreateProblemState(
             "게임",
             "밀리터리"
         ),
-        val categoriesSelection: ImmutableList<Boolean> = List(categories.size) { false }.toImmutableList(),
+        val categorySelection: Int = -1,
         val examTitle: String = "",
         val examDescription: String = "",
         val certifyingStatement: String = "",

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemStep.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemStep.kt
@@ -7,6 +7,9 @@
 
 package team.duckie.app.android.feature.ui.create.problem.viewmodel.state
 
+import team.duckie.app.android.util.kotlin.AllowMagicNumber
+
+@AllowMagicNumber
 enum class CreateProblemStep(private val index: Int) {
     FindExamArea(0),
     ExamInformation(1),

--- a/feature-ui-create-problem/src/main/res/values/strings.xml
+++ b/feature-ui-create-problem/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="certifying_statement">"필적 확인 문구</string>
     <string name="input_certifying_statement">"필적확인 문구를 입력해 주세요"</string>
     <string name="add_also">+%s 추가하기</string>
+    <string name="search_exam_area_tag">"시험 영역으로 설정할 태그를 검색해 주세요."</string>
 </resources>

--- a/feature-ui-detail/src/main/kotlin/team/duckie/app/android/feature/ui/detail/screen/DetailScreen.kt
+++ b/feature-ui-detail/src/main/kotlin/team/duckie/app/android/feature/ui/detail/screen/DetailScreen.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:AllowMagicNumber
+
 package team.duckie.app.android.feature.ui.detail.screen
 
 import android.app.Activity
@@ -40,6 +42,7 @@ import team.duckie.app.android.util.compose.CoroutineScopeContent
 import team.duckie.app.android.util.compose.LocalViewModel
 import team.duckie.app.android.util.compose.asLoose
 import team.duckie.app.android.util.compose.rememberToast
+import team.duckie.app.android.util.kotlin.AllowMagicNumber
 import team.duckie.app.android.util.kotlin.fastFirstOrNull
 import team.duckie.app.android.util.kotlin.npe
 import team.duckie.quackquack.ui.color.QuackColor

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -36,9 +36,9 @@ import team.duckie.app.android.feature.ui.home.R
 import team.duckie.quackquack.ui.component.QuackBody1
 import team.duckie.quackquack.ui.component.QuackBody2
 import team.duckie.quackquack.ui.component.QuackBody3
+import team.duckie.quackquack.ui.component.QuackLarge1
 import team.duckie.quackquack.ui.component.QuackLargeButton
 import team.duckie.quackquack.ui.component.QuackLargeButtonType
-import team.duckie.quackquack.ui.component.QuackSplashSlogan
 import team.duckie.quackquack.ui.component.QuackTitle2
 import team.duckie.quackquack.ui.component.QuackUnderlineHeadLine2
 import team.duckie.quackquack.ui.modifier.quackClickable
@@ -129,7 +129,7 @@ private fun HomeRecommendContentScreen(
             contentScale = ContentScale.FillWidth,
         )
         Spacer(modifier = Modifier.height(24.dp))
-        QuackSplashSlogan(
+        QuackLarge1(
             text = recommendItem.title,
         )
         Spacer(modifier = Modifier.height(12.dp))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ di-inject = "1"
 ktor-core = "2.1.2"
 
 # quack
-quack-ui-components = "1.3.8"
+quack-ui-components = "1.4.0"
 quack-lint-core = "1.0.1"
 quack-lint-quack = "1.0.1"
 quack-lint-compose = "1.0.2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,7 @@ include(
     ":feature-ui-solve-problem",
     ":feature-ui-create-problem",
     ":feature-ui-detail",
+    ":shared-ui-compose",
     ":util-ui",
     ":util-viewmodel",
     ":util-kotlin",

--- a/shared-ui-compose/src/main/java/team/duckie/app/android/shared/ui/compose/DuckieGridLayout.kt
+++ b/shared-ui-compose/src/main/java/team/duckie/app/android/shared/ui/compose/DuckieGridLayout.kt
@@ -7,7 +7,6 @@
 
 package team.duckie.app.android.shared.ui.compose
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
-import team.duckie.app.android.util.kotlin.fastForEach
 import team.duckie.app.android.util.kotlin.fastForEachIndexed
 
 @Composable

--- a/shared-ui-compose/src/main/java/team/duckie/app/android/shared/ui/compose/DuckieGridLayout.kt
+++ b/shared-ui-compose/src/main/java/team/duckie/app/android/shared/ui/compose/DuckieGridLayout.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,7 +22,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import team.duckie.app.android.util.kotlin.fastForEach
 import team.duckie.app.android.util.kotlin.fastForEachIndexed
-import team.duckie.quackquack.ui.component.QuackGridLayout
 
 @Composable
 fun <T> DuckieGridLayout(
@@ -41,20 +39,17 @@ fun <T> DuckieGridLayout(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(space = verticalPadding),
     ) {
-        var index = 0
         items.chunked(columns)
-            .fastForEachIndexed { ii, chunkedList ->
-                Log.d("index", ii.toString())
+            .fastForEachIndexed { index, chunkedList ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    chunkedList.fastForEach { item ->
+                    chunkedList.fastForEachIndexed { chunkedIndex, item ->
                         Box(
                             modifier = Modifier.weight(1f),
-                            contentAlignment = Alignment.Center,
                         ) {
-                            content(index++, item)
+                            content(chunkedIndex + columns * index, item)
                         }
                     }
                     if (chunkedList.size < columns) {

--- a/shared-ui-compose/src/main/java/team/duckie/app/android/shared/ui/compose/DuckieGridLayout.kt
+++ b/shared-ui-compose/src/main/java/team/duckie/app/android/shared/ui/compose/DuckieGridLayout.kt
@@ -5,21 +5,16 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
-/*
- * Designed and developed by Duckie Team, 2022
- *
- * Licensed under the MIT.
- * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
- */
+package team.duckie.app.android.shared.ui.compose
 
-package team.duckie.app.android.util.compose.component
-
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,6 +22,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import team.duckie.app.android.util.kotlin.fastForEach
+import team.duckie.app.android.util.kotlin.fastForEachIndexed
+import team.duckie.quackquack.ui.component.QuackGridLayout
 
 @Composable
 fun <T> DuckieGridLayout(
@@ -46,7 +43,8 @@ fun <T> DuckieGridLayout(
     ) {
         var index = 0
         items.chunked(columns)
-            .fastForEach { chunkedList ->
+            .fastForEachIndexed { ii, chunkedList ->
+                Log.d("index", ii.toString())
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/AllowMagicNumber.kt
+++ b/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/AllowMagicNumber.kt
@@ -12,6 +12,6 @@ package team.duckie.app.android.util.kotlin
  *
  * @param because MagicNumber 을 허용하는 이유
  */
-@Target(AnnotationTarget.EXPRESSION, AnnotationTarget.CLASS)
+@Target(AnnotationTarget.EXPRESSION, AnnotationTarget.CLASS, AnnotationTarget.FILE)
 @Retention(AnnotationRetention.SOURCE)
 annotation class AllowMagicNumber(val because: String = "")


### PR DESCRIPTION
## Overview (Required)
### ExamInformationScreen
- QuackTheme 적용
- 시험 영역 텍스트 필드와 Tag가 나타나는 부분 Fade Animation으로 자연스럽게 변경
- figma 디자인에 맞게 padding 수정
- 시험 영역 태그를 클릭하면 기존 값 사라지도록 변경
- 텍스트필드 글자 수 제한 적용

### FindExamAreaScreen
- 시험 영역 placeholder 개선하여 TextField로 유도하도록 변경
- 시험 영역 화면에서 이전 화면으로 돌아갔을 때, 스크롤 상태 유지
- 시험 영역 찾기 리스트에서 횡범위를 넓게 설정
- 키보드 done ime action 시 현재 텍스트를 시험 영역으로 설정 