### PR TITLE
시험 시작 화면 UI 및 데이터 연동

### DIFF
--- a/feature-ui-start-exam/build.gradle.kts
+++ b/feature-ui-start-exam/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
         libs.orbit.compose,
         libs.quack.ui.components,
         libs.compose.lifecycle.runtime,
+        libs.compose.ui.material, // needs for CircularProgressIndicator
         libs.firebase.crashlytics,
     )
 }

--- a/feature-ui-start-exam/build.gradle.kts
+++ b/feature-ui-start-exam/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+import DependencyHandler.Extensions.implementations
+
+plugins {
+    id(ConventionEnum.AndroidLibrary)
+    id(ConventionEnum.AndroidLibraryCompose)
+    id(ConventionEnum.AndroidHilt)
+}
+
+android {
+    namespace = "team.duckie.app.android.feature.ui.start.exam"
+}
+
+dependencies {
+    implementations(
+        platform(libs.firebase.bom),
+        projects.di,
+        projects.domain,
+        projects.utilUi,
+        projects.utilKotlin,
+        projects.utilCompose,
+        projects.sharedUiCompose,
+        libs.orbit.viewmodel,
+        libs.orbit.compose,
+        libs.quack.ui.components,
+        libs.compose.lifecycle.runtime,
+        libs.firebase.crashlytics,
+    )
+}

--- a/feature-ui-start-exam/src/main/AndroidManifest.xml
+++ b/feature-ui-start-exam/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Designed and developed by Duckie Team, 2022
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".screen.StartExamActivity"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
@@ -9,7 +9,6 @@ package team.duckie.app.android.feature.ui.start.exam.screen
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import team.duckie.app.android.shared.ui.compose.DuckieTodoScreen
 import team.duckie.app.android.util.ui.BaseActivity
 import team.duckie.quackquack.ui.theme.QuackTheme
 
@@ -19,7 +18,7 @@ class StartExamActivity : BaseActivity() {
 
         setContent {
             QuackTheme {
-                DuckieTodoScreen()
+                StartExamScreen()
             }
         }
     }

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.screen
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import team.duckie.app.android.shared.ui.compose.DuckieTodoScreen
+import team.duckie.app.android.util.ui.BaseActivity
+import team.duckie.quackquack.ui.theme.QuackTheme
+
+class StartExamActivity : BaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            QuackTheme {
+                DuckieTodoScreen()
+            }
+        }
+    }
+}

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
@@ -9,16 +9,53 @@ package team.duckie.app.android.feature.ui.start.exam.screen
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.ui.Modifier
+import dagger.hilt.android.AndroidEntryPoint
+import org.orbitmvi.orbit.viewmodel.observe
+import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamSideEffect
+import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamViewModel
 import team.duckie.app.android.util.ui.BaseActivity
+import team.duckie.app.android.util.ui.finishWithAnimation
+import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
 
+@AndroidEntryPoint
 class StartExamActivity : BaseActivity() {
+    private val viewModel: StartExamViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
             QuackTheme {
-                StartExamScreen()
+                StartExamScreen(
+                    Modifier
+                        .fillMaxSize()
+                        .background(color = QuackColor.White.composeColor)
+                        .systemBarsPadding(),
+                )
+            }
+        }
+
+        viewModel.observe(
+            lifecycleOwner = this@StartExamActivity,
+            sideEffect = ::handleSideEffect,
+        )
+    }
+
+    private fun handleSideEffect(sideEffect: StartExamSideEffect) {
+        when (sideEffect) {
+            is StartExamSideEffect.FinishStartExam -> {
+                if (sideEffect.certified) {
+                    // TODO(riflockle7): 시험 풀기 화면으로 이동 필요 및 필요 extra 확인 필요
+                    finishWithAnimation()
+                } else {
+                    finishWithAnimation()
+                }
             }
         }
     }

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamActivity.kt
@@ -8,6 +8,7 @@
 package team.duckie.app.android.feature.ui.start.exam.screen
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -52,8 +53,10 @@ class StartExamActivity : BaseActivity() {
             is StartExamSideEffect.FinishStartExam -> {
                 if (sideEffect.certified) {
                     // TODO(riflockle7): 시험 풀기 화면으로 이동 필요 및 필요 extra 확인 필요
+                    Log.i("riflockle7", "시험 풀기 화면으로 이동")
                     finishWithAnimation()
                 } else {
+                    Log.i("riflockle7", "화면 종료")
                     finishWithAnimation()
                 }
             }

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamScreen.kt
@@ -1,0 +1,157 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.screen
+
+import android.app.Activity
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import team.duckie.app.android.feature.ui.start.exam.R
+import team.duckie.app.android.shared.ui.compose.ImeSpacer
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
+import team.duckie.quackquack.ui.component.QuackHeadLine1
+import team.duckie.quackquack.ui.component.QuackLargeButton
+import team.duckie.quackquack.ui.component.QuackLargeButtonType
+import team.duckie.quackquack.ui.component.QuackTopAppBar
+import team.duckie.quackquack.ui.component.internal.QuackText
+import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.ui.textstyle.QuackTextStyle
+
+@Composable
+fun StartExamScreen() {
+    val activity = LocalContext.current as Activity
+
+    // TODO(riflockle7): 추후 ViewModel 연동 시 다른 값으로 바꾸어야 함
+    val certifyingStatement: String by remember {
+        mutableStateOf(activity.getString(R.string.certifing_statement_placeholder))
+    }
+    // TODO(riflockle7): 추후 ViewModel 연동 시 val 로 바꾸어야 함
+    var certifyingStatementText: String by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(QuackColor.White.composeColor)
+            .systemBarsPadding()
+    ) {
+        // 상단 탭바
+        QuackTopAppBar(
+            leadingIcon = QuackIcon.ArrowBack,
+            onLeadingIconClick = { activity.finish() }
+        )
+
+        // 제목
+        QuackHeadLine1(
+            modifier = Modifier.padding(
+                top = 16.dp,
+                start = 16.dp,
+                end = 16.dp,
+            ),
+            text = stringResource(id = R.string.title),
+        )
+
+        // 필적 확인 문구 TextField
+        StartExamTextField(
+            modifier = Modifier.padding(
+                top = 28.dp,
+                start = 16.dp,
+                end = 16.dp,
+            ),
+            text = certifyingStatementText,
+            onTextChanged = { certifyingStatementText = it },
+            placeholderText = certifyingStatement,
+        )
+
+        // 여백
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 시험시작 버튼
+        QuackLargeButton(
+            modifier = Modifier.padding(
+                vertical = 12.dp,
+                horizontal = 16.dp,
+            ),
+            type = QuackLargeButtonType.Fill,
+            text = stringResource(id = R.string.start_button),
+            enabled = certifyingStatement == certifyingStatementText
+        ) {
+            Log.i("riflockle7", "시험 시작 클릭")
+        }
+
+        ImeSpacer()
+    }
+}
+
+/**
+ * [시험 시작 화면][StartExamScreen]에서 활용하는 TextField
+ * 기존 [QuackGrayscaleTextField] 와 차이가 있다면, placeholder 가 계속 유지된다.
+ *
+ * // TODO(riflockle7): 추후 QuackQuack 라이브러리에서 해당 기능 제공 시 아래 코드 제거 및 대체 필요
+ */
+@Composable
+internal fun StartExamTextField(
+    modifier: Modifier = Modifier,
+    text: String,
+    alwaysPlaceholderVisible: Boolean = true,
+    placeholderText: String,
+    onTextChanged: (text: String) -> Unit,
+    imeAction: ImeAction = ImeAction.Done,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+) {
+    BasicTextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = QuackColor.Gray4.composeColor)
+            .padding(
+                vertical = 17.dp,
+                horizontal = 20.dp,
+            ),
+        value = text,
+        onValueChange = onTextChanged,
+        textStyle = QuackTextStyle.Body1.asComposeStyle(),
+        keyboardOptions = KeyboardOptions(imeAction = imeAction),
+        keyboardActions = keyboardActions,
+        singleLine = true,
+        cursorBrush = QuackColor.Black.toBrush(),
+        decorationBox = { textField ->
+            Box(propagateMinConstraints = true) {
+                // TODO(riflockle7): 추후 QuackTextFieldCommonBody1Placeholder 내용에 반영 필요
+                if (alwaysPlaceholderVisible || text.isEmpty()) {
+                    QuackText(
+                        text = placeholderText,
+                        style = QuackTextStyle.Body1.change(color = QuackColor.Gray2),
+                    )
+                }
+            }
+
+            Box(propagateMinConstraints = true) {
+                textField()
+            }
+        },
+    )
+}

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamScreen.kt
@@ -7,7 +7,6 @@
 
 package team.duckie.app.android.feature.ui.start.exam.screen
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,7 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -86,7 +84,6 @@ private fun StartExamLoadingScreen(modifier: Modifier, viewModel: StartExamViewM
  */
 @Composable
 internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewModel) {
-    val activity = LocalContext.current as Activity
     val state = viewModel.collectAsState().value as StartExamState.Input
 
     val certifyingStatement: String = remember(state.certifyingStatement) {
@@ -100,7 +97,7 @@ internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewMo
         // 상단 탭바
         QuackTopAppBar(
             leadingIcon = QuackIcon.ArrowBack,
-            onLeadingIconClick = { activity.finish() }
+            onLeadingIconClick = viewModel::finishStartExam,
         )
 
         // 제목

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamSideEffect.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamSideEffect.kt
@@ -1,0 +1,12 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.viewmodel
+
+internal sealed class StartExamSideEffect {
+    data class FinishStartExam(val certified: Boolean) : StartExamSideEffect()
+}

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamState.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamState.kt
@@ -1,0 +1,32 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.viewmodel
+
+import team.duckie.app.android.feature.ui.start.exam.screen.StartExamActivity
+
+sealed class StartExamState {
+    /** [StartExamActivity] 가 로딩 중임을 나타냅니다. */
+    object Loading : StartExamState()
+
+    /** [StartExamViewModel] 데이터를 잘 받았을 때의 상태를 나타냅니다. */
+    data class Input(
+        val examId: Int,
+        val certifyingStatement: String,
+        val certifyingStatementInputText: String = "",
+    ) : StartExamState() {
+        val isCertified: Boolean
+            get() = certifyingStatement == certifyingStatementInputText
+    }
+
+    /**
+     * [StartExamViewModel] 의 비즈니스 로직 처리중에 예외가 발생한 상태를 나타냅니다.
+     *
+     * @param exception 발생한 예외
+     */
+    class Error(val exception: Throwable) : StartExamState()
+}

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamViewModel.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamViewModel.kt
@@ -16,11 +16,13 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.util.kotlin.AllowMagicNumber
 import team.duckie.app.android.util.kotlin.DuckieClientLogicProblemException
 import team.duckie.app.android.util.ui.const.Extras
 import javax.inject.Inject
 
 @HiltViewModel
+@AllowMagicNumber
 internal class StartExamViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) : ContainerHost<StartExamState, StartExamSideEffect>, ViewModel() {

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamViewModel.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamViewModel.kt
@@ -1,0 +1,65 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.util.kotlin.DuckieClientLogicProblemException
+import team.duckie.app.android.util.ui.const.Extras
+import javax.inject.Inject
+
+@HiltViewModel
+internal class StartExamViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) : ContainerHost<StartExamState, StartExamSideEffect>, ViewModel() {
+    override val container = container<StartExamState, StartExamSideEffect>(StartExamState.Loading)
+
+    /** state 를 초기 설정한다. */
+    fun initState() {
+        val examId = savedStateHandle.getStateFlow(Extras.ExamId, -1).value
+        val certifyingStatement = savedStateHandle
+            .getStateFlow(Extras.CertifyingStatement, "").value
+
+        intent {
+            delay(2000L)
+
+            reduce {
+                if (examId == -1 || certifyingStatement == "") {
+                    StartExamState.Error(DuckieClientLogicProblemException(code = ""))
+                } else {
+                    StartExamState.Input(examId, certifyingStatement)
+                }
+            }
+        }
+    }
+
+    /** 필적 확인 문구를 입력한다. */
+    fun inputCertifyingStatement(text: String) = intent {
+        reduce {
+            (state as StartExamState.Input).copy(certifyingStatementInputText = text)
+        }
+    }
+
+    /** validate 를 체크한다. */
+    fun startExamValidate(): Boolean {
+        // TODO(riflockle7): 꼭 null 확인을 해주어야할까? 확인할 필요 없으면 위처럼 처리해도 괜찮을 듯
+        return (container.stateFlow.value as? StartExamState.Input)?.isCertified == true
+    }
+
+    /** 시험 시작 화면을 종료한다. */
+    fun finishStartExam() = intent {
+        postSideEffect(StartExamSideEffect.FinishStartExam(startExamValidate()))
+    }
+}

--- a/feature-ui-start-exam/src/main/res/values/strings.xml
+++ b/feature-ui-start-exam/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="title">시험 시작 전, 필적 확인 문구를\n정확히 입력해주세요.</string>
+    <string name="certifing_statement_placeholder">누칼협? 열심히 살지 말자</string>
+    <string name="start_button">시험시작</string>
+</resources>

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -19,6 +19,7 @@ android {
 }
 
 dependencies {
+    implementation(project(mapOf("path" to ":feature-ui-start-exam")))
     implementations(
         projects.di,
         projects.utilUi,

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 }
 
 dependencies {
-    implementation(project(mapOf("path" to ":feature-ui-create-problem")))
     implementations(
         projects.di,
         projects.utilUi,

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 }
 
 dependencies {
-    implementation(project(mapOf("path" to ":feature-ui-start-exam")))
     implementations(
         projects.di,
         projects.utilUi,

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/IntroActivity.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/IntroActivity.kt
@@ -25,8 +25,8 @@ import kotlinx.coroutines.flow.first
 import org.orbitmvi.orbit.viewmodel.observe
 import team.duckie.app.android.feature.datastore.PreferenceKey
 import team.duckie.app.android.feature.datastore.dataStore
+import team.duckie.app.android.feature.ui.home.screen.HomeActivity
 import team.duckie.app.android.feature.ui.onboard.OnboardActivity
-import team.duckie.app.android.feature.ui.start.exam.screen.StartExamActivity
 import team.duckie.app.android.presentation.screen.IntroScreen
 import team.duckie.app.android.presentation.viewmodel.IntroViewModel
 import team.duckie.app.android.presentation.viewmodel.sideeffect.IntroSideEffect
@@ -121,7 +121,7 @@ class IntroActivity : BaseActivity() {
 
     private fun launchHomeActivity() {
         // TODO(sungbin): 끝낼 때 별다른 메시지를 안하는게 맞을까?
-        changeActivityWithAnimation<StartExamActivity>()
+        changeActivityWithAnimation<HomeActivity>()
     }
 
     private fun launchHomeOrOnboardActivity(isOnboardFinish: Boolean) {

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/IntroActivity.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/IntroActivity.kt
@@ -25,8 +25,8 @@ import kotlinx.coroutines.flow.first
 import org.orbitmvi.orbit.viewmodel.observe
 import team.duckie.app.android.feature.datastore.PreferenceKey
 import team.duckie.app.android.feature.datastore.dataStore
-import team.duckie.app.android.feature.ui.home.screen.HomeActivity
 import team.duckie.app.android.feature.ui.onboard.OnboardActivity
+import team.duckie.app.android.feature.ui.start.exam.screen.StartExamActivity
 import team.duckie.app.android.presentation.screen.IntroScreen
 import team.duckie.app.android.presentation.viewmodel.IntroViewModel
 import team.duckie.app.android.presentation.viewmodel.sideeffect.IntroSideEffect
@@ -121,7 +121,7 @@ class IntroActivity : BaseActivity() {
 
     private fun launchHomeActivity() {
         // TODO(sungbin): 끝낼 때 별다른 메시지를 안하는게 맞을까?
-        changeActivityWithAnimation<HomeActivity>()
+        changeActivityWithAnimation<StartExamActivity>()
     }
 
     private fun launchHomeOrOnboardActivity(isOnboardFinish: Boolean) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,6 +47,7 @@ include(
     ":feature-ui-onboard",
     ":feature-ui-notification",
     ":feature-ui-home",
+    ":feature-ui-start-exam",
     ":feature-ui-solve-problem",
     ":feature-ui-create-problem",
     ":feature-ui-detail",

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/DuckieTodoScreen.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/DuckieTodoScreen.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.app.android.shared.ui.compose
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.component.QuackTitle1
 
@@ -25,7 +27,9 @@ import team.duckie.quackquack.ui.component.QuackTitle1
 @Composable
 fun DuckieTodoScreen() {
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(QuackColor.White.composeColor),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/util-ui/src/main/kotlin/team/duckie/app/android/util/ui/const/Extras.kt
+++ b/util-ui/src/main/kotlin/team/duckie/app/android/util/ui/const/Extras.kt
@@ -1,0 +1,14 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.util.ui.const
+
+/** Intent.Extra Key 값 모음 */
+object Extras {
+    const val ExamId = "ExtraExamId"
+    const val CertifyingStatement = "ExtraCertifyingStatement"
+}


### PR DESCRIPTION
1. 추후 화면의 백그라운드 색상을 설정했습니다 (흰색)
2. 모듈 추가를 해보면서 시험 시작 화면을 추가했습니다
3. Intent.Extra Key 값을 모아두는 곳을 만들었습니다.
    해당 파일 위치가 괜찮은지, 관리 방식은 괜찮은지도 comment 부탁드립니다
4. placeholder 가 안 없어지는 TextField 가 필요하여 따로 만들었습니다.
    해당 파일은 추후 꽥꽥으로 들어가야 할 것 같습니다.

---

1. 바로 시험 시작 화면을 향하면 오류가 발생합니다.
    ExamId 와 CertifyingStatement 를 extra 로 넘겨주어야 동작합니다.
    ```kotlin
    // ex
    
    .apply {
        putExtra(Extras.ExamId, 3)
        putExtra(Extras.CertifyingStatement, "abcd")
    }
    ```
2. 추후 extras 를 넣어야 할 경우를 대비한 startActivity 유틸 함수도 있으면 좋을 것 같다는 생각을 했습니다.
    `startActivityForResult` 와 requestCode, resultCode 를 생각하면, 그냥 자체 구현이 좋을지도 생각이 드네요