### PR TITLE
문제 만들기 1단계 UI/UX 변경사항 반영

### DIFF
--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -125,7 +125,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                         leadingIcon = QuackIcon.Search,
                         text = state.examArea,
                         onTextChanged = {},
-                        placeholderText = stringResource(id = R.string.find_exam_area),
+                        placeholderText = stringResource(id = R.string.search_exam_area_tag),
                         enabled = false,
                     )
                 }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -187,7 +187,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                             }
                         },
                     ),
-                    maxLength = CreateProblemViewModel.certifyingStatementMaxLength,
+                    maxLength = CertifyingStatementMaxLength,
                     showCounter = true,
                 )
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -58,6 +58,10 @@ import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.modifier.quackClickable
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
+private const val ExamTitleMaxLength = 12
+private const val ExamDescriptionMaxLength = 30
+private const val CertifyingStatementMaxLength = 16
+
 @Composable
 internal fun ExamInformationScreen() = CoroutineScopeContent {
     val viewModel = LocalViewModel.current as CreateProblemViewModel
@@ -135,7 +139,11 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
             TitleAndComponent(stringResource = R.string.exam_title) {
                 QuackBasicTextField(
                     text = state.examTitle,
-                    onTextChanged = viewModel::setExamTitle,
+                    onTextChanged = {
+                        if (state.examTitle.length <= ExamTitleMaxLength) {
+                            viewModel.setExamTitle(it)
+                        }
+                    },
                     placeholderText = stringResource(id = R.string.input_exam_title),
                     keyboardOptions = ImeActionNext,
                     keyboardActions = moveDownFocus(focusManager),
@@ -150,7 +158,11 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                             viewModel.onExamAreaFocusChanged(state.isFocused)
                         },
                     text = state.examDescription,
-                    onTextChanged = viewModel::setExamDescription,
+                    onTextChanged = {
+                        if (state.examDescription.length <= ExamDescriptionMaxLength) {
+                            viewModel.setExamDescription(it)
+                        }
+                    },
                     placeholderText = stringResource(id = R.string.input_exam_description),
                     imeAction = ImeAction.Next,
                     keyboardActions = moveDownFocus(focusManager),
@@ -161,7 +173,11 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                 QuackGrayscaleTextField(
                     modifier = Modifier.padding(bottom = 16.dp),
                     text = state.certifyingStatement,
-                    onTextChanged = viewModel::setCertifyingStatement,
+                    onTextChanged = {
+                        if (state.certifyingStatement.length <= CertifyingStatementMaxLength) {
+                            viewModel.setCertifyingStatement(it)
+                        }
+                    },
                     placeholderText = stringResource(id = R.string.input_certifying_statement),
                     keyboardActions = KeyboardActions(
                         onDone = {
@@ -171,7 +187,7 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                             }
                         },
                     ),
-                    maxLength = viewModel.certifyingStatementMaxLength,
+                    maxLength = CreateProblemViewModel.certifyingStatementMaxLength,
                     showCounter = true,
                 )
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -44,9 +44,9 @@ import team.duckie.app.android.shared.ui.compose.DuckieGridLayout
 import team.duckie.app.android.util.compose.CoroutineScopeContent
 import team.duckie.app.android.util.compose.LocalViewModel
 import team.duckie.app.android.util.compose.launch
-import team.duckie.quackquack.ui.component.QuackBasicTextArea
 import team.duckie.quackquack.ui.component.QuackBasicTextField
 import team.duckie.quackquack.ui.component.QuackCircleTag
+import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
 import team.duckie.quackquack.ui.component.QuackMediumToggleButton
 import team.duckie.quackquack.ui.component.QuackReviewTextArea
 import team.duckie.quackquack.ui.icon.QuackIcon
@@ -154,9 +154,9 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                     keyboardActions = moveDownFocus(focusManager),
                     focused = state.examDescriptionFocused,
                 )
-            } // TODO(EvergreenTree97): 컴포넌트 필요
+            }
             TitleAndComponent(stringResource = R.string.certifying_statement) {
-                QuackBasicTextArea(
+                QuackGrayscaleTextField(
                     modifier = Modifier.padding(bottom = 16.dp),
                     text = state.certifyingStatement,
                     onTextChanged = viewModel::setCertifyingStatement,
@@ -169,6 +169,8 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                             }
                         },
                     ),
+                    maxLength = viewModel.certifyingStatementMaxLength,
+                    showCounter = true,
                 )
             }
         }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -44,13 +46,17 @@ import team.duckie.app.android.shared.ui.compose.DuckieGridLayout
 import team.duckie.app.android.util.compose.CoroutineScopeContent
 import team.duckie.app.android.util.compose.LocalViewModel
 import team.duckie.app.android.util.compose.launch
+import team.duckie.quackquack.ui.border.QuackBorder
+import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBasicTextField
 import team.duckie.quackquack.ui.component.QuackCircleTag
 import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
-import team.duckie.quackquack.ui.component.QuackMediumToggleButton
 import team.duckie.quackquack.ui.component.QuackReviewTextArea
+import team.duckie.quackquack.ui.component.QuackSurface
+import team.duckie.quackquack.ui.component.internal.QuackText
 import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.modifier.quackClickable
+import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 @Composable
 internal fun ExamInformationScreen() = CoroutineScopeContent {
@@ -90,15 +96,11 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                 ),
             state = lazyListState,
             verticalArrangement = Arrangement.spacedBy(space = 48.dp),
-        ) { // TODO(EvergreenTree97): 컴포넌트 필요
+        ) {
             TitleAndComponent(stringResource = R.string.category_title) {
                 AnimatedVisibility(visible = state.isCategoryLoading.not()) {
                     DuckieGridLayout(items = state.categories) { index, item ->
-                        QuackMediumToggleButton(
-                            modifier = Modifier.size(
-                                width = 102.dp,
-                                height = 40.dp,
-                            ),
+                        MediumButton(
                             text = item.name,
                             selected = state.categorySelection == index,
                             onClick = {
@@ -174,5 +176,45 @@ internal fun ExamInformationScreen() = CoroutineScopeContent {
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun MediumButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    QuackSurface(
+        modifier = modifier.size(
+            width = 102.dp,
+            height = 40.dp,
+        ),
+        backgroundColor = QuackColor.White,
+        border = QuackBorder(
+            color = when (selected) {
+                true -> QuackColor.DuckieOrange
+                else -> QuackColor.Gray3
+            },
+        ),
+        shape = RoundedCornerShape(size = 8.dp),
+        onClick = onClick,
+    ) {
+        QuackText(
+            modifier = Modifier.padding(all = 10.dp),
+            text = text,
+            style = when (selected) {
+                true -> QuackTextStyle.Title2.change(
+                    color = QuackColor.DuckieOrange,
+                    textAlign = TextAlign.Center,
+                )
+                else -> QuackTextStyle.Body1.change(
+                    color = QuackColor.Black,
+                    textAlign = TextAlign.Center,
+                )
+            },
+            singleLine = true,
+        )
     }
 }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/FindExamAreaScreen.kt
@@ -19,11 +19,16 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -42,6 +47,14 @@ internal fun FindExamAreaScreen() {
     val viewModel = LocalViewModel.current as CreateProblemViewModel
     val state = viewModel.state.collectAsStateWithLifecycle().value.examInformation.foundExamArea
     val focusRequester = remember { FocusRequester() }
+    var examAreaTextFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = state.examArea,
+                selection = TextRange(state.cursorPosition),
+            )
+        )
+    }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -67,8 +80,14 @@ internal fun FindExamAreaScreen() {
             QuackBasicTextField(
                 modifier = Modifier.focusRequester(focusRequester),
                 leadingIcon = QuackIcon.Search,
-                text = state.examArea,
-                onTextChanged = viewModel::setExamArea,
+                value = examAreaTextFieldValue,
+                onValueChanged = { textFieldValue ->
+                    examAreaTextFieldValue = textFieldValue
+                    viewModel.setExamArea(
+                        examArea = textFieldValue.text,
+                        cursorPosition = textFieldValue.selection.end,
+                    )
+                },
                 placeholderText = stringResource(id = R.string.search_exam_area_tag),
                 keyboardActions = KeyboardActions(
                     onDone = { viewModel.onClickSearchListHeader() }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -27,10 +27,6 @@ import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateP
 import team.duckie.app.android.util.kotlin.copy
 import team.duckie.app.android.util.viewmodel.BaseViewModel
 
-private const val ExamTitleMaxLength = 12
-private const val ExamDescriptionMaxLength = 30
-private const val CertifyingStatementMaxLength = 16
-
 @Singleton
 class CreateProblemViewModel @Inject constructor(
     private val makeExamUseCase: MakeExamUseCase,
@@ -49,9 +45,6 @@ class CreateProblemViewModel @Inject constructor(
      * `ProfileScreen` 에서 `PhotoPicker` 에 사용할 이미지 목록을 불러오기 위해 사용됩니다.
      */
     val galleryImages: ImmutableList<String> get() = mutableGalleryImages
-
-    val certifyingStatementMaxLength: Int
-        get() = CertifyingStatementMaxLength
 
     suspend fun makeExam() {
         makeExamUseCase(dummyParam).onSuccess { isSuccess: Boolean ->
@@ -114,38 +107,32 @@ class CreateProblemViewModel @Inject constructor(
     }
 
     fun setExamTitle(examTitle: String) {
-        if (examTitle.length <= ExamTitleMaxLength) {
-            updateState { prevState ->
-                prevState.copy(
-                    examInformation = prevState.examInformation.copy(
-                        examTitle = examTitle,
-                    ),
-                )
-            }
+        updateState { prevState ->
+            prevState.copy(
+                examInformation = prevState.examInformation.copy(
+                    examTitle = examTitle,
+                ),
+            )
         }
     }
 
     fun setExamDescription(examDescription: String) {
-        if (examDescription.length <= ExamDescriptionMaxLength) {
-            updateState { prevState ->
-                prevState.copy(
-                    examInformation = prevState.examInformation.copy(
-                        examDescription = examDescription,
-                    ),
-                )
-            }
+        updateState { prevState ->
+            prevState.copy(
+                examInformation = prevState.examInformation.copy(
+                    examDescription = examDescription,
+                ),
+            )
         }
     }
 
     fun setCertifyingStatement(certifyingStatement: String) {
-        if (certifyingStatement.length <= CertifyingStatementMaxLength) {
-            updateState { prevState ->
-                prevState.copy(
-                    examInformation = prevState.examInformation.copy(
-                        certifyingStatement = certifyingStatement,
-                    ),
-                )
-            }
+        updateState { prevState ->
+            prevState.copy(
+                examInformation = prevState.examInformation.copy(
+                    certifyingStatement = certifyingStatement,
+                ),
+            )
         }
     }
 
@@ -296,6 +283,7 @@ class CreateProblemViewModel @Inject constructor(
             categorySelection >= 0 && isExamAreaSelected && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()
         }
     }
+
 }
 
 private val dummyParam = ExamParam(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -50,7 +50,7 @@ class CreateProblemViewModel @Inject constructor(
      */
     val galleryImages: ImmutableList<String> get() = mutableGalleryImages
 
-    val certifyingStatementMaxLength : Int
+    val certifyingStatementMaxLength: Int
         get() = CertifyingStatementMaxLength
 
     suspend fun makeExam() {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -149,13 +149,17 @@ class CreateProblemViewModel @Inject constructor(
         }
     }
 
-    fun setExamArea(examArea: String) {
+    fun setExamArea(
+        examArea: String,
+        cursorPosition: Int,
+    ) {
         updateState { prevState ->
             prevState.copy(
                 examInformation = prevState.examInformation.copy(
                     foundExamArea = prevState.examInformation.foundExamArea.copy(
                         examArea = examArea,
-                    )
+                        cursorPosition = cursorPosition,
+                    ),
                 ),
             )
         }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -50,6 +50,9 @@ class CreateProblemViewModel @Inject constructor(
      */
     val galleryImages: ImmutableList<String> get() = mutableGalleryImages
 
+    val certifyingStatementMaxLength : Int
+        get() = CertifyingStatementMaxLength
+
     suspend fun makeExam() {
         makeExamUseCase(dummyParam).onSuccess { isSuccess: Boolean ->
             print(isSuccess) // TODO(EvergreenTree97) 문제 만들기 3단계에서 사용 가능

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -283,7 +283,6 @@ class CreateProblemViewModel @Inject constructor(
             categorySelection >= 0 && isExamAreaSelected && examTitle.isNotEmpty() && examDescription.isNotEmpty() && certifyingStatement.isNotEmpty()
         }
     }
-
 }
 
 private val dummyParam = ExamParam(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -41,6 +41,7 @@ data class CreateProblemState(
                 "도로 패션",
             ),
             val examArea: String = "",
+            val cursorPosition: Int = 0,
         )
         data class AdditionInfoArea(
             val thumbnail: Any? = null,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ di-inject = "1"
 ktor-core = "2.1.2"
 
 # quack
-quack-ui-components = "1.4.1"
+quack-ui-components = "1.4.3"
 quack-lint-core = "1.0.1"
 quack-lint-quack = "1.0.1"
 quack-lint-compose = "1.0.2"


### PR DESCRIPTION
## Overview (Required)
- **꽥꽥 1.4.3 버전을 적용하였습니다**
- 필적 확인 문구 TextField를 새로운 꽥꽥 컴포넌트로 변경하였습니다
- 시험 영역 찾기에서 검색 도중 이전 화면에 갔다와도 커서가 유지되도록 변경하였습니다
- 시험 영역 placeholder를 피그마 요구사항에 맞게 변경하였습니다
- QuackSurface를 이용하여 **해당 화면에서만 쓰이는 MediumButton**을 만들었습니다.

## Screenshot
![image](https://user-images.githubusercontent.com/70064912/209797056-f93cad06-9b54-40ec-af5e-c98c052beea1.png)

![image](https://user-images.githubusercontent.com/70064912/209796866-c64187f5-21f2-4ebf-9bf3-a75941a4603e.png)

