### PR TITLE
문제 만들기 화면에 유저 연동 & 문제 만들기 도중 발생하는 오류 수정

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/tag/repository/TagRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/tag/repository/TagRepositoryImpl.kt
@@ -19,7 +19,7 @@ import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.tag.repository.TagRepository
 
 class TagRepositoryImpl @Inject constructor(private val fuel: Fuel) : TagRepository {
-    // TODO(riflockle7): 문제 만들기 화면에서 잘 동작하는지 확인 필요
+    // TODO(riflockle7): 동작확인 필요
     override suspend fun create(name: String): Tag = withContext(Dispatchers.IO) {
         val (_, response) = fuel
             .post("/tags")

--- a/feature-ui-create-problem/build.gradle.kts
+++ b/feature-ui-create-problem/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
         projects.utilKotlin,
         projects.utilAndroid,
         projects.utilCompose,
+        projects.featureDatastore,
         projects.featurePhotopicker,
         projects.sharedUiCompose,
         projects.utilExceptionHandling,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
@@ -276,7 +276,6 @@ internal fun AdditionalInformationScreen(
                     nextButtonClick = {
                         coroutineScope.launch {
                             vm.makeExam()
-                            vm.finishCreateProblem()
                         }
                     },
                     isValidateCheck = vm::isAllFieldsNotEmpty,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -54,6 +54,7 @@ import team.duckie.app.android.domain.search.model.Search
 import team.duckie.app.android.domain.search.usecase.GetSearchUseCase
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.tag.repository.TagRepository
+import team.duckie.app.android.feature.datastore.me
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.sideeffect.CreateProblemSideEffect
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateProblemPhotoState
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.state.CreateProblemState
@@ -87,7 +88,7 @@ internal class CreateProblemViewModel @Inject constructor(
 ) : ContainerHost<CreateProblemState, CreateProblemSideEffect>, ViewModel() {
 
     override val container =
-        container<CreateProblemState, CreateProblemSideEffect>(CreateProblemState())
+        container<CreateProblemState, CreateProblemSideEffect>(CreateProblemState(me))
 
     suspend fun initState() {
         val examId = savedStateHandle.getStateFlow(Extras.ExamId, -1).value

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -66,6 +66,7 @@ import team.duckie.app.android.util.kotlin.DuckieStatusCode
 import team.duckie.app.android.util.kotlin.OutOfDateApi
 import team.duckie.app.android.util.kotlin.copy
 import team.duckie.app.android.util.kotlin.duckieClientLogicProblemException
+import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 import team.duckie.app.android.util.kotlin.fastMap
 import team.duckie.app.android.util.kotlin.fastMapIndexed
 import team.duckie.app.android.util.ui.const.Extras
@@ -252,9 +253,6 @@ internal class CreateProblemViewModel @Inject constructor(
         val createProblemState = container.stateFlow.value.createProblem
         val additionalInfoState = container.stateFlow.value.additionalInfo
 
-        // 카테고리는 선택 되어 있어야 함
-        require(examInformationState.categorySelection != -1)
-
         val problems = createProblemState.questions.fastMapIndexed { index, question ->
             Problem(
                 index,
@@ -271,7 +269,8 @@ internal class CreateProblemViewModel @Inject constructor(
             description = examInformationState.examDescription,
             mainTagId = examInformationState.categories.first().id,
             subTagIds = additionalInfoState.subTags.map { it.id }.toPersistentList(),
-            categoryId = examInformationState.selectedCategory.id,
+            categoryId = examInformationState.selectedCategory?.id
+                ?: duckieResponseFieldNpe("선택된 카테고리가 있어야 합니다."),
             certifyingStatement = examInformationState.certifyingStatement,
             thumbnailImageUrl = "${additionalInfoState.thumbnail}",
             thumbnailType = additionalInfoState.thumbnailType,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -232,6 +232,7 @@ internal class CreateProblemViewModel @Inject constructor(
     internal fun makeExam() = intent {
         makeExamUseCase(generateExamBody()).onSuccess { isSuccess: Boolean ->
             print(isSuccess) // TODO(EvergreenTree97) 문제 만들기 3단계에서 사용 가능
+            finishCreateProblem()
         }.onFailure {
             it.printStackTrace()
             throw it

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -16,8 +16,10 @@ import team.duckie.app.android.domain.exam.model.Question
 import team.duckie.app.android.domain.exam.model.ThumbnailType
 import team.duckie.app.android.domain.exam.model.getDefaultAnswer
 import team.duckie.app.android.domain.tag.model.Tag
+import team.duckie.app.android.domain.user.model.User
 
 internal data class CreateProblemState(
+    val me: User,
     val isEditMode: Boolean = false,
     val createProblemStep: CreateProblemStep = CreateProblemStep.Loading,
     val examInformation: ExamInformation = ExamInformation(),

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -46,7 +46,7 @@ internal data class CreateProblemState(
 
         val examThumbnailBody: ExamThumbnailBody
             get() = ExamThumbnailBody(
-                category = categories[categorySelection].name,
+                category = selectedCategory.name,
                 certifyingStatement = certifyingStatement,
                 mainTag = mainTag,
                 // TODO(riflockle7): 유저 데이터 활용 가능해질 시 처리 필요
@@ -55,6 +55,9 @@ internal data class CreateProblemState(
                 // TODO(riflockle7): 기획이 나오는대로 해당 값 처리 방법 구현해야 함
                 type = "text",
             )
+
+        val selectedCategory: Category
+            get() = categories[categorySelection]
     }
 
     /** 문제 만들기 2단계 화면에서 사용하는 data 모음 */

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -17,6 +17,7 @@ import team.duckie.app.android.domain.exam.model.ThumbnailType
 import team.duckie.app.android.domain.exam.model.getDefaultAnswer
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.user.model.User
+import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 
 internal data class CreateProblemState(
     val me: User,
@@ -46,7 +47,7 @@ internal data class CreateProblemState(
 
         val examThumbnailBody: ExamThumbnailBody
             get() = ExamThumbnailBody(
-                category = selectedCategory.name,
+                category = selectedCategory?.name ?: duckieResponseFieldNpe("선택된 카테고리가 있어야 합니다."),
                 certifyingStatement = certifyingStatement,
                 mainTag = mainTag,
                 // TODO(riflockle7): 유저 데이터 활용 가능해질 시 처리 필요
@@ -56,8 +57,12 @@ internal data class CreateProblemState(
                 type = "text",
             )
 
-        val selectedCategory: Category
-            get() = categories[categorySelection]
+        // TODO(riflockle7):
+        val selectedCategory: Category?
+            get() = if (categorySelection == -1)
+                null
+            else
+                categories[categorySelection]
     }
 
     /** 문제 만들기 2단계 화면에서 사용하는 data 모음 */

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -59,10 +59,11 @@ internal data class CreateProblemState(
 
         // TODO(riflockle7):
         val selectedCategory: Category?
-            get() = if (categorySelection == -1)
+            get() = if (categorySelection == -1) {
                 null
-            else
+            } else {
                 categories[categorySelection]
+            }
     }
 
     /** 문제 만들기 2단계 화면에서 사용하는 data 모음 */


### PR DESCRIPTION
- 문제 만들기 화면에서 앱 유저 정보를 가져올 수 있도록 처리했습니다.
- 문제 만들기 도중 발생하는 오류를 수정하였습니다
  - 문제 만들기를 실패해도 화면 종료하는 오류
  - 카테고리 설정이 안되는 오류
  - 에러 핸들링 로직 개선 (crash 없애기)

---

Fuel 작업이 merge 된 이후 동작 확인이 필요합니다. (그러니 절대 merge 하지 마세요)
https://github.com/duckie-team/duckie-android/issues/199 일부 내용을 반영 예정입니다.
