### PR TITLE
[MAJOR] feat: OnboardViewModel 재구현

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1.0.5
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/build-logic/local-enums/build.gradle.kts
+++ b/build-logic/local-enums/build.gradle.kts
@@ -30,11 +30,11 @@ gradlePlugin {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }
 
 tasks.withType<JavaCompile> {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }

--- a/build-logic/src/main/kotlin/team/duckie/app/android/convention/ApplicationConstants.kt
+++ b/build-logic/src/main/kotlin/team/duckie/app/android/convention/ApplicationConstants.kt
@@ -18,5 +18,5 @@ internal object ApplicationConstants {
     const val compileSdk = 33
     const val versionCode = 1
     const val versionName = "MVP-1.0.0"
-    val javaVersion = JavaVersion.VERSION_11
+    val javaVersion = JavaVersion.VERSION_17
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ allprojects {
 
         tasks.withType<KotlinCompile> {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
                 freeCompilerArgs = freeCompilerArgs + listOf(
                     "-opt-in=kotlin.OptIn",
                     "-opt-in=kotlin.RequiresOptIn",

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,6 +9,7 @@ import DependencyHandler.Extensions.implementations
 
 plugins {
     id(ConventionEnum.AndroidLibrary)
+    id("kotlin-parcelize")
 }
 
 android {

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/category/model/Category.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/category/model/Category.kt
@@ -7,14 +7,16 @@
 
 package team.duckie.app.android.domain.category.model
 
+import android.os.Parcelable
 import androidx.compose.runtime.Immutable
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.parcelize.Parcelize
 import team.duckie.app.android.domain.tag.model.Tag
 
 @Immutable
+@Parcelize
 data class Category(
     val id: Int,
     val name: String,
     val thumbnailUrl: String,
-    val popularTags: ImmutableList<Tag>?,
-)
+    val popularTags: List<Tag>?,
+) : Parcelable

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/tag/model/Tag.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/tag/model/Tag.kt
@@ -7,10 +7,13 @@
 
 package team.duckie.app.android.domain.tag.model
 
+import android.os.Parcelable
 import androidx.compose.runtime.Immutable
+import kotlinx.parcelize.Parcelize
 
 @Immutable
+@Parcelize
 data class Tag(
     val id: Int,
     val name: String,
-)
+) : Parcelable

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/user/model/User.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/user/model/User.kt
@@ -9,32 +9,20 @@
 
 package team.duckie.app.android.domain.user.model
 
+import android.os.Parcelable
 import androidx.compose.runtime.Immutable
-import com.fasterxml.jackson.annotation.JsonIgnore
-import java.io.File
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.parcelize.Parcelize
 import team.duckie.app.android.domain.category.model.Category
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.user.constant.DuckieTier
 
 @Immutable
+@Parcelize
 data class User(
     val id: Int,
     val nickname: String,
     val profileImageUrl: String,
     val tier: DuckieTier,
-    val favoriteTags: ImmutableList<Tag>?,
-    val favoriteCategories: ImmutableList<Category>?,
-) {
-    @JsonIgnore
-    var temporaryNickname: String? = null
-
-    @JsonIgnore
-    var temporaryProfileImageFile: File? = null
-
-    @JsonIgnore
-    var temporaryProfileImageUrl: String? = null
-
-    @JsonIgnore
-    var temporaryFavoriteTags: List<Tag>? = null
-}
+    val favoriteTags: List<Tag>?,
+    val favoriteCategories: List<Category>?,
+) : Parcelable

--- a/feature-ui-onboard/build.gradle.kts
+++ b/feature-ui-onboard/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id(ConventionEnum.AndroidLibrary)
     id(ConventionEnum.AndroidLibraryCompose)
     id(ConventionEnum.AndroidHilt)
+    id("kotlin-parcelize")
 }
 
 android {

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/constant/OnboardStep.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/constant/OnboardStep.kt
@@ -11,6 +11,7 @@ import team.duckie.app.android.util.kotlin.AllowMagicNumber
 
 @AllowMagicNumber
 internal enum class OnboardStep(private val index: Int) {
+    Activity(-1),
     Login(0),
     Profile(1),
     Category(2),

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/constant/OnboardStep.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/constant/OnboardStep.kt
@@ -27,4 +27,7 @@ internal enum class OnboardStep(private val index: Int) {
     }
 }
 
+internal annotation class CollectInStep { companion object }
+internal annotation class CollectInViewModel { companion object }
+
 internal annotation class RequiredStep(@Suppress("unused") vararg val step: OnboardStep)

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/0_LoginScreen.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/0_LoginScreen.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:Suppress("ConstPropertyName", "PrivatePropertyName")
+
 package team.duckie.app.android.feature.ui.onboard.screen
 
 import androidx.compose.foundation.Image

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/1_ProfileScreen.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/1_ProfileScreen.kt
@@ -6,6 +6,7 @@
  */
 
 @file:OptIn(FlowPreview::class, ExperimentalComposeUiApi::class)
+@file:Suppress("ConstPropertyName", "PrivatePropertyName")
 
 package team.duckie.app.android.feature.ui.onboard.screen
 
@@ -48,7 +49,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import org.orbitmvi.orbit.compose.collectState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import team.duckie.app.android.feature.photopicker.PhotoPicker
 import team.duckie.app.android.feature.photopicker.PhotoPickerConstants
 import team.duckie.app.android.feature.ui.onboard.R
@@ -56,7 +57,7 @@ import team.duckie.app.android.feature.ui.onboard.common.OnboardTopAppBar
 import team.duckie.app.android.feature.ui.onboard.common.TitleAndDescription
 import team.duckie.app.android.feature.ui.onboard.constant.OnboardStep
 import team.duckie.app.android.feature.ui.onboard.viewmodel.OnboardViewModel
-import team.duckie.app.android.feature.ui.onboard.viewmodel.state.OnboardState
+import team.duckie.app.android.feature.ui.onboard.viewmodel.sideeffect.OnboardSideEffect
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.compose.asLoose
 import team.duckie.app.android.util.compose.rememberToast
@@ -198,9 +199,9 @@ internal fun ProfileScreen(vm: OnboardViewModel = activityViewModel()) {
     var nicknameIsUseable by remember { mutableStateOf(false) }
 
     // Collecting in LaunchedEffect
-    vm.collectState { state ->
-        if (state is OnboardState.NicknameDuplicateChecked) {
-            nicknameIsUseable = state.isUsable
+    vm.collectSideEffect { sideEffect ->
+        if (sideEffect is OnboardSideEffect.NicknameDuplicateChecked) {
+            nicknameIsUseable = sideEffect.isUsable
         }
     }
 
@@ -370,7 +371,7 @@ private fun navigateNextStepIfOk(
     nicknameIsUseable: Boolean,
 ) {
     if (debounceFinish && nickname.isNotEmpty() && !nicknameRuleError && nicknameIsUseable) {
-        vm.me.temporaryNickname = nickname
+        vm.updateUserNickname(nickname)
         vm.navigateStep(currentStep + 1)
     }
 }

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/OnboardViewModel.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/OnboardViewModel.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:Suppress("ConstPropertyName", "PrivatePropertyName")
+
 package team.duckie.app.android.feature.ui.onboard.viewmodel
 
 import android.app.Application
@@ -22,11 +24,8 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import java.io.File
 import kotlin.coroutines.resume
-import kotlin.properties.Delegates
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.apache.commons.io.FileUtils
@@ -45,13 +44,13 @@ import team.duckie.app.android.domain.gallery.usecase.LoadGalleryImagesUseCase
 import team.duckie.app.android.domain.kakao.usecase.GetKakaoAccessTokenUseCase
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.tag.usecase.TagCreateUseCase
-import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.domain.user.usecase.NicknameDuplicateCheckUseCase
 import team.duckie.app.android.domain.user.usecase.UserUpdateUseCase
 import team.duckie.app.android.feature.ui.onboard.constant.OnboardStep
 import team.duckie.app.android.feature.ui.onboard.viewmodel.sideeffect.OnboardSideEffect
 import team.duckie.app.android.feature.ui.onboard.viewmodel.state.OnboardState
 import team.duckie.app.android.util.android.permission.PermissionCompat
+import team.duckie.app.android.util.android.savedstate.SaveableMutableStateFlow
 import team.duckie.app.android.util.android.viewmodel.context
 import team.duckie.app.android.util.kotlin.cancelChildrenAndItself
 import team.duckie.app.android.util.kotlin.fastForEach
@@ -60,9 +59,11 @@ import team.duckie.app.android.util.kotlin.seconds
 private val NextStepNavigateThrottle = 1.seconds
 private const val ProfileImageCompressQuality = 100
 
+private const val ImagePermissionGrantStateSavedKey = "ImagePermissionGrantState"
+
 internal class OnboardViewModel @AssistedInject constructor(
     application: Application,
-    @Suppress("UNUSED_PARAMETER") @Assisted savedStateHandle: SavedStateHandle,
+    @Assisted private val savedStateHandle: SavedStateHandle,
     private val nicknameDuplicateCheckUseCase: NicknameDuplicateCheckUseCase,
     private val loadGalleryImagesUseCase: LoadGalleryImagesUseCase,
     private val joinUseCase: JoinUseCase,
@@ -105,27 +106,30 @@ internal class OnboardViewModel @AssistedInject constructor(
 
     /* ----- Variable ----- */
 
-    override val container = container<OnboardState, OnboardSideEffect>(OnboardState.Initial)
+    override val container = container<OnboardState, OnboardSideEffect>(
+        initialState = OnboardState(),
+        savedStateHandle = savedStateHandle,
+    )
 
     private val duckieUserProfileImageTemporaryFile =
-        File.createTempFile("temporary-duckie-user-profile-image", ".png", application.cacheDir)
+        File.createTempFile("temporary-duckie-user-profile-image", ".png", context.cacheDir)
 
     private val nicknameFilter = Regex("[^가-힣a-zA-Z0-9_.]")
     private var lastestUpdateStepMillis = System.currentTimeMillis()
 
-    private var _galleryImages = persistentListOf<String>()
-    val galleryImages: ImmutableList<String> get() = _galleryImages
+    val galleryImages: ImmutableList<String> get() = container.stateFlow.value.galleryImages.toImmutableList()
 
-    private val mutableImagePermissionGrantState = MutableStateFlow<Boolean?>(null)
-    val imagePermissionGrantState = mutableImagePermissionGrantState.asStateFlow()
-    val isImagePermissionGranted get() = imagePermissionGrantState.value
+    private var imagePermissionGrantState by SaveableMutableStateFlow<Boolean?>(
+        savedStateHandle = savedStateHandle,
+        key = ImagePermissionGrantStateSavedKey,
+        initialValue = null,
+    )
+    val isImagePermissionGranted: Boolean? get() = imagePermissionGrantState
 
     val imagePermission = PermissionCompat.getImageStoragePermission()
     var isCameraPermissionGranted = false
 
-    var me by Delegates.notNull<User>()
-    var categories by Delegates.notNull<ImmutableList<Category>>()
-    var selectedCategories: ImmutableList<Category> = persistentListOf()
+    val me get() = requireNotNull(container.stateFlow.value.me) { "User is not initialized." }
 
     /* ----- Onboard Logic ----- */
 
@@ -136,15 +140,13 @@ internal class OnboardViewModel @AssistedInject constructor(
             return@intent
         }
         lastestUpdateStepMillis = System.currentTimeMillis()
-        reduce {
-            OnboardState.NavigateStep(step)
-        }
+        postSideEffect(OnboardSideEffect.NavigateStep(step))
     }
 
     suspend fun nicknameDuplicateCheck(nickname: String) = intent {
         nicknameDuplicateCheckUseCase(nickname)
             .onSuccess { result ->
-                reduce { OnboardState.NicknameDuplicateChecked(result) }
+                postSideEffect(OnboardSideEffect.NicknameDuplicateChecked(result))
             }
             .attachExceptionHandling()
     }
@@ -159,38 +161,46 @@ internal class OnboardViewModel @AssistedInject constructor(
                 postSideEffect(OnboardSideEffect.UpdateGalleryImages(images))
             }
             .onFailure { expection ->
-                reduce {
-                    OnboardState.Error(expection)
-                }
                 postSideEffect(OnboardSideEffect.ReportError(expection))
             }
     }
 
-    fun addGalleryImages(images: List<String>) {
-        _galleryImages = _galleryImages.addAll(images)
+    fun addGalleryImages(images: List<String>) = intent {
+        reduce {
+            state.copy(galleryImages = images)
+        }
     }
 
-    fun updateUserProfileImageFile(fileUri: Uri) {
+    // from Uri
+    fun updateUserProfileImageFile(fileUri: Uri) = intent {
         val file = duckieUserProfileImageTemporaryFile.also { it.delete() }
         val stream = context.contentResolver.openInputStream(fileUri)
         FileUtils.copyInputStreamToFile(stream, file)
-        me.temporaryProfileImageFile = file
+        reduce {
+            state.copy(temporaryProfileImageFile = file)
+        }
     }
 
-    fun updateUserProfileImageFile(imageBitmap: Bitmap) {
+    // from Bitmap
+    fun updateUserProfileImageFile(imageBitmap: Bitmap) = intent {
         val file = duckieUserProfileImageTemporaryFile.also { it.delete() }
         imageBitmap.compress(Bitmap.CompressFormat.PNG, ProfileImageCompressQuality, file.outputStream())
-        me.temporaryProfileImageFile = file
+        reduce {
+            state.copy(temporaryProfileImageFile = file)
+        }
     }
 
-    suspend fun updateUserProfileImage() {
+    suspend fun updateUserProfileImage() = intent {
         suspendCancellableCoroutine { continuation ->
-            val file = me.temporaryProfileImageFile ?: return@suspendCancellableCoroutine continuation.resume(Unit)
+            // 유저가 프사 등록을 건너뛴 경우
+            val file = state.temporaryProfileImageFile ?: return@suspendCancellableCoroutine continuation.resume(Unit)
             val job = viewModelScope.launch {
                 launch {
-                    container.stateFlow.collect { state ->
-                        if (state is OnboardState.PrfileImageUploaded) {
-                            me.temporaryProfileImageUrl = state.url
+                    container.sideEffectFlow.collect { sideEffect ->
+                        if (sideEffect is OnboardSideEffect.PrfileImageUploaded) {
+                            reduce {
+                                state.copy(temporaryProfileImageUrl = sideEffect.url)
+                            }
                             continuation.resume(Unit)
                         }
                     }
@@ -198,7 +208,10 @@ internal class OnboardViewModel @AssistedInject constructor(
 
                 launch {
                     updateProfileImageFile(file)
-                    me.temporaryProfileImageFile?.delete()
+                    state.temporaryProfileImageFile?.delete()
+                    reduce {
+                        state.copy(temporaryProfileImageFile = null)
+                    }
                 }
             }
 
@@ -208,18 +221,20 @@ internal class OnboardViewModel @AssistedInject constructor(
         }
     }
 
-    suspend fun updateUserFavorateTags(favorateTagNames: List<String>) {
+    suspend fun updateUserFavorateTags(favorateTagNames: List<String>) = intent {
         suspendCancellableCoroutine { continuation ->
             val favorateTagSize = favorateTagNames.size
             val favorateTags = ArrayList<Tag>(favorateTagSize)
             val job = viewModelScope.launch {
                 launch {
-                    container.stateFlow.collect { state ->
-                        if (state is OnboardState.TagCreated) {
-                            favorateTags.add(state.tag)
+                    container.sideEffectFlow.collect { sideEffect ->
+                        if (sideEffect is OnboardSideEffect.TagCreated) {
+                            favorateTags.add(sideEffect.tag)
 
                             if (favorateTags.size == favorateTagSize) {
-                                me.temporaryFavoriteTags = favorateTags
+                                reduce {
+                                    state.copy(temporaryFavoriteTags = favorateTags)
+                                }
                                 continuation.resume(Unit)
                             }
                         }
@@ -246,7 +261,7 @@ internal class OnboardViewModel @AssistedInject constructor(
     /* ----- Permission ----- */
 
     fun updateImagePermissionGrantState(isGranted: Boolean?) {
-        mutableImagePermissionGrantState.value = isGranted
+        imagePermissionGrantState = isGranted
     }
 
     /* ----- Api ----- */
@@ -262,10 +277,10 @@ internal class OnboardViewModel @AssistedInject constructor(
     suspend fun join(kakaoAccessToken: String) = intent {
         joinUseCase(kakaoAccessToken)
             .onSuccess { response ->
-                reduce { OnboardState.Joined(response.isNewUser) }
                 postSideEffect(OnboardSideEffect.UpdateUser(response.user))
                 postSideEffect(OnboardSideEffect.UpdateAccessToken(response.accessToken))
                 postSideEffect(OnboardSideEffect.AttachAccessTokenToHeader(response.accessToken))
+                postSideEffect(OnboardSideEffect.Joined(response.isNewUser))
             }
             .attachExceptionHandling()
     }
@@ -277,7 +292,7 @@ internal class OnboardViewModel @AssistedInject constructor(
     suspend fun getCategories(withPopularTags: Boolean) = intent {
         getCategoriesUseCase(withPopularTags)
             .onSuccess { categories ->
-                reduce { OnboardState.CategoriesLoaded(categories) }
+                postSideEffect(OnboardSideEffect.CategoriesLoaded(categories))
             }
             .attachExceptionHandling()
     }
@@ -285,7 +300,7 @@ internal class OnboardViewModel @AssistedInject constructor(
     private suspend fun updateProfileImageFile(file: File) = intent {
         fileUploadUseCase(file, FileType.Profile)
             .onSuccess { url ->
-                reduce { OnboardState.PrfileImageUploaded(url) }
+                postSideEffect(OnboardSideEffect.PrfileImageUploaded(url))
             }
             .attachExceptionHandling()
     }
@@ -293,7 +308,7 @@ internal class OnboardViewModel @AssistedInject constructor(
     private suspend fun createTag(name: String) = intent {
         tagCreateUseCase(name)
             .onSuccess { tag ->
-                reduce { OnboardState.TagCreated(tag) }
+                postSideEffect(OnboardSideEffect.TagCreated(tag))
             }
             .attachExceptionHandling()
     }
@@ -322,7 +337,6 @@ internal class OnboardViewModel @AssistedInject constructor(
         additinal: (exception: Throwable) -> Unit = {},
     ) = intent {
         onFailure { exception ->
-            reduce { OnboardState.Error(exception) }
             postSideEffect(OnboardSideEffect.ReportError(exception))
             additinal(exception)
         }

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/sideeffect/OnboardSideEffect.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/sideeffect/OnboardSideEffect.kt
@@ -7,10 +7,9 @@
 
 package team.duckie.app.android.feature.ui.onboard.viewmodel.sideeffect
 
-import kotlinx.collections.immutable.ImmutableList
-import team.duckie.app.android.domain.category.model.Category
 import team.duckie.app.android.domain.tag.model.Tag
-import team.duckie.app.android.domain.user.model.User
+import team.duckie.app.android.feature.ui.onboard.constant.CollectInStep
+import team.duckie.app.android.feature.ui.onboard.constant.CollectInViewModel
 import team.duckie.app.android.feature.ui.onboard.constant.OnboardStep
 import team.duckie.app.android.feature.ui.onboard.constant.RequiredStep
 
@@ -27,27 +26,23 @@ internal sealed class OnboardSideEffect {
     @RequiredStep(OnboardStep.Login)
     class AttachAccessTokenToHeader(val accessToken: String) : OnboardSideEffect()
 
-    @RequiredStep(OnboardStep.Login, OnboardStep.Tag) // 마지막 단계에서 유저 정보 업데이트함
-    class UpdateUser(val user: User) : OnboardSideEffect()
-
     @RequiredStep(OnboardStep.Login)
     class Joined(val isNewUser: Boolean) : OnboardSideEffect()
 
+    @CollectInStep
     @RequiredStep(OnboardStep.Profile)
     class NicknameDuplicateChecked(val isUsable: Boolean) : OnboardSideEffect()
 
-    @RequiredStep(OnboardStep.Category)
-    class CategoriesLoaded(val catagories: ImmutableList<Category>) : OnboardSideEffect()
-
+    @CollectInViewModel
     @RequiredStep(OnboardStep.Tag)
     class TagCreated(val tag: Tag) : OnboardSideEffect()
 
+    @CollectInViewModel
     @RequiredStep(OnboardStep.Tag) // 마지막 단계에서 유저 정보 업데이트함
     class PrfileImageUploaded(val url: String) : OnboardSideEffect()
 
     @RequiredStep(OnboardStep.Activity, OnboardStep.Tag)
     object FinishOnboard : OnboardSideEffect()
 
-    class NavigateStep(val step: OnboardStep) : OnboardSideEffect()
     class ReportError(val exception: Throwable) : OnboardSideEffect()
 }

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/sideeffect/OnboardSideEffect.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/sideeffect/OnboardSideEffect.kt
@@ -7,12 +7,15 @@
 
 package team.duckie.app.android.feature.ui.onboard.viewmodel.sideeffect
 
+import kotlinx.collections.immutable.ImmutableList
+import team.duckie.app.android.domain.category.model.Category
+import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.feature.ui.onboard.constant.OnboardStep
 import team.duckie.app.android.feature.ui.onboard.constant.RequiredStep
 
 internal sealed class OnboardSideEffect {
-    object FinishOnboard : OnboardSideEffect()
+    @RequiredStep(OnboardStep.Activity)
     class UpdateGalleryImages(val images: List<String>) : OnboardSideEffect()
 
     @RequiredStep(OnboardStep.Login)
@@ -27,5 +30,24 @@ internal sealed class OnboardSideEffect {
     @RequiredStep(OnboardStep.Login, OnboardStep.Tag) // 마지막 단계에서 유저 정보 업데이트함
     class UpdateUser(val user: User) : OnboardSideEffect()
 
+    @RequiredStep(OnboardStep.Login)
+    class Joined(val isNewUser: Boolean) : OnboardSideEffect()
+
+    @RequiredStep(OnboardStep.Profile)
+    class NicknameDuplicateChecked(val isUsable: Boolean) : OnboardSideEffect()
+
+    @RequiredStep(OnboardStep.Category)
+    class CategoriesLoaded(val catagories: ImmutableList<Category>) : OnboardSideEffect()
+
+    @RequiredStep(OnboardStep.Tag)
+    class TagCreated(val tag: Tag) : OnboardSideEffect()
+
+    @RequiredStep(OnboardStep.Tag) // 마지막 단계에서 유저 정보 업데이트함
+    class PrfileImageUploaded(val url: String) : OnboardSideEffect()
+
+    @RequiredStep(OnboardStep.Activity, OnboardStep.Tag)
+    object FinishOnboard : OnboardSideEffect()
+
+    class NavigateStep(val step: OnboardStep) : OnboardSideEffect()
     class ReportError(val exception: Throwable) : OnboardSideEffect()
 }

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/state/OnboardState.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/state/OnboardState.kt
@@ -7,30 +7,23 @@
 
 package team.duckie.app.android.feature.ui.onboard.viewmodel.state
 
-import kotlinx.collections.immutable.ImmutableList
+import android.os.Parcelable
+import java.io.File
+import kotlinx.parcelize.Parcelize
 import team.duckie.app.android.domain.category.model.Category
 import team.duckie.app.android.domain.tag.model.Tag
+import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.feature.ui.onboard.constant.OnboardStep
-import team.duckie.app.android.feature.ui.onboard.constant.RequiredStep
 
-internal sealed class OnboardState {
-    object Initial : OnboardState()
-    class NavigateStep(val step: OnboardStep) : OnboardState()
-
-    @RequiredStep(OnboardStep.Login)
-    class Joined(val isNewUser: Boolean) : OnboardState()
-
-    @RequiredStep(OnboardStep.Profile)
-    class NicknameDuplicateChecked(val isUsable: Boolean) : OnboardState()
-
-    @RequiredStep(OnboardStep.Category)
-    class CategoriesLoaded(val catagories: ImmutableList<Category>) : OnboardState()
-
-    @RequiredStep(OnboardStep.Tag)
-    class TagCreated(val tag: Tag) : OnboardState()
-
-    @RequiredStep(OnboardStep.Tag) // 마지막 단계에서 유저 정보 업데이트함
-    class PrfileImageUploaded(val url: String) : OnboardState()
-
-    class Error(val exception: Throwable) : OnboardState()
-}
+@Parcelize
+internal data class OnboardState(
+    val step: OnboardStep = OnboardStep.Activity,
+    val me: User? = null,
+    val temporaryNickname: String? = null,
+    val temporaryProfileImageFile: File? = null,
+    val temporaryProfileImageUrl: String? = null,
+    val temporaryFavoriteTags: List<Tag>? = null,
+    val galleryImages: List<String> = emptyList(),
+    val categories: List<Category> = emptyList(),
+    val selectedCategories: List<Category> = emptyList(),
+) : Parcelable

--- a/feature-ui-onboard/src/main/res/values/strings.xml
+++ b/feature-ui-onboard/src/main/res/values/strings.xml
@@ -9,7 +9,6 @@
     <string name="permission_needs_for_profile_photo">프로필 사진을 설정하기 위해 이미지/카메라 접근 권한이 필요해요.</string>
     <string name="permission_denied">권한이 거부되어 프로필 사진을 기본 사진으로 사용할게요.</string>
     <string name="bad_internet">인터넷 연결이 불안정해요. 인터넷 연결 상태를 확인해 보세요.</string>
-    <string name="internal_error">요청하신 작업에 문제가 발생했어요.\n잠시 후 다시 시도해 주세요.</string>
 
     <string name="topappbar_trailing_skip">건너뛰기</string>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,7 @@ android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.defaults.databinding.addKtx=false
+android.nonFinalResIds=false
 
 # https://developer.android.com/studio/releases/gradle-plugin#experimental_further_app_size_reductions
 android.experimental.enableNewResourceShrinker.preciseShrinking=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # plugin - build
-plugin-build-gradle-android = "8.0.0-alpha08"
+plugin-build-gradle-android = "8.1.0-alpha01"
 plugin-build-google-service = "4.3.14"
 
 # plugin - code

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-rc-1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/util-android/build.gradle.kts
+++ b/util-android/build.gradle.kts
@@ -18,6 +18,8 @@ android {
 dependencies {
     implementations(
         libs.androidx.lifecycle.savedstate,
+        libs.ktx.lifecycle.runtime,
         libs.ktx.lifecycle.viewmodel,
+        libs.compose.ui.activity,
     )
 }

--- a/util-android/build.gradle.kts
+++ b/util-android/build.gradle.kts
@@ -1,3 +1,5 @@
+import DependencyHandler.Extensions.implementations
+
 /*
  * Designed and developed by Duckie Team, 2022
  *
@@ -14,5 +16,8 @@ android {
 }
 
 dependencies {
-    implementation(libs.ktx.lifecycle.viewmodel)
+    implementations(
+        libs.androidx.lifecycle.savedstate,
+        libs.ktx.lifecycle.viewmodel,
+    )
 }

--- a/util-android/src/main/kotlin/team/duckie/app/android/util/android/lifecycle/RepeatOnCreated.kt
+++ b/util-android/src/main/kotlin/team/duckie/app/android/util/android/lifecycle/RepeatOnCreated.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.util.android.lifecycle
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CoroutineScope
+
+// FIXME(sungbin): `launchWhenCreated` + `repeatOnLifecycle` 가 best 한 조합일까?
+fun ComponentActivity.repeatOnCreated(block: suspend CoroutineScope.() -> Unit) {
+    lifecycleScope.launchWhenCreated {
+        repeatOnLifecycle(
+            state = Lifecycle.State.CREATED,
+            block = block,
+        )
+    }
+}

--- a/util-android/src/main/kotlin/team/duckie/app/android/util/android/savedstate/SaveableMutableStateFlow.kt
+++ b/util-android/src/main/kotlin/team/duckie/app/android/util/android/savedstate/SaveableMutableStateFlow.kt
@@ -1,0 +1,29 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.util.android.savedstate
+
+import androidx.lifecycle.SavedStateHandle
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+class SaveableMutableStateFlow<T>(
+    private val savedStateHandle: SavedStateHandle,
+    private val key: String,
+    initialValue: T,
+) : ReadWriteProperty<Any, T> {
+    private val state = savedStateHandle.getStateFlow(key, initialValue)
+    fun asStateFlow() = state
+
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+        return state.value
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+        savedStateHandle[key] = value
+    }
+}

--- a/util-android/src/main/kotlin/team/duckie/app/android/util/android/savedstate/SaveableMutableStateFlow.kt
+++ b/util-android/src/main/kotlin/team/duckie/app/android/util/android/savedstate/SaveableMutableStateFlow.kt
@@ -17,13 +17,19 @@ class SaveableMutableStateFlow<T>(
     initialValue: T,
 ) : ReadWriteProperty<Any, T> {
     private val state = savedStateHandle.getStateFlow(key, initialValue)
+    var value: T
+        get() = state.value
+        set(value) {
+            savedStateHandle[key] = value
+        }
+
     fun asStateFlow() = state
 
     override fun getValue(thisRef: Any, property: KProperty<*>): T {
-        return state.value
+        return value
     }
 
     override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
-        savedStateHandle[key] = value
+        this.value = value
     }
 }

--- a/util-compose/src/main/kotlin/team/duckie/app/android/util/compose/visibility.kt
+++ b/util-compose/src/main/kotlin/team/duckie/app/android/util/compose/visibility.kt
@@ -1,0 +1,13 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.util.compose
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+
+fun Modifier.invisible() = drawWithContent { }

--- a/util-exception-handling/src/main/kotlin/team/duckie/app/android/util/exception/handling/reporter/toast.kt
+++ b/util-exception-handling/src/main/kotlin/team/duckie/app/android/util/exception/handling/reporter/toast.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:Suppress("PrivatePropertyName")
+
 package team.duckie.app.android.util.exception.handling.reporter
 
 import android.app.Activity


### PR DESCRIPTION
## Overview (Required)

- AS 버전을 Giraffe 로 올렸습니다.
- OnboardViewModel 에 SavedStateHandle 지원을 추가했습니다.
- State 와 SideEffect 을 재정의했습니다.

## Note

- JDK 업데이트로 MavenLocal 재배포가 필요합니다.
- JDK 빌드 확인을 위해 `./gradlew build` 가 검증되지 않은 상태로 CI 돌립니다.
- 아직 런타임 검증을 하지 않았습니다. PR 범위를 줄이기 위해 먼저 올리고, 머지된 이후에 런타임 검증에 들어갑니다.