### PR TITLE
문제 만들기 연결 로직 작성 & 문제 만들기 화면에 수정모드 적용 및 초기 에러 연동

### DIFF
--- a/di/src/main/kotlin/team/duckie/app/android/di/usecase/exam/ExamUseCaseModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/usecase/exam/ExamUseCaseModule.kt
@@ -13,6 +13,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import team.duckie.app.android.domain.exam.repository.ExamRepository
 import team.duckie.app.android.domain.exam.usecase.GetExamThumbnailUseCase
+import team.duckie.app.android.domain.exam.usecase.GetExamUseCase
 import team.duckie.app.android.domain.exam.usecase.MakeExamInstanceSubmitUseCase
 import team.duckie.app.android.domain.exam.usecase.MakeExamInstanceUseCase
 import team.duckie.app.android.domain.exam.usecase.MakeExamUseCase
@@ -23,6 +24,11 @@ object ExamUseCaseModule {
     @Provides
     fun provideMakeExamUseCase(repository: ExamRepository): MakeExamUseCase {
         return MakeExamUseCase(repository)
+    }
+
+    @Provides
+    fun provideGetExamUseCase(repository: ExamRepository): GetExamUseCase {
+        return GetExamUseCase(repository)
     }
 
     @Provides

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/GetExamUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/usecase/GetExamUseCase.kt
@@ -1,0 +1,23 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.exam.usecase
+
+import androidx.compose.runtime.Immutable
+import javax.inject.Inject
+import team.duckie.app.android.domain.exam.repository.ExamRepository
+import team.duckie.app.android.util.kotlin.OutOfDateApi
+
+@Immutable
+class GetExamUseCase @Inject constructor(
+    private val examRepository: ExamRepository,
+) {
+    @OptIn(OutOfDateApi::class)
+    suspend operator fun invoke(id: Int) = runCatching {
+        examRepository.getExam(id)
+    }
+}

--- a/feature-ui-create-problem/build.gradle.kts
+++ b/feature-ui-create-problem/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
         projects.utilCompose,
         projects.featurePhotopicker,
         projects.sharedUiCompose,
+        projects.utilExceptionHandling,
         libs.orbit.viewmodel,
         libs.orbit.compose,
         libs.ktx.lifecycle.runtime,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -29,7 +29,9 @@ import kotlinx.coroutines.flow.onEach
 import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.feature.ui.create.problem.screen.AdditionalInformationScreen
 import team.duckie.app.android.feature.ui.create.problem.screen.CreateProblemScreen
+import team.duckie.app.android.feature.ui.create.problem.screen.ErrorScreen
 import team.duckie.app.android.feature.ui.create.problem.screen.ExamInformationScreen
+import team.duckie.app.android.feature.ui.create.problem.screen.LoadingScreen
 import team.duckie.app.android.feature.ui.create.problem.screen.SearchTagScreen
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.sideeffect.CreateProblemSideEffect
@@ -52,9 +54,10 @@ class CreateProblemActivity : BaseActivity() {
 
             BackHandler {
                 when (createProblemStep) {
-                    CreateProblemStep.ExamInformation -> finishWithAnimation()
-                    CreateProblemStep.Search -> viewModel.navigateStep(CreateProblemStep.ExamInformation)
-                    else -> viewModel.navigateStep(createProblemStep.minus(1))
+                    CreateProblemStep.CreateProblem, CreateProblemStep.AdditionalInformation ->
+                        viewModel.navigateStep(createProblemStep.minus(1))
+                    CreateProblemStep.Loading, CreateProblemStep.Error -> finishWithAnimation()
+                    else -> {}
                 }
             }
 
@@ -74,6 +77,11 @@ class CreateProblemActivity : BaseActivity() {
                     targetState = createProblemStep,
                 ) { step: CreateProblemStep ->
                     when (step) {
+                        CreateProblemStep.Loading -> LoadingScreen(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .statusBarsPadding(),
+                        )
                         CreateProblemStep.ExamInformation -> ExamInformationScreen(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -90,6 +98,11 @@ class CreateProblemActivity : BaseActivity() {
                                 .statusBarsPadding(),
                         )
                         CreateProblemStep.AdditionalInformation -> AdditionalInformationScreen(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .statusBarsPadding(),
+                        )
+                        CreateProblemStep.Error -> ErrorScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .statusBarsPadding(),

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -62,6 +62,8 @@ class CreateProblemActivity : BaseActivity() {
                 viewModel.container.sideEffectFlow
                     .onEach(::handleSideEffect)
                     .launchIn(this)
+
+                viewModel.initState()
             }
 
             QuackTheme {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ErrorScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ErrorScreen.kt
@@ -9,19 +9,14 @@ package team.duckie.app.android.feature.ui.create.problem.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.feature.ui.create.problem.R
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
 import team.duckie.app.android.util.compose.activityViewModel
-import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackTitle1
 
 @Composable

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ErrorScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ErrorScreen.kt
@@ -1,0 +1,48 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.create.problem.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.feature.ui.create.problem.R
+import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
+import team.duckie.app.android.util.compose.activityViewModel
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackTitle1
+
+@Composable
+internal fun ErrorScreen(
+    viewModel: CreateProblemViewModel = activityViewModel(),
+    modifier: Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        val isEditMode = viewModel.collectAsState().value.isEditMode
+        QuackTitle1(
+            text = "에러입니다\n\n$viewModel\n\n${
+                if (isEditMode) {
+                    stringResource(id = R.string.get_exam_authorized_error)
+                } else {
+                    ""
+                }
+            }",
+        )
+    }
+}

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/LoadingScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/LoadingScreen.kt
@@ -1,0 +1,43 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.create.problem.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
+import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
+import team.duckie.app.android.util.compose.activityViewModel
+import team.duckie.quackquack.ui.color.QuackColor
+
+@Composable
+internal fun LoadingScreen(
+    viewModel: CreateProblemViewModel = activityViewModel(),
+    modifier: Modifier,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(Unit) {
+        coroutineScope.launch { viewModel.initState() }
+    }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        // TODO(riflockle7): 추후 DuckieCircularProgressIndicator.kt 와 합치거나 꽥꽥 컴포넌트로 필요
+        CircularProgressIndicator(
+            color = QuackColor.DuckieOrange.composeColor,
+        )
+    }
+}

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -140,7 +140,7 @@ internal class CreateProblemViewModel @Inject constructor(
                                     isSubTagsAdded = exam.subTags.isNotEmpty(),
                                     searchSubTags = state.additionalInfo.searchSubTags.copy(
                                         results = exam.subTags,
-                                    )
+                                    ),
                                 ),
                             )
                         }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -18,7 +18,7 @@ import team.duckie.app.android.domain.exam.model.getDefaultAnswer
 import team.duckie.app.android.domain.tag.model.Tag
 
 internal data class CreateProblemState(
-    val createProblemStep: CreateProblemStep = CreateProblemStep.AdditionalInformation,
+    val createProblemStep: CreateProblemStep = CreateProblemStep.ExamInformation,
     val examInformation: ExamInformation = ExamInformation(),
     val createProblem: CreateProblem = CreateProblem(),
     val additionalInfo: AdditionInfo = AdditionInfo(),

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -18,12 +18,12 @@ import team.duckie.app.android.domain.exam.model.getDefaultAnswer
 import team.duckie.app.android.domain.tag.model.Tag
 
 internal data class CreateProblemState(
-    val createProblemStep: CreateProblemStep = CreateProblemStep.ExamInformation,
+    val isEditMode: Boolean = false,
+    val createProblemStep: CreateProblemStep = CreateProblemStep.Loading,
     val examInformation: ExamInformation = ExamInformation(),
     val createProblem: CreateProblem = CreateProblem(),
     val additionalInfo: AdditionInfo = AdditionInfo(),
     val findResultType: FindResultType = FindResultType.MainTag,
-    val error: Error? = null,
     val photoState: CreateProblemPhotoState? = null,
     val defaultThumbnail: String = "",
 ) {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemStep.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemStep.kt
@@ -16,7 +16,7 @@ enum class CreateProblemStep(private val index: Int) {
     CreateProblem(2),
     AdditionalInformation(3),
     Search(4),
-    Error(5)
+    Error(5),
     ;
 
     operator fun minus(previous: Int): CreateProblemStep {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemStep.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemStep.kt
@@ -11,10 +11,12 @@ import team.duckie.app.android.util.kotlin.AllowMagicNumber
 
 @AllowMagicNumber
 enum class CreateProblemStep(private val index: Int) {
-    Search(0),
+    Loading(0),
     ExamInformation(1),
     CreateProblem(2),
     AdditionalInformation(3),
+    Search(4),
+    Error(5)
     ;
 
     operator fun minus(previous: Int): CreateProblemStep {

--- a/feature-ui-create-problem/src/main/res/values/strings.xml
+++ b/feature-ui-create-problem/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
 <resources>
     <string name="create_problem_permission_toast_message">접근 권한이 없습니다.\n앱 설정에서 갤러리 권한을 허용해 주세요.</string>
     <string name="network_error">일시적인 오류가 발생했습니다. 관리자에게 문의해주세요.</string>
+    <string name="get_exam_authorized_error">해당 시험을 수정할 수 있는 권한이 없습니다.</string>
+    <string name="get_exam_not_found_error">찾을 수 없는 시험입니다.</string>
 
     <string name="create_problem">"문제 만들기"</string>
     <string name="cancel">취소</string>

--- a/feature-ui-home/build.gradle.kts
+++ b/feature-ui-home/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
         projects.utilCompose,
         projects.sharedUiCompose,
         projects.featureUiDetail,
+        projects.featureUiCreateProblem,
         libs.orbit.viewmodel,
         libs.orbit.compose,
         libs.quack.ui.components,

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -41,6 +41,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.domain.exam.model.Exam
+import team.duckie.app.android.feature.ui.create.problem.CreateProblemActivity
 import team.duckie.app.android.feature.ui.detail.DetailActivity
 import team.duckie.app.android.feature.ui.home.R
 import team.duckie.app.android.feature.ui.home.component.HomeTopAppBar
@@ -93,6 +94,13 @@ internal fun HomeRecommendScreen(
                     vm.changedHomeScreen(HomeStep.toStep(step))
                 },
                 onClickedEdit = {
+                    // TODO(riflockle7): 구현 스펙을 알 수 없어 임시로 처리한 코드. 추후 sideEffect 로 처리 필요
+                    activity.startActivityWithAnimation<CreateProblemActivity>(
+                        intentBuilder = {
+                            putExtra(Extras.ExamId, 1)
+                            putExtra(Extras.AppUserId, 2)
+                        }
+                    )
                     // TODO("limsaehyun"): 수정 페이지로 이동 필요
                 },
             )

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -99,7 +99,7 @@ internal fun HomeRecommendScreen(
                         intentBuilder = {
                             putExtra(Extras.ExamId, 1)
                             putExtra(Extras.AppUserId, 2)
-                        }
+                        },
                     )
                     // TODO("limsaehyun"): 수정 페이지로 이동 필요
                 },


### PR DESCRIPTION
- 문제 만들기 화면 연결 로직을 초기 작성하였습니다.
- 문제 만들기 화면에 수정모드를 적용하였습니다.
  - 로딩화면, 에러 화면을 새로 만들었습니다. (이에 따른 나열 순서 및 숫자 값을 변경했습니다)
  - ViewModel 에 초기화 로직(`initState`), CreateProblemState 에 `isEditMode` 값을 추가했습니다.
  - 에러 핸들링 코드를 작성했습니다.

---

홈 화면 작업과 겹쳐 conflict 가 우려됩니다.
해당 내용은 TODO 로 명세해 놓았습니다. (feat @limsaehyun)

추후 400, 401, 404 와 같은 status 분류가 필요합니다.
이에 따라 `responseCatching()` 복원 및 추가 작업이 필요합니다.
이와 관련된 작업은 다음 PR 에서 진행하겠습니다.