### PR TITLE
Fuel 에 토큰 체크 로직 추가

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/file/repository/FileRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/file/repository/FileRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FileDataPart
 import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.coroutines.awaitString
+import team.duckie.app.android.data._datasource.AuthInterceptorFuelClient
 import java.io.File
 import javax.inject.Inject
 import team.duckie.app.android.data._util.toStringJsonMap
@@ -18,7 +19,9 @@ import team.duckie.app.android.domain.file.repository.FileRepository
 import team.duckie.app.android.util.kotlin.AllowMagicNumber
 import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 
-class FileRepositoryImpl @Inject constructor(private val client: Fuel) : FileRepository {
+class FileRepositoryImpl @Inject constructor(
+    @AuthInterceptorFuelClient private val client: Fuel,
+) : FileRepository {
     override suspend fun upload(file: File, type: String): String {
         val request = client
             .upload(

--- a/data/src/main/kotlin/team/duckie/app/android/data/heart/repository/HeartsRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/heart/repository/HeartsRepositoryImpl.kt
@@ -11,7 +11,6 @@ import com.github.kittinunf.fuel.Fuel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import team.duckie.app.android.data._datasource.AuthInterceptorFuelClient
-import team.duckie.app.android.data._datasource.DuckieHttpHeaders
 import team.duckie.app.android.data._datasource.bodyAsText
 import team.duckie.app.android.data._exception.util.responseCatchingGet
 import team.duckie.app.android.data._util.buildJson

--- a/data/src/main/kotlin/team/duckie/app/android/data/heart/repository/HeartsRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/heart/repository/HeartsRepositoryImpl.kt
@@ -10,6 +10,8 @@ package team.duckie.app.android.data.heart.repository
 import com.github.kittinunf.fuel.Fuel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import team.duckie.app.android.data._datasource.AuthInterceptorFuelClient
+import team.duckie.app.android.data._datasource.DuckieHttpHeaders
 import team.duckie.app.android.data._datasource.bodyAsText
 import team.duckie.app.android.data._exception.util.responseCatchingGet
 import team.duckie.app.android.data._util.buildJson
@@ -17,7 +19,9 @@ import team.duckie.app.android.domain.heart.model.HeartsBody
 import team.duckie.app.android.domain.heart.repository.HeartsRepository
 import javax.inject.Inject
 
-class HeartsRepositoryImpl @Inject constructor(private val fuel: Fuel) : HeartsRepository {
+class HeartsRepositoryImpl @Inject constructor(
+    @AuthInterceptorFuelClient private val fuel: Fuel,
+) : HeartsRepository {
     override suspend fun heart(examId: Int): Int = withContext(Dispatchers.IO) {
         val (_, response) = fuel
             .post("/hearts")

--- a/data/src/main/kotlin/team/duckie/app/android/data/tag/repository/TagRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/tag/repository/TagRepositoryImpl.kt
@@ -10,7 +10,6 @@ package team.duckie.app.android.data.tag.repository
 import com.github.kittinunf.fuel.Fuel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import team.duckie.app.android.data._datasource.AuthInterceptorFuelClient
 import team.duckie.app.android.data._datasource.UnAuthorInterceptorFuelClient
 import team.duckie.app.android.data._datasource.bodyAsText
 import team.duckie.app.android.data._exception.util.responseCatching

--- a/data/src/main/kotlin/team/duckie/app/android/data/tag/repository/TagRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/tag/repository/TagRepositoryImpl.kt
@@ -10,6 +10,8 @@ package team.duckie.app.android.data.tag.repository
 import com.github.kittinunf.fuel.Fuel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import team.duckie.app.android.data._datasource.AuthInterceptorFuelClient
+import team.duckie.app.android.data._datasource.UnAuthorInterceptorFuelClient
 import team.duckie.app.android.data._datasource.bodyAsText
 import team.duckie.app.android.data._exception.util.responseCatching
 import javax.inject.Inject
@@ -20,7 +22,9 @@ import team.duckie.app.android.data.tag.model.TagData
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.tag.repository.TagRepository
 
-class TagRepositoryImpl @Inject constructor(private val fuel: Fuel) : TagRepository {
+class TagRepositoryImpl @Inject constructor(
+    @UnAuthorInterceptorFuelClient private val fuel: Fuel,
+) : TagRepository {
     override suspend fun create(name: String): Tag = withContext(Dispatchers.IO) {
         val (_, response) = fuel
             .post("/tags")

--- a/plugin-ktor-client/src/main/kotlin/team/duckie/app/ktor/client/plugin/DuckieAuthorizationHeaderOrNothingPlugin.kt
+++ b/plugin-ktor-client/src/main/kotlin/team/duckie/app/ktor/client/plugin/DuckieAuthorizationHeaderOrNothingPlugin.kt
@@ -33,6 +33,12 @@ val DuckieAuthorizationHeaderOrNothingPlugin = createClientPlugin(
     }
 }
 
+// TODO(riflockle7): 의존 관계가 꼬여있는듯한 느낌이 있음. Api Header 명세 내용을 해당 모듈로 옮길 필요가 있음
+//   일단은 하드코딩으로 처리
+fun MutableMap<String, String>.addDuckieAuthorizationHeader() = this.apply {
+    DuckieAuthorizationHeader.accessToken?.let { put("Authorization", "Bearer $it") }
+}
+
 class DuckieAuthorizationHeaderConfig {
     var headerKey: String = "authorization"
 }


### PR DESCRIPTION
- Fuel 클라이언트에서 토큰을 체크할 수 있도록 처리했습니다. 
  토큰 사용 유무는 어노테이션으로 분리합니다. 자세한 내용은 [FuelClient.kt](https://github.com/duckie-team/duckie-android/compare/feat/fuel-token-check?expand=1#diff-20a4c33784080b5ae6ae97ba87d8de2b3df0c2d89c34c2bb8201660f99dbfb18) 확인
- Fuel 용 responseCatching 을 추가하였습니다.
- 코드 라인을 개선했습니다.

---

- 개인적으로는 responseCatching 을 합쳐 처리하고 싶었는데, 코드 변경점이 많을듯하여 일단은 분리하여 구현하였습니다
- 네트워크 로직에서 사용하는 상수들을 다른 모듈로 옮기면 어떨까 생각했습니다.
   제가 이렇게 생각한 이유는 fuelClient 에서 authorization 헤더에 키값을 어떻게 넣었는지 보시면 알게 되실 겁니다.