### PR TITLE
test: BodyNegotiation E2E 테스트 작성

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -44,6 +44,6 @@ dependencies {
         libs.test.coroutines,
         libs.test.ktor.client,
         libs.test.ktor.server, // for E2E test
-        libs.bundles.ktor.server, // for E2E test
+        libs.ktor.server.core, // for E2E test
     )
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
         libs.login.kakao,
         libs.kotlin.coroutines,
         libs.kotlin.collections.immutable,
-        libs.bundles.ktor,
+        libs.bundles.ktor.client,
         projects.domain,
         projects.utilKotlin,
         projects.pluginKtorClient,
@@ -43,5 +43,7 @@ dependencies {
     testImplementations(
         libs.test.coroutines,
         libs.test.ktor.client,
+        libs.test.ktor.server, // for E2E test
+        libs.bundles.ktor.server, // for E2E test
     )
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_util/JsonBuilder.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_util/JsonBuilder.kt
@@ -7,8 +7,10 @@
 
 package team.duckie.app.android.data._util
 
+import team.duckie.app.android.util.kotlin.DuckieDsl
 import team.duckie.app.android.util.kotlin.fastForEach
 
+@DuckieDsl
 internal interface JsonBuilder {
     infix fun String.withInt(value: Int)
     infix fun String.withFloat(value: Float)

--- a/data/src/main/kotlin/team/duckie/app/android/data/_util/KtorExtensions.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_util/KtorExtensions.kt
@@ -12,7 +12,9 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.setBody
 import team.duckie.app.android.data._datasource.updateClient
+import team.duckie.app.android.util.kotlin.DuckieDsl
 
+@DuckieDsl
 internal inline fun HttpRequestBuilder.jsonBody(builder: JsonBuilder.() -> Unit) {
     setBody(buildJson(builder))
 }

--- a/data/src/test/kotlin/team/duckie/app/android/data/e2e_test/BodyNegotiationTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/e2e_test/BodyNegotiationTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.e2e_test
+
+import io.ktor.client.request.get
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.testing.testApplication
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEqualTo
+import team.duckie.app.android.data._util.jsonBody
+import team.duckie.app.android.data.e2e_test.module.bodyResponseModule
+import team.duckie.app.android.data.e2e_test.util.createContentNegotiationClient
+import team.duckie.app.android.domain.tag.model.Tag
+
+class BodyNegotiationTest {
+    @Test
+    fun equal_plain_text_as_same_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            setBody("Hello, world!")
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "Hello, world!"
+
+        expectThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun not_equal_plain_text_as_same_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            setBody("Bye, world!")
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "Hello, world!"
+
+        expectThat(actual).isNotEqualTo(expected)
+    }
+
+    @Test
+    fun equal_object_as_json_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            setBody(
+                mapOf(
+                    "name" to "Duckie",
+                    "age" to 1,
+                )
+            )
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "{\"name\":\"Duckie\",\"age\":1}"
+
+        expectThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun not_equal_object_as_json_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            setBody(
+                mapOf(
+                    "name" to "Duckie",
+                    "age" to 100,
+                )
+            )
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "{\"name\":\"Duckie\",\"age\":1}"
+
+        expectThat(actual).isNotEqualTo(expected)
+    }
+
+    @Test
+    fun equal_pojo_as_json_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            setBody(Tag(id = 1, name = "Tag"))
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "{\"id\":1,\"name\":\"Tag\"}"
+
+        expectThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun not_equal_pojo_as_json_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            setBody(Tag(id = 100, name = "Tag"))
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "{\"id\":1,\"name\":\"Tag\"}"
+
+        expectThat(actual).isNotEqualTo(expected)
+    }
+
+    @Test
+    fun equal_plain_json_as_same_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            jsonBody {
+                "name" withString "Duckie"
+                "age" withInt 1
+            }
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "{\"name\":\"Duckie\",\"age\":1}"
+
+        expectThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun not_equal_plain_json_as_same_body() = testApplication {
+        val client = createContentNegotiationClient()
+        application { bodyResponseModule() }
+
+        val response = client.get("/") {
+            jsonBody {
+                "name" withString "Duckie"
+                "age" withInt 100
+            }
+        }
+        val actual = response.bodyAsText()
+
+        val expected = "{\"name\":\"Duckie\",\"age\":1}"
+
+        expectThat(actual).isNotEqualTo(expected)
+    }
+}

--- a/data/src/test/kotlin/team/duckie/app/android/data/e2e_test/module/BodyResponseModule.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/e2e_test/module/BodyResponseModule.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.e2e_test.module
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+fun Application.bodyResponseModule() {
+    routing {
+        get("/") {
+            val rawBody = call.receiveText()
+            call.respondText(rawBody)
+        }
+    }
+}

--- a/data/src/test/kotlin/team/duckie/app/android/data/e2e_test/util/ApplicationTestClientBuilder.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/e2e_test/util/ApplicationTestClientBuilder.kt
@@ -1,0 +1,27 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.e2e_test.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.testing.ApplicationTestBuilder
+
+fun ApplicationTestBuilder.createContentNegotiationClient(): HttpClient {
+    return createClient {
+        install(ContentNegotiation) {
+            jackson()
+        }
+        defaultRequest {
+            contentType(ContentType.Application.Json)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -186,7 +186,6 @@ di-inject = { module = "javax.inject:javax.inject", version.ref = "di-inject" }
 
 ktor-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor-core" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor-core" }
-ktor-server-engine = { module = "io.ktor:ktor-server-netty", version.ref = "ktor-core" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor-core" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor-core" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor-core" }
@@ -215,5 +214,4 @@ ktx = ["ktx-core", "ktx-activiy", "ktx-lifecycle"]
 compose-core = ["compose-runtime", "compose-ui-foundation", "compose-ui-activity", "compose-util-tooling-preview"]
 compose-debug = ["compose-util-tooling-core", "compose-util-customview-pooling-container"] # debugImplementation
 ktor-client = ["ktor-jackson", "ktor-client-core", "ktor-client-content-negotiation", "ktor-client-logging", "ktor-client-engine"]
-ktor-server = ["ktor-server-core", "ktor-server-engine"]
 quack-lint = ["quack-lint-core", "quack-lint-quack", "quack-lint-compose"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -184,11 +184,13 @@ di-hilt-core = { module = "com.google.dagger:hilt-android", version.ref = "di-hi
 di-hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "di-hilt" }
 di-inject = { module = "javax.inject:javax.inject", version.ref = "di-inject" }
 
-ktor-client = { module = "io.ktor:ktor-client-core", version.ref = "ktor-core" }
-ktor-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor-core" }
 ktor-jackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "ktor-core" }
-ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor-core" }
-ktor-engine = { module = "io.ktor:ktor-client-cio", version.ref = "ktor-core" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor-core" }
+ktor-server-engine = { module = "io.ktor:ktor-server-netty", version.ref = "ktor-core" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor-core" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor-core" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor-core" }
+ktor-client-engine = { module = "io.ktor:ktor-client-cio", version.ref = "ktor-core" }
 
 quack-ui-components = { module = "team.duckie.quack:quack-ui-components", version.ref = "quack-ui-components" }
 quack-lint-core = { module = "team.duckie.quack:quack-lint-core", version.ref = "quack-lint-core" }
@@ -206,10 +208,12 @@ test-parameter-injector = { module = "com.google.testparameterinjector:test-para
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "test-turbine" }
 test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 test-ktor-client = { module = "io.ktor:ktor-client-mock", version.ref = "ktor-core" }
+test-ktor-server = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor-core" }
 
 [bundles]
 ktx = ["ktx-core", "ktx-activiy", "ktx-lifecycle"]
 compose-core = ["compose-runtime", "compose-ui-foundation", "compose-ui-activity", "compose-util-tooling-preview"]
 compose-debug = ["compose-util-tooling-core", "compose-util-customview-pooling-container"] # debugImplementation
-ktor = ["ktor-client", "ktor-content-negotiation", "ktor-jackson", "ktor-logging", "ktor-engine"]
+ktor-client = ["ktor-jackson", "ktor-client-core", "ktor-client-content-negotiation", "ktor-client-logging", "ktor-client-engine"]
+ktor-server = ["ktor-server-core", "ktor-server-engine"]
 quack-lint = ["quack-lint-core", "quack-lint-quack", "quack-lint-compose"]

--- a/plugin-ktor-client/build.gradle.kts
+++ b/plugin-ktor-client/build.gradle.kts
@@ -13,9 +13,9 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.ktor.client)
+    implementation(libs.ktor.client.core)
     testImplementations(
-        libs.ktor.engine,
+        libs.ktor.client.engine,
         libs.test.coroutines,
     )
 }


### PR DESCRIPTION
## Overview (Required)

Body 를 항상 POJO 로만 제공하다가, `jsonBody()` 를 도입하면서 Plain-Text 로 제공하는 코드가 생겼습니다. Plain-Text 로 Body 를 제공하는 경우는 처음인지라 테스트 코드가 필요하다고 느꼈고, 이에 맞는 테스트 코드를 작성하였습니다.

BodyNegotiationTest 는 위 설명대로 다음과 같은 케이스를 assertion 합니다.

- POJO Body 와 Plain-Text Body 의 receive 결과가 동일해야 함
- Object Body 와 Plain-Text Body 의 receive 결과가 동일해야 함

현스님의 조언으론 서버에서 Body 는 Plain-Text 로 처리되기에 클라이언트에서 Body 를 보낼 때 직렬화를 어떻게 하냐가 중요하다고 하셨습니다.

이 테스트는 Ktor Client 가 Body 를 보낼 때 POJO 와 Plain-Text 모두 동일하게 처리하는지를 assertion 하여 `jsonBody()` 에 문제가 없음을 확신하기 위함입니다.