### PR TITLE
ExceptionBody 에 statusCode 값 추가 & 에러 핸들링 처리 개선

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
@@ -60,7 +60,6 @@ private object AuthorizationHeaderClient {
     private const val ClientName = "android"
 
     operator fun invoke() = HttpClient(engineFactory = CIO) {
-        expectSuccess = true
         engine {
             endpoint {
                 connectTimeout = MaxTimeoutMillis

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/model/ExceptionBody.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/model/ExceptionBody.kt
@@ -27,12 +27,11 @@ internal data class ExceptionBody(
     val errors: List<String?>? = null,
 )
 
-internal fun ExceptionBody.throwing(throwable: Throwable): Nothing {
+internal fun ExceptionBody.throwing(): Nothing {
     duckieResponseException(
         statusCode = statusCode,
         serverMessage = message,
         code = code ?: duckieResponseFieldNpe("code"),
         errors = errors?.filterNotNull(),
-        throwable = throwable,
     )
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/model/ExceptionBody.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/model/ExceptionBody.kt
@@ -7,11 +7,15 @@
 
 package team.duckie.app.android.data._exception.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import team.duckie.app.android.util.kotlin.duckieResponseException
 import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 
 internal data class ExceptionBody(
+    @JsonIgnore
+    val statusCode: Int? = null,
+
     @field:JsonProperty("code")
     val code: String? = null,
 
@@ -24,6 +28,7 @@ internal data class ExceptionBody(
 
 internal fun ExceptionBody.throwing(throwable: Throwable): Nothing {
     duckieResponseException(
+        statusCode = statusCode ?: duckieResponseFieldNpe("statusCode"),
         message = message,
         code = code ?: duckieResponseFieldNpe("code"),
         errors = errors?.filterNotNull(),

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/model/ExceptionBody.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/model/ExceptionBody.kt
@@ -9,12 +9,13 @@ package team.duckie.app.android.data._exception.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
+import team.duckie.app.android.util.kotlin.DuckieStatusCode
 import team.duckie.app.android.util.kotlin.duckieResponseException
 import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 
 internal data class ExceptionBody(
     @JsonIgnore
-    val statusCode: Int? = null,
+    val statusCode: DuckieStatusCode = DuckieStatusCode.Unknown,
 
     @field:JsonProperty("code")
     val code: String? = null,
@@ -28,8 +29,8 @@ internal data class ExceptionBody(
 
 internal fun ExceptionBody.throwing(throwable: Throwable): Nothing {
     duckieResponseException(
-        statusCode = statusCode ?: duckieResponseFieldNpe("statusCode"),
-        message = message,
+        statusCode = statusCode,
+        serverMessage = message,
         code = code ?: duckieResponseFieldNpe("code"),
         errors = errors?.filterNotNull(),
         throwable = throwable,

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
@@ -34,6 +34,7 @@ internal suspend inline fun <reified DataModel, DomainModel> responseCatching(
 // TODO(riflockle7): statusCode 에 따라 에러 핸들링 또는 데이터 반환하도록 해주어야 함
 @Suppress("TooGenericExceptionCaught")
 internal inline fun <DomainModel> responseCatching(
+    statusCode: Int,
     response: String,
     parse: (body: String) -> DomainModel,
 ): DomainModel {
@@ -43,6 +44,7 @@ internal inline fun <DomainModel> responseCatching(
         // TODO(riflockle7): 개발 도중 에러를 확인하기 위해 추가한 코드. 추후 논의를 통해 제거 필요
         throwable.printStackTrace()
         val errorBody = jsonMapper.readValue(response, ExceptionBody::class.java)
+            .copy(statusCode = statusCode.toDuckieStatusCode())
         errorBody.throwing(throwable = throwable)
     }
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
@@ -38,13 +38,12 @@ internal inline fun <DomainModel> responseCatching(
     response: String,
     parse: (body: String) -> DomainModel,
 ): DomainModel {
-    return try {
-        parse(response)
-    } catch (throwable: Throwable) {
-        // TODO(riflockle7): 개발 도중 에러를 확인하기 위해 추가한 코드. 추후 논의를 통해 제거 필요
-        throwable.printStackTrace()
+    if(statusCode < 400) {
+        return parse(response)
+    } else {
         val errorBody = jsonMapper.readValue(response, ExceptionBody::class.java)
             .copy(statusCode = statusCode.toDuckieStatusCode())
-        errorBody.throwing(throwable = throwable)
+        // TODO(riflockle7): 의미없는 Throwable 생성인 듯 하여 제거 고민
+        errorBody.throwing(throwable = Throwable("response status error ${errorBody.statusCode}"))
     }
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
@@ -12,6 +12,7 @@ import io.ktor.client.statement.HttpResponse
 import team.duckie.app.android.data._exception.model.ExceptionBody
 import team.duckie.app.android.data._exception.model.throwing
 import team.duckie.app.android.data._util.jsonMapper
+import team.duckie.app.android.util.kotlin.toDuckieStatusCode
 
 @Suppress("TooGenericExceptionCaught")
 internal suspend inline fun <reified DataModel, DomainModel> responseCatching(
@@ -23,7 +24,8 @@ internal suspend inline fun <reified DataModel, DomainModel> responseCatching(
         return parse(body)
     } else {
         val statusCode = response.status.value
-        val errorBody: ExceptionBody = response.body<ExceptionBody>().copy(statusCode = statusCode)
+        val errorBody: ExceptionBody = response.body<ExceptionBody>()
+            .copy(statusCode = statusCode.toDuckieStatusCode())
         // TODO(riflockle7): 의미없는 Throwable 생성인 듯 하여 제거 고민
         errorBody.throwing(throwable = Throwable("response status error ${errorBody.statusCode}"))
     }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
@@ -12,6 +12,7 @@ import io.ktor.client.statement.HttpResponse
 import team.duckie.app.android.data._exception.model.ExceptionBody
 import team.duckie.app.android.data._exception.model.throwing
 import team.duckie.app.android.data._util.jsonMapper
+import team.duckie.app.android.util.kotlin.ApiErrorThreshold
 import team.duckie.app.android.util.kotlin.toDuckieStatusCode
 
 @Suppress("TooGenericExceptionCaught")
@@ -19,7 +20,7 @@ internal suspend inline fun <reified DataModel, DomainModel> responseCatching(
     response: HttpResponse,
     parse: (body: DataModel) -> DomainModel,
 ): DomainModel {
-    if(response.status.value < 400) {
+    if (response.status.value < ApiErrorThreshold) {
         val body: DataModel = response.body()
         return parse(body)
     } else {
@@ -37,7 +38,7 @@ internal inline fun <DomainModel> responseCatching(
     response: String,
     parse: (body: String) -> DomainModel,
 ): DomainModel {
-    if(statusCode < 400) {
+    if (statusCode < ApiErrorThreshold) {
         return parse(response)
     } else {
         jsonMapper.readValue(response, ExceptionBody::class.java)

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
@@ -24,10 +24,9 @@ internal suspend inline fun <reified DataModel, DomainModel> responseCatching(
         return parse(body)
     } else {
         val statusCode = response.status.value
-        val errorBody: ExceptionBody = response.body<ExceptionBody>()
+        response.body<ExceptionBody>()
             .copy(statusCode = statusCode.toDuckieStatusCode())
-        // TODO(riflockle7): 의미없는 Throwable 생성인 듯 하여 제거 고민
-        errorBody.throwing(throwable = Throwable("response status error ${errorBody.statusCode}"))
+            .throwing()
     }
 }
 
@@ -41,9 +40,8 @@ internal inline fun <DomainModel> responseCatching(
     if(statusCode < 400) {
         return parse(response)
     } else {
-        val errorBody = jsonMapper.readValue(response, ExceptionBody::class.java)
+        jsonMapper.readValue(response, ExceptionBody::class.java)
             .copy(statusCode = statusCode.toDuckieStatusCode())
-        // TODO(riflockle7): 의미없는 Throwable 생성인 듯 하여 제거 고민
-        errorBody.throwing(throwable = Throwable("response status error ${errorBody.statusCode}"))
+            .throwing()
     }
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_exception/util/responseCatching.kt
@@ -9,49 +9,35 @@ package team.duckie.app.android.data._exception.util
 
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
+import team.duckie.app.android.data._exception.model.ExceptionBody
+import team.duckie.app.android.data._exception.model.throwing
+import team.duckie.app.android.data._util.jsonMapper
 
-// FIXME(sungbin): 역직렬화 로직이 잘못됨
-/**
- * Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException:
- * Unrecognized field "isNewUser" (class team.duckie.app.android.data._exception.model.ExceptionBody),
- * not marked as ignorable (3 known properties: "errors", "code", "message"])
- * at [Source: (InputStreamReader); line: 1, column: 479] (through reference chain: team.duckie.app.android.data._exception.model.ExceptionBody["isNewUser"])
- */
 @Suppress("TooGenericExceptionCaught")
 internal suspend inline fun <reified DataModel, DomainModel> responseCatching(
     response: HttpResponse,
     parse: (body: DataModel) -> DomainModel,
 ): DomainModel {
-    /*return try {
+    return try {
         val body: DataModel = response.body()
         parse(body)
     } catch (throwable: Throwable) {
         val errorBody: ExceptionBody = response.body()
         errorBody.throwing(throwable = throwable)
-    }*/
-    val body: DataModel = response.body()
-    return parse(body)
+    }
 }
 
-// FIXME(sungbin): 역직렬화 로직이 잘못됨
-/**
- * Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException:
- * Unrecognized field "isNewUser" (class team.duckie.app.android.data._exception.model.ExceptionBody),
- * not marked as ignorable (3 known properties: "errors", "code", "message"])
- * at [Source: (InputStreamReader); line: 1, column: 479] (through reference chain: team.duckie.app.android.data._exception.model.ExceptionBody["isNewUser"])
- */
 @Suppress("TooGenericExceptionCaught")
 internal inline fun <DomainModel> responseCatching(
     response: String,
     parse: (body: String) -> DomainModel,
 ): DomainModel {
-    /*return try {
+    return try {
         parse(response)
     } catch (throwable: Throwable) {
         // TODO(riflockle7): 개발 도중 에러를 확인하기 위해 추가한 코드. 추후 논의를 통해 제거 필요
         throwable.printStackTrace()
         val errorBody = jsonMapper.readValue(response, ExceptionBody::class.java)
         errorBody.throwing(throwable = throwable)
-    }*/
-    return parse(response)
+    }
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/category/repository/CategoryRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/category/repository/CategoryRepositoryImpl.kt
@@ -28,7 +28,7 @@ class CategoryRepositoryImpl @Inject constructor() : CategoryRepository {
             url("/categories")
             parameter("withPopularTags", withPopularTags)
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json: Map<String, List<CategoryData>> = body.toJsonMap()
             json["categories"]?.fastMap(CategoryData::toDomain) ?: duckieResponseFieldNpe("categories")
         }

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
@@ -49,9 +49,7 @@ class ExamRepositoryImpl @Inject constructor() : ExamRepository {
         val response = client.get {
             url("/exams/$id")
         }
-        return responseCatching(response.bodyAsText()) { body ->
-            body.toJsonObject<ExamData>().toDomain()
-        }
+        return responseCatching(response, ExamData::toDomain)
     }
 
     @OutOfDateApi

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/repository/ExamRepositoryImpl.kt
@@ -38,7 +38,7 @@ class ExamRepositoryImpl @Inject constructor() : ExamRepository {
             url("/exams")
             setBody(exam.toData())
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()
             json["success"]?.toBoolean() ?: duckieResponseFieldNpe("success")
         }
@@ -58,7 +58,7 @@ class ExamRepositoryImpl @Inject constructor() : ExamRepository {
             url("/exams/thumbnail")
             setBody(examThumbnailBody.toData())
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()
             json["url"] ?: duckieResponseFieldNpe("url")
         }
@@ -70,7 +70,7 @@ class ExamRepositoryImpl @Inject constructor() : ExamRepository {
             url("/exam-instance")
             setBody(examInstanceBody.toData())
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()
             json["success"]?.toBoolean() ?: duckieResponseFieldNpe("success")
         }
@@ -85,7 +85,7 @@ class ExamRepositoryImpl @Inject constructor() : ExamRepository {
             url("/exam-instance/$id/submit")
             setBody(examInstanceSubmitBody.toData())
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             body.toJsonObject<ExamInstanceSubmitData>().toDomain()
         }
     }

--- a/data/src/main/kotlin/team/duckie/app/android/data/follow/repository/FollowsRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/follow/repository/FollowsRepositoryImpl.kt
@@ -25,7 +25,7 @@ class FollowsRepositoryImpl @Inject constructor() : FollowsRepository {
         val response = client.post("/follows") {
             setBody(followsBody.toData())
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()
             json["success"]?.toBoolean() ?: duckieResponseFieldNpe("success")
         }
@@ -35,7 +35,7 @@ class FollowsRepositoryImpl @Inject constructor() : FollowsRepository {
         val response = client.delete("/follows") {
             setBody(followsBody.toData())
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()
             json["success"]?.toBoolean() ?: duckieResponseFieldNpe("success")
         }

--- a/data/src/main/kotlin/team/duckie/app/android/data/recommendation/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/recommendation/repository/RecommendationRepositoryImpl.kt
@@ -29,7 +29,7 @@ class RecommendationRepositoryImpl : RecommendationRepository {
             url("/recommendations")
         }
 
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             @Suppress("UNUSED_VARIABLE")
             val recommendations = body.toJsonObject<RecommendationData>().toDomain().recommendations
             RecommendationPagingSource()

--- a/data/src/main/kotlin/team/duckie/app/android/data/search/repository/SearchRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/search/repository/SearchRepositoryImpl.kt
@@ -24,7 +24,7 @@ class SearchRepositoryImpl @Inject constructor() : SearchRepository {
         val response = client.get {
             url("/search")
         }
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             body.toJsonObject<SearchData>().toDomain()
         }
     }

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/repository/UserRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/repository/UserRepositoryImpl.kt
@@ -65,7 +65,7 @@ class UserRepositoryImpl @Inject constructor() : UserRepository {
     override suspend fun nicknameValidateCheck(nickname: String): Boolean {
         val response = client.get("/users/$nickname/duplicate-check")
 
-        return responseCatching(response.bodyAsText()) { body ->
+        return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()
             json["success"]?.toBoolean() ?: duckieResponseFieldNpe("success")
         }

--- a/data/src/test/kotlin/team/duckie/app/android/data/ExceptionTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/ExceptionTest.kt
@@ -11,6 +11,7 @@ package team.duckie.app.android.data
 
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -27,19 +28,22 @@ import team.duckie.app.android.data.user.mapper.toDomain
 import team.duckie.app.android.data.user.model.UserResponse
 import team.duckie.app.android.data.util.buildMockHttpClient
 import team.duckie.app.android.util.kotlin.DuckieResponseException
+import team.duckie.app.android.util.kotlin.DuckieStatusCode
 
-@Ignore(value = "responseCatching is TODO")
+@Ignore("statusCode 400 이상의 dummy HttpResponse 만들기 전까지는 비활성화")
 class ExceptionTest {
     private val exception = DuckieResponseException(
+        statusCode = DuckieStatusCode.Unknown,
         code = "1000",
-        message = "error",
+        serverMessage = "error",
         errors = listOf("awesome-error"),
         throwable = Throwable("ExceptionTest"),
     )
     private val exceptionContent = jsonMapper.writeValueAsString(
         ExceptionBody(
+            statusCode = DuckieStatusCode.BadRequest,
             code = exception.code,
-            message = exception.originalMessage,
+            message = "error",
             errors = exception.errors,
         ),
     )
@@ -58,6 +62,7 @@ class ExceptionTest {
             .isFailure()
             .run {
                 with(subject as DuckieResponseException) {
+                    get { statusCode } isEqualTo exception.statusCode
                     get { code } isEqualTo exception.code
                     get { message } isEqualTo exception.message
                     get { errors } isEqualTo exception.errors
@@ -77,6 +82,7 @@ class ExceptionTest {
             .isFailure()
             .run {
                 with(subject as DuckieResponseException) {
+                    get { statusCode } isEqualTo exception.statusCode
                     get { code } isEqualTo exception.code
                     get { message } isEqualTo exception.message
                     get { errors } isEqualTo exception.errors

--- a/data/src/test/kotlin/team/duckie/app/android/data/ExceptionTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/ExceptionTest.kt
@@ -11,7 +11,6 @@ package team.duckie.app.android.data
 
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -37,7 +36,6 @@ class ExceptionTest {
         code = "1000",
         serverMessage = "error",
         errors = listOf("awesome-error"),
-        throwable = Throwable("ExceptionTest"),
     )
     private val exceptionContent = jsonMapper.writeValueAsString(
         ExceptionBody(
@@ -75,7 +73,7 @@ class ExceptionTest {
         val response = client.get("")
 
         expectCatching {
-            responseCatching(response.bodyAsText()) { body ->
+            responseCatching(response.status.value, response.bodyAsText()) { body ->
                 body.toStringJsonMap()["hi"]
             }
         }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -65,8 +65,6 @@ class CreateProblemActivity : BaseActivity() {
                 viewModel.container.sideEffectFlow
                     .onEach(::handleSideEffect)
                     .launchIn(this)
-
-                viewModel.initState()
             }
 
             QuackTheme {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -153,13 +153,14 @@ internal class CreateProblemViewModel @Inject constructor(
                         if (
                             it is DuckieResponseException &&
                             it.statusCode == DuckieStatusCode.UnAuthorized
-                        )
+                        ) {
                             reduce {
                                 state.copy(
                                     createProblemStep = CreateProblemStep.Error,
                                     isEditMode = true,
                                 )
                             }
+                        }
 
                         postSideEffect(CreateProblemSideEffect.ReportError(it))
                     }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -60,6 +60,8 @@ import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateP
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateProblemStep
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.FindResultType
 import team.duckie.app.android.util.android.image.MediaUtil
+import team.duckie.app.android.util.kotlin.DuckieResponseException
+import team.duckie.app.android.util.kotlin.DuckieStatusCode
 import team.duckie.app.android.util.kotlin.OutOfDateApi
 import team.duckie.app.android.util.kotlin.copy
 import team.duckie.app.android.util.kotlin.duckieClientLogicProblemException
@@ -148,12 +150,17 @@ internal class CreateProblemViewModel @Inject constructor(
                 }
                 .onFailure {
                     intent {
-                        reduce {
-                            state.copy(
-                                createProblemStep = CreateProblemStep.Error,
-                                isEditMode = true,
-                            )
-                        }
+                        if (
+                            it is DuckieResponseException &&
+                            it.statusCode == DuckieStatusCode.UnAuthorized
+                        )
+                            reduce {
+                                state.copy(
+                                    createProblemStep = CreateProblemStep.Error,
+                                    isEditMode = true,
+                                )
+                            }
+
                         postSideEffect(CreateProblemSideEffect.ReportError(it))
                     }
                 }

--- a/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/exception.kt
+++ b/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/exception.kt
@@ -46,14 +46,12 @@ fun Int.toDuckieStatusCode(): DuckieStatusCode = when (this) {
  * @param serverMessage 예외 메시지. 선택으로 값을 받습니다.
  * @param code 예외 코드. 필수로 값을 받습니다.
  * @param errors 발생한 에러 목록. 선택으로 값을 받습니다
- * @param throwable 실제로 앱 내에서 발생한 throwable 원본
  */
 class DuckieResponseException(
     serverMessage: String? = null,
     val statusCode: DuckieStatusCode,
     val code: String,
     val errors: List<String>? = null,
-    val throwable: Throwable,
 ) : DuckieException(code) {
     override val message = "DuckieResponseException: $code".runIf(serverMessage != null) { plus(" - $serverMessage") }
     override fun toString(): String {
@@ -66,14 +64,12 @@ fun duckieResponseException(
     serverMessage: String? = null,
     code: String,
     errors: List<String>? = null,
-    throwable: Throwable,
 ): Nothing {
     throw DuckieResponseException(
         statusCode = statusCode,
         serverMessage = serverMessage,
         code = code,
         errors = errors,
-        throwable = throwable,
     )
 }
 

--- a/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/exception.kt
+++ b/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/exception.kt
@@ -18,37 +18,59 @@ package team.duckie.app.android.util.kotlin
  */
 sealed class DuckieException(code: String) : IllegalStateException("DuckieException: $code")
 
+/** 서버 응답 StatusCode */
+enum class DuckieStatusCode(val statusCode: Int) {
+    Unknown(-1),
+    BadRequest(400),
+    UnAuthorized(401),
+    Forbidden(403),
+    NotFound(404),
+    InternalServer(500);
+}
+
+/** [Int] -> [DuckieStatusCode] */
+fun Int.toDuckieStatusCode(): DuckieStatusCode = when (this) {
+    400 -> DuckieStatusCode.BadRequest
+    401 -> DuckieStatusCode.UnAuthorized
+    403 -> DuckieStatusCode.Forbidden
+    404 -> DuckieStatusCode.NotFound
+    500 -> DuckieStatusCode.InternalServer
+    else -> DuckieStatusCode.Unknown
+}
+
 /**
  * 덕키 API 의 response 가 정상적으로 처리되지 않았을 때 [DuckieException] 을 나타냅니다.
  *
  * 백엔드의 [에러 처리 규칙](https://www.notion.so/jisungbin/6487a9d604e14375bc02df6fd8397f15) 을 따릅니다.
  *
- * @param message 예외 메시지. 선택으로 값을 받습니다.
+ * @param serverMessage 예외 메시지. 선택으로 값을 받습니다.
  * @param code 예외 코드. 필수로 값을 받습니다.
  * @param errors 발생한 에러 목록. 선택으로 값을 받습니다
  * @param throwable 실제로 앱 내에서 발생한 throwable 원본
  */
 class DuckieResponseException(
-    message: String? = null,
+    serverMessage: String? = null,
+    val statusCode: DuckieStatusCode,
     val code: String,
     val errors: List<String>? = null,
     val throwable: Throwable,
 ) : DuckieException(code) {
-    val originalMessage = message
-    override val message = "DuckieResponseException: $code".runIf(message != null) { plus(" - $message") }
+    override val message = "DuckieResponseException: $code".runIf(serverMessage != null) { plus(" - $serverMessage") }
     override fun toString(): String {
-        return "DuckieApiException(message=$message, code=$code, errors=$errors, throwable=$throwable)"
+        return "DuckieApiException(message=$message, statusCode=$statusCode, code=$code, errors=$errors, throwable=$throwable)"
     }
 }
 
 fun duckieResponseException(
-    message: String? = null,
+    statusCode: DuckieStatusCode,
+    serverMessage: String? = null,
     code: String,
     errors: List<String>? = null,
     throwable: Throwable,
 ): Nothing {
     throw DuckieResponseException(
-        message = message,
+        statusCode = statusCode,
+        serverMessage = serverMessage,
         code = code,
         errors = errors,
         throwable = throwable,


### PR DESCRIPTION
- `expectSuccess = true` 로 인해, ktor 로직 호출 시 바로 exception 이 방출되는 내용 수정했습니다 (@jisungbin 과 협의)
- ExceptionBody 에 statusCode 값을 추가하였습니다. 
  - 위 작업에 따라 각 responseCatching() 로직도 수정했습니다.
  - enum 값을 통해 확인 가능하며, 처리 예시는 https://github.com/duckie-team/duckie-android/commit/1b1a861f61a6cf7b24a9a22cbd21f1acc8a86cc6 입니다.
  - 두 번의 조건 체크를 해야해서 보다 효율적인 체크를 고민중입니다. (일단은 리뷰로 매 맞고 싶어(?) 저렇게 처리해놨습니다)
- 기타 기능 개선을 했습니다.
  - 의미없는 throwable 생성을 없앴습니다.
- 테스트 코드는 활성화하려다가 취소했습니다. 사유는 Ignore 텍스트 내용 참고 바랍니다.

---

- 위 내용물을 util-errorHandling 모듈로 모두 옮기면 어떨지 생각중입니다.
  혼자 생각한 내용이고, PR 이 커지는 걸 막기 위해 이 작업은 하지 않았습니다.