### PR TITLE
백앤드 반영 후 문제 만들기 화면 최종 확인 & 백앤드 연동 누락 내용 추가 (/search 및 Search 엔티티)

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/moshi.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/moshi.kt
@@ -8,8 +8,18 @@
 package team.duckie.app.android.data._datasource
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import team.duckie.app.android.data.search.model.SearchData
+import team.duckie.app.android.domain.search.model.Search
 
 internal val MoshiBuilder = Moshi.Builder()
+    .add(searchDataFactory)
     .addLast(KotlinJsonAdapterFactory())
     .build()
+
+internal val searchDataFactory
+    get() = PolymorphicJsonAdapterFactory.of(SearchData::class.java, "type")
+        .withSubtype(SearchData.ExamSearchData::class.java, Search.Exam)
+        .withSubtype(SearchData.TagSearchData::class.java, Search.Tags)
+        .withSubtype(SearchData.UserSearchData::class.java, Search.User)

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -37,7 +37,6 @@ import team.duckie.app.android.domain.exam.model.ExamThumbnailBody
 import team.duckie.app.android.domain.exam.model.ImageChoiceModel
 import team.duckie.app.android.domain.exam.model.Problem
 import team.duckie.app.android.domain.exam.model.Question
-import team.duckie.app.android.domain.exam.model.ShortModel
 import team.duckie.app.android.util.kotlin.AllowCyclomaticComplexMethod
 import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 import team.duckie.app.android.util.kotlin.fastMap
@@ -96,11 +95,7 @@ internal fun QuestionData.toDomain() = when (this) {
 }
 
 internal fun AnswerData.toDomain(): Answer = when (this) {
-    is AnswerData.ShortAnswer -> Answer.Short(
-        answer = ShortModel(
-            shortAnswer ?: duckieResponseFieldNpe("${this::class.java.simpleName}.shortAnswer"),
-        ),
-    )
+    is AnswerData.ShortAnswer -> Answer.Short()
 
     is AnswerData.Choice -> Answer.Choice(
         choices = choices?.fastMap(ChoiceData::toDomain)?.toImmutableList()
@@ -169,9 +164,7 @@ internal fun Problem.toData() = ProblemData(
     },
     answer = answer?.let { answer ->
         when (answer) {
-            is Answer.Short -> AnswerData.ShortAnswer(
-                shortAnswer = answer.answer.text,
-            )
+            is Answer.Short -> AnswerData.ShortAnswer()
 
             is Answer.Choice -> AnswerData.Choice(
                 choices = answer.choices.map {

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -148,25 +148,21 @@ internal fun Problem.toData() = ProblemData(
     question = question.let { question ->
         when (question) {
             is Question.Text -> QuestionData.Text(
-                type = question.type.key,
                 text = question.text,
             )
 
             is Question.Video -> QuestionData.Video(
                 videoUrl = question.videoUrl,
-                type = question.type.key,
                 text = question.text,
             )
 
             is Question.Image -> QuestionData.Image(
                 imageUrl = question.imageUrl,
-                type = question.type.key,
                 text = question.text,
             )
 
             is Question.Audio -> QuestionData.Audio(
                 audioUrl = question.audioUrl,
-                type = question.type.key,
                 text = question.text,
             )
         }
@@ -175,21 +171,18 @@ internal fun Problem.toData() = ProblemData(
         when (answer) {
             is Answer.Short -> AnswerData.ShortAnswer(
                 shortAnswer = answer.answer.text,
-                type = answer.type.key,
             )
 
             is Answer.Choice -> AnswerData.Choice(
                 choices = answer.choices.map {
                     it.toData()
                 }.toList(),
-                type = answer.type.key,
             )
 
             is Answer.ImageChoice -> AnswerData.ImageChoice(
                 choices = answer.imageChoice.map {
                     it.toData()
                 }.toList(),
-                type = answer.type.key,
             )
         }
     },

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -108,7 +108,7 @@ internal fun AnswerData.toDomain(): Answer = when (this) {
     )
 
     is AnswerData.ImageChoice -> Answer.ImageChoice(
-        imageChoice = imageChoice?.fastMap(ImageChoiceData::toDomain)?.toImmutableList()
+        imageChoice = choices?.fastMap(ImageChoiceData::toDomain)?.toImmutableList()
             ?: duckieResponseFieldNpe("${this::class.java.simpleName}.imageChoice"),
     )
 }
@@ -186,7 +186,7 @@ internal fun Problem.toData() = ProblemData(
             )
 
             is Answer.ImageChoice -> AnswerData.ImageChoice(
-                imageChoice = answer.imageChoice.map {
+                choices = answer.imageChoice.map {
                     it.toData()
                 }.toList(),
                 type = answer.type.key,

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamBodyData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamBodyData.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.app.android.data.exam.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 internal data class ExamBodyData(
@@ -40,6 +41,7 @@ internal data class ExamBodyData(
     @field:JsonProperty("problems")
     val problems: List<ProblemData>? = null,
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonProperty("status")
     val status: String? = null,
 )

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -97,8 +97,8 @@ internal sealed class AnswerData(
     ) : AnswerData(type)
 
     internal data class ImageChoice(
-        @field:JsonProperty("imageChoice")
-        val imageChoice: List<ImageChoiceData>? = null,
+        @field:JsonProperty("choices")
+        val choices: List<ImageChoiceData>? = null,
         override val type: String? = null,
     ) : AnswerData(type)
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -7,11 +7,13 @@
 
 package team.duckie.app.android.data.exam.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 
 internal data class ProblemData(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonProperty("id")
     val id: Int? = null,
 

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -91,10 +91,7 @@ internal sealed class QuestionData(
 internal sealed class AnswerData(
     open val type: String? = null,
 ) {
-    internal data class ShortAnswer(
-        @field:JsonProperty("shortAnswer")
-        val shortAnswer: String? = null,
-    ) : AnswerData("shortAnswer")
+    internal class ShortAnswer : AnswerData("shortAnswer")
 
     internal data class Choice(
         @field:JsonProperty("choices")

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ProblemItemData.kt
@@ -33,7 +33,11 @@ internal data class ProblemData(
     val memo: String? = null,
 )
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+)
 @JsonSubTypes(
     JsonSubTypes.Type(value = QuestionData.Text::class, name = "text"),
     JsonSubTypes.Type(value = QuestionData.Image::class, name = "image"),
@@ -41,66 +45,66 @@ internal data class ProblemData(
     JsonSubTypes.Type(value = QuestionData.Video::class, name = "video"),
 )
 internal sealed class QuestionData(
-    @field:JsonProperty("type")
     open val type: String? = null,
-
-    @field:JsonProperty("text")
     open val text: String? = null,
 ) {
     internal data class Text(
-        override val type: String? = null,
+        @field:JsonProperty("text")
         override val text: String? = null,
-    ) : QuestionData(type, text)
+    ) : QuestionData("text", text)
 
     internal data class Image(
         @field:JsonProperty("imageUrl")
         val imageUrl: String? = null,
-        override val type: String? = null,
+
+        @field:JsonProperty("text")
         override val text: String? = null,
-    ) : QuestionData(type, text)
+    ) : QuestionData("image", text)
 
     internal data class Audio(
         @field:JsonProperty("audioUrl")
         val audioUrl: String? = null,
-        override val type: String? = null,
+
+        @field:JsonProperty("text")
         override val text: String? = null,
-    ) : QuestionData(type, text)
+    ) : QuestionData("audio", text)
 
     internal data class Video(
         @field:JsonProperty("videoUrl")
         val videoUrl: String? = null,
-        override val type: String? = null,
+
+        @field:JsonProperty("text")
         override val text: String? = null,
-    ) : QuestionData(type, text)
+    ) : QuestionData("video", text)
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+)
 @JsonSubTypes(
     JsonSubTypes.Type(value = AnswerData.ShortAnswer::class, name = "shortAnswer"),
     JsonSubTypes.Type(value = AnswerData.Choice::class, name = "choice"),
     JsonSubTypes.Type(value = AnswerData.ImageChoice::class, name = "imageChoice"),
 )
 internal sealed class AnswerData(
-    @field:JsonProperty("type")
     open val type: String? = null,
 ) {
     internal data class ShortAnswer(
         @field:JsonProperty("shortAnswer")
         val shortAnswer: String? = null,
-        override val type: String? = null,
-    ) : AnswerData(type)
+    ) : AnswerData("shortAnswer")
 
     internal data class Choice(
         @field:JsonProperty("choices")
         val choices: List<ChoiceData>? = null,
-        override val type: String? = null,
-    ) : AnswerData(type)
+    ) : AnswerData("choice")
 
     internal data class ImageChoice(
         @field:JsonProperty("choices")
         val choices: List<ImageChoiceData>? = null,
-        override val type: String? = null,
-    ) : AnswerData(type)
+    ) : AnswerData("imageChoice")
 }
 
 internal data class ChoiceData(

--- a/data/src/main/kotlin/team/duckie/app/android/data/search/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/search/mapper/mapper.kt
@@ -20,20 +20,17 @@ import team.duckie.app.android.util.kotlin.fastMap
 
 internal fun SearchData.toDomain() = when (this) {
     is SearchData.ExamSearchData -> Search.ExamSearch(
-        exams = exams?.fastMap(ExamData::toDomain)
-            ?: duckieResponseFieldNpe("${this::class.java.simpleName}.exams"),
-        page = page ?: duckieResponseFieldNpe("${this::class.java.simpleName}.page"),
+        exams = result?.fastMap(ExamData::toDomain)
+            ?: duckieResponseFieldNpe("${this::class.java.simpleName}.result"),
     )
 
     is SearchData.UserSearchData -> Search.UserSearch(
-        users = users?.fastMap(UserResponse::toDomain)
-            ?: duckieResponseFieldNpe("${this::class.java.simpleName}.users"),
-        page = page ?: duckieResponseFieldNpe("${this::class.java.simpleName}.page"),
+        users = result?.fastMap(UserResponse::toDomain)
+            ?: duckieResponseFieldNpe("${this::class.java.simpleName}.result"),
     )
 
     is SearchData.TagSearchData -> Search.TagSearch(
-        tags = tags?.fastMap(TagData::toDomain)
-            ?: duckieResponseFieldNpe("${this::class.java.simpleName}.tags"),
-        page = page ?: duckieResponseFieldNpe("${this::class.java.simpleName}.page"),
+        tags = result?.fastMap(TagData::toDomain)
+            ?: duckieResponseFieldNpe("${this::class.java.simpleName}.result"),
     )
 }

--- a/data/src/main/kotlin/team/duckie/app/android/data/search/model/SearchData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/search/model/SearchData.kt
@@ -15,7 +15,11 @@ import team.duckie.app.android.data.tag.model.TagData
 import team.duckie.app.android.data.user.model.UserResponse
 import team.duckie.app.android.domain.search.model.Search
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+)
 @JsonSubTypes(
     JsonSubTypes.Type(value = SearchData.ExamSearchData::class, name = Search.Exam),
     JsonSubTypes.Type(value = SearchData.UserSearchData::class, name = Search.User),

--- a/data/src/main/kotlin/team/duckie/app/android/data/search/model/SearchData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/search/model/SearchData.kt
@@ -8,48 +8,31 @@
 package team.duckie.app.android.data.search.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.squareup.moshi.JsonClass
 import team.duckie.app.android.data.exam.model.ExamData
 import team.duckie.app.android.data.tag.model.TagData
 import team.duckie.app.android.data.user.model.UserResponse
-import team.duckie.app.android.domain.search.model.Search
 
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    include = JsonTypeInfo.As.EXISTING_PROPERTY,
-    property = "type",
-)
-@JsonSubTypes(
-    JsonSubTypes.Type(value = SearchData.ExamSearchData::class, name = Search.Exam),
-    JsonSubTypes.Type(value = SearchData.UserSearchData::class, name = Search.User),
-    JsonSubTypes.Type(value = SearchData.TagSearchData::class, name = Search.Tags),
-)
+@JsonClass(generateAdapter = true)
 internal sealed class SearchData(
     @field:JsonProperty("type")
     open val type: String? = null,
-
-    @field:JsonProperty("page")
-    open val page: Int? = null,
 ) {
+    @JsonClass(generateAdapter = true)
     internal data class ExamSearchData(
-        @field:JsonProperty("exams")
-        val exams: List<ExamData>? = null,
-        override val type: String? = null,
-        override val page: Int? = null,
+        @field:JsonProperty("result")
+        val result: List<ExamData>? = null,
     ) : SearchData()
 
+    @JsonClass(generateAdapter = true)
     internal data class UserSearchData(
-        @field:JsonProperty("users")
-        val users: List<UserResponse>? = null,
-        override val type: String? = null,
-        override val page: Int? = null,
+        @field:JsonProperty("result")
+        val result: List<UserResponse>? = null,
     ) : SearchData()
 
+    @JsonClass(generateAdapter = true)
     internal data class TagSearchData(
-        @field:JsonProperty("tags")
-        val tags: List<TagData>? = null,
-        override val type: String? = null,
-        override val page: Int? = null,
+        @field:JsonProperty("result")
+        val result: List<TagData>? = null,
     ) : SearchData()
 }

--- a/data/src/test/kotlin/team/duckie/app/android/data/dummy/SearchDummyResponse.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/dummy/SearchDummyResponse.kt
@@ -14,7 +14,6 @@ object SearchDummyResponse {
     const val RawData = ""
 
     val DomainData = Search.TagSearch(
-        page = 1,
         tags = persistentListOf(),
     )
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamBody.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/ExamBody.kt
@@ -14,7 +14,7 @@ import kotlinx.collections.immutable.ImmutableList
 
 @Immutable
 enum class ThumbnailType(val value: String) {
-    Default("default"),
+    Text("text"),
     Image("image"),
 }
 

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
@@ -55,6 +55,14 @@ sealed class Question(val type: Type, open val text: String) {
         text = text,
     )
 
+    val mediaUri: String
+        get() = when (this) {
+            is Text -> ""
+            is Image -> this.imageUrl
+            is Audio -> this.audioUrl
+            is Video -> this.videoUrl
+        }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Question) return false

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
@@ -96,7 +96,10 @@ sealed class Answer(val type: Type) {
     }
 
     @Immutable
-    class Short(val answer: ShortModel) : Answer(type = Type.ShortAnswer)
+    class Short(
+        /** [correctAnswer] 는 문제 풀기 화면에서만 사용된다. */
+        val correctAnswer: String = "",
+    ) : Answer(type = Type.ShortAnswer)
 
     @Immutable
     class Choice(val choices: ImmutableList<ChoiceModel>) : Answer(type = Type.Choice)
@@ -111,7 +114,7 @@ sealed class Answer(val type: Type) {
         if (type != other.type) return false
 
         if (this is Short && other is Short) {
-            return this.answer.text == other.answer.text
+            return this.correctAnswer == other.correctAnswer
         }
         if (this is Choice && other is Choice) {
             return this.choices == other.choices
@@ -128,8 +131,7 @@ sealed class Answer(val type: Type) {
     }
 
     fun validate(): Boolean = when (this) {
-        is Short ->
-            this.answer.text.isNotEmpty()
+        is Short -> true
 
         is Choice ->
             this.choices
@@ -147,7 +149,7 @@ sealed class Answer(val type: Type) {
 
 /** [문제 타입][Answer.Type]에 맞는 기본 [답안][Answer] 를 가져옵니다. */
 fun Answer.Type.getDefaultAnswer(): Answer = when (this) {
-    Answer.Type.ShortAnswer -> Answer.Short(getDefaultAnswerModel())
+    Answer.Type.ShortAnswer -> Answer.Short()
     Answer.Type.Choice -> Answer.Choice(
         persistentListOf(
             getDefaultAnswerModel(),
@@ -168,7 +170,7 @@ interface AnswerModel
 
 // TODO(riflockle7): value class 적용 검토하기
 @Immutable
-data class ShortModel(val text: String) : AnswerModel
+object ShortModel : AnswerModel
 
 // TODO(riflockle7): value class 적용 검토하기
 @Immutable
@@ -183,19 +185,13 @@ data class ImageChoiceModel(
 /** [문제 타입][Answer.Type]에 맞는 기본 [답안 모델][AnswerModel]을 가져옵니다. */
 @Suppress("UNCHECKED_CAST")
 fun <T : AnswerModel> Answer.Type.getDefaultAnswerModel(): T = when (this) {
-    Answer.Type.ShortAnswer -> ShortModel("") as T
+    Answer.Type.ShortAnswer -> ShortModel as T
     Answer.Type.Choice -> ChoiceModel("") as T
     Answer.Type.ImageChoice -> ImageChoiceModel("", "") as T
 }
 
 /** [Answer] -> [Answer.Short] */
-fun Answer.toShort(newAnswer: String? = null) = Answer.Short(
-    when (this) {
-        is Answer.Short -> ShortModel(newAnswer ?: this.answer.text)
-        is Answer.Choice -> ShortModel(newAnswer ?: this.choices.firstOrNull()?.text ?: "")
-        is Answer.ImageChoice -> ShortModel(newAnswer ?: this.imageChoice.firstOrNull()?.text ?: "")
-    },
-)
+fun Answer.toShort() = Answer.Short()
 
 /** [Answer] -> [Answer.Choice] */
 fun Answer.toChoice(answerIndex: Int? = null, newAnswer: String? = null) = when (this) {

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
@@ -247,3 +247,12 @@ fun Answer.toImageChoice(
         }.toPersistentList(),
     )
 }
+
+/** client 용 correctAnswer (index) -> 백앤드용 correctAnswer (answerValue) */
+fun String.toCorrectAnswerData(answers: Answer) = when (answers) {
+    is Answer.ImageChoice -> answers.imageChoice[this.toInt()].text
+
+    is Answer.Choice -> answers.choices[this.toInt()].text
+
+    else -> this
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/search/model/Search.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/search/model/Search.kt
@@ -13,7 +13,7 @@ import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.user.model.User
 
 @Immutable
-sealed class Search(val type: String, open val page: Int) {
+sealed class Search(val type: String) {
     companion object {
         const val Exam = "EXAM"
         const val User = "USER"
@@ -23,18 +23,15 @@ sealed class Search(val type: String, open val page: Int) {
     @Immutable
     data class ExamSearch(
         val exams: List<Exam>,
-        override val page: Int,
-    ) : Search(Exam, page)
+    ) : Search(Exam)
 
     @Immutable
     data class UserSearch(
         val users: List<User>,
-        override val page: Int,
-    ) : Search(User, page)
+    ) : Search(User)
 
     @Immutable
     data class TagSearch(
         val tags: List<Tag>,
-        override val page: Int,
-    ) : Search(Tags, page)
+    ) : Search(Tags)
 }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -80,26 +80,31 @@ class CreateProblemActivity : BaseActivity() {
                                 .fillMaxSize()
                                 .statusBarsPadding(),
                         )
+
                         CreateProblemStep.ExamInformation -> ExamInformationScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .statusBarsPadding(),
                         )
+
                         CreateProblemStep.Search -> SearchTagScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .statusBarsPadding(),
                         )
+
                         CreateProblemStep.CreateProblem -> CreateProblemScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .statusBarsPadding(),
                         )
+
                         CreateProblemStep.AdditionalInformation -> AdditionalInformationScreen(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .statusBarsPadding(),
                         )
+
                         CreateProblemStep.Error -> ErrorScreen(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -116,6 +121,7 @@ class CreateProblemActivity : BaseActivity() {
             CreateProblemSideEffect.FinishActivity -> {
                 finishWithAnimation()
             }
+
             is CreateProblemSideEffect.ReportError -> {
                 Firebase.crashlytics.recordException(sideEffect.exception)
 
@@ -126,6 +132,7 @@ class CreateProblemActivity : BaseActivity() {
                     sideEffect.exception.reportToToast(getString(R.string.network_error))
                 }
             }
+
             is CreateProblemSideEffect.UpdateGalleryImages -> {
                 viewModel.addGalleryImages(sideEffect.images)
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/CreateProblemActivity.kt
@@ -56,8 +56,6 @@ class CreateProblemActivity : BaseActivity() {
 
             BackHandler {
                 when (createProblemStep) {
-                    CreateProblemStep.CreateProblem, CreateProblemStep.AdditionalInformation ->
-                        viewModel.navigateStep(createProblemStep.minus(1))
                     CreateProblemStep.Loading, CreateProblemStep.Error -> finishWithAnimation()
                     else -> {}
                 }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/CreateProblemBottomLayout.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/CreateProblemBottomLayout.kt
@@ -95,7 +95,7 @@ internal fun CreateProblemBottomLayout(
     tempSaveButtonClick: (() -> Unit)? = null,
     nextButtonText: String,
     nextButtonClick: () -> Unit,
-    isMaximumProblemCount: Boolean? = null,
+    isProblemCountValidate: Boolean? = null,
     isValidateCheck: () -> Boolean,
 ) {
     val isValidate = isValidateCheck()
@@ -107,12 +107,12 @@ internal fun CreateProblemBottomLayout(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             leftButtonClick?.let { createButtonClick ->
-                requireNotNull(isMaximumProblemCount)
+                requireNotNull(isProblemCountValidate)
                 requireNotNull(leftButtonText)
                 Row(
                     modifier = Modifier
                         .quackClickable {
-                            if (!isMaximumProblemCount) {
+                            if (!isProblemCountValidate) {
                                 createButtonClick()
                             }
                         }
@@ -122,7 +122,7 @@ internal fun CreateProblemBottomLayout(
                     leftButtonLeadingIcon?.let { QuackImage(src = it, size = DpSize(16.dp, 16.dp)) }
                     QuackSubtitle2(
                         text = leftButtonText,
-                        color = if (isMaximumProblemCount) QuackColor.Gray2 else QuackColor.Black,
+                        color = if (isProblemCountValidate) QuackColor.Gray2 else QuackColor.Black,
                     )
                 }
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
@@ -81,6 +81,7 @@ import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.compose.rememberToast
 import team.duckie.app.android.util.compose.systemBarPaddings
 import team.duckie.app.android.util.kotlin.fastMap
+import team.duckie.app.android.util.kotlin.takeBy
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBasicTextField
 import team.duckie.quackquack.ui.component.QuackImage
@@ -96,7 +97,7 @@ private const val TopAppBarLayoutId = "AdditionalInfoScreenTopAppBarLayoutId"
 private const val ContentLayoutId = "AdditionalInfoScreenContentLayoutId"
 private const val BottomLayoutId = "AdditionalInfoScreenBottomLayoutId"
 
-private const val TakeTitleMaxLength = 12;
+private const val TakeTitleMaxLength = 12
 
 /** 문제 만들기 3단계 (추가정보 입력) Screen */
 @Composable
@@ -372,12 +373,13 @@ private fun AdditionalTakeLayout(vm: CreateProblemViewModel = activityViewModel(
     ) {
         QuackBasicTextField(
             text = state.takeTitle,
-            onTextChanged = { newText ->
-                if (state.takeTitle.length <= TakeTitleMaxLength) {
-                    vm.setButtonTitle(newText)
-                } else {
-                    vm.setButtonTitle(state.takeTitle)
-                }
+            onTextChanged = {
+                vm.setButtonTitle(
+                    it.takeBy(
+                        TakeTitleMaxLength,
+                        state.takeTitle,
+                    ),
+                )
             },
             placeholderText = stringResource(id = R.string.additional_information_take_input_hint),
             keyboardOptions = ImeActionNext,

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
@@ -96,6 +96,8 @@ private const val TopAppBarLayoutId = "AdditionalInfoScreenTopAppBarLayoutId"
 private const val ContentLayoutId = "AdditionalInfoScreenContentLayoutId"
 private const val BottomLayoutId = "AdditionalInfoScreenBottomLayoutId"
 
+private const val TakeTitleMaxLength = 12;
+
 /** 문제 만들기 3단계 (추가정보 입력) Screen */
 @Composable
 internal fun AdditionalInformationScreen(
@@ -370,7 +372,13 @@ private fun AdditionalTakeLayout(vm: CreateProblemViewModel = activityViewModel(
     ) {
         QuackBasicTextField(
             text = state.takeTitle,
-            onTextChanged = vm::setButtonTitle,
+            onTextChanged = { newText ->
+                if (state.takeTitle.length <= TakeTitleMaxLength) {
+                    vm.setButtonTitle(newText)
+                } else {
+                    vm.setButtonTitle(state.takeTitle)
+                }
+            },
             placeholderText = stringResource(id = R.string.additional_information_take_input_hint),
             keyboardOptions = ImeActionNext,
         )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
@@ -202,7 +202,7 @@ internal fun AdditionalInformationScreen(
                         title = "기본 썸네일",
                         src = rootState.defaultThumbnail,
                         onClick = {
-                            vm.selectThumbnail(thumbnailType = ThumbnailType.Default)
+                            vm.selectThumbnail(thumbnailType = ThumbnailType.Text)
                             coroutineScope.launch {
                                 sheetState.hide()
                             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -104,6 +104,7 @@ private const val BottomLayoutId = "CreateProblemScreenBottomLayoutId"
 private const val GalleryListLayoutId = "CreateProblemScreenGalleryListLayoutId"
 
 private const val MaximumChoice = 5
+private const val MinimumProblem = 5
 private const val MaximumProblem = 10
 private const val TextFieldMaxLength = 20
 
@@ -500,7 +501,7 @@ internal fun CreateProblemScreen(
                             vm.navigateStep(CreateProblemStep.AdditionalInformation)
                         }
                     },
-                    isMaximumProblemCount = problemCount >= MaximumProblem,
+                    isProblemCountValidate = problemCount in MinimumProblem..MaximumProblem,
                     isValidateCheck = vm::createProblemIsValidate,
                 )
             },

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -314,7 +314,7 @@ internal fun CreateProblemScreen(
                                             sheetState.animateTo(ModalBottomSheetValue.Expanded)
                                         }
                                     },
-                                    answers = answers,
+                                    answer = correctAnswer,
                                     answerTextChanged = { newTitle, answerIndex ->
                                         vm.setAnswer(
                                             questionIndex,
@@ -322,7 +322,7 @@ internal fun CreateProblemScreen(
                                             Answer.Type.ShortAnswer,
                                             answer = newTitle.takeBy(
                                                 TextFieldMaxLength,
-                                                answers.answer.text,
+                                                state.correctAnswers[answerIndex],
                                             ),
                                         )
                                     },
@@ -879,7 +879,7 @@ private fun ShortAnswerProblemLayout(
     titleChanged: (String) -> Unit,
     imageClick: () -> Unit,
     onDropdownItemClick: (Int) -> Unit,
-    answers: Answer.Short,
+    answer: String,
     answerTextChanged: (String, Int) -> Unit,
     deleteLongClick: () -> Unit,
 ) {
@@ -896,12 +896,12 @@ private fun ShortAnswerProblemLayout(
             question,
             titleChanged,
             imageClick,
-            answers.type.title,
+            Answer.Type.ShortAnswer.title,
             onDropdownItemClick,
         )
 
         QuackBasicTextField(
-            text = answers.answer.text,
+            text = answer,
             onTextChanged = { newAnswer -> answerTextChanged(newAnswer, 0) },
             placeholderText = stringResource(id = R.string.create_problem_short_answer_placeholder),
         )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -82,6 +82,7 @@ import team.duckie.app.android.util.compose.rememberToast
 import team.duckie.app.android.util.compose.systemBarPaddings
 import team.duckie.app.android.util.kotlin.fastForEach
 import team.duckie.app.android.util.kotlin.fastForEachIndexed
+import team.duckie.app.android.util.kotlin.takeBy
 import team.duckie.quackquack.ui.border.QuackBorder
 import team.duckie.quackquack.ui.border.applyAnimatedQuackBorder
 import team.duckie.quackquack.ui.color.QuackColor
@@ -288,7 +289,10 @@ internal fun CreateProblemScreen(
                                         vm.setQuestion(
                                             question.type,
                                             questionIndex,
-                                            title = newTitle.take(TextFieldMaxLength),
+                                            title = newTitle.takeBy(
+                                                TextFieldMaxLength,
+                                                question.text,
+                                            ),
                                         )
                                     },
                                     imageClick = {
@@ -316,7 +320,10 @@ internal fun CreateProblemScreen(
                                             questionIndex,
                                             answerIndex,
                                             Answer.Type.ShortAnswer,
-                                            answer = newTitle.take(TextFieldMaxLength),
+                                            answer = newTitle.takeBy(
+                                                TextFieldMaxLength,
+                                                answers.answer.text,
+                                            ),
                                         )
                                     },
                                     deleteLongClick = {
@@ -331,7 +338,10 @@ internal fun CreateProblemScreen(
                                         vm.setQuestion(
                                             question.type,
                                             questionIndex,
-                                            title = newTitle.take(TextFieldMaxLength),
+                                            title = newTitle.takeBy(
+                                                TextFieldMaxLength,
+                                                question.text,
+                                            ),
                                         )
                                     },
                                     imageClick = {
@@ -359,7 +369,10 @@ internal fun CreateProblemScreen(
                                             questionIndex,
                                             answerIndex,
                                             Answer.Type.Choice,
-                                            answer = newTitle.take(TextFieldMaxLength),
+                                            answer = newTitle.takeBy(
+                                                TextFieldMaxLength,
+                                                answers.choices[answerIndex].text,
+                                            ),
                                         )
                                     },
                                     addAnswerClick = {
@@ -387,7 +400,10 @@ internal fun CreateProblemScreen(
                                         vm.setQuestion(
                                             question.type,
                                             questionIndex,
-                                            title = newTitle.take(TextFieldMaxLength),
+                                            title = newTitle.takeBy(
+                                                TextFieldMaxLength,
+                                                question.text,
+                                            ),
                                         )
                                     },
                                     imageClick = {
@@ -415,7 +431,10 @@ internal fun CreateProblemScreen(
                                             questionIndex,
                                             answerIndex,
                                             Answer.Type.ImageChoice,
-                                            answer = newTitle.take(TextFieldMaxLength),
+                                            answer = newTitle.takeBy(
+                                                TextFieldMaxLength,
+                                                answers.imageChoice[answerIndex].text,
+                                            ),
                                         )
                                     },
                                     answerImageClick = { answersIndex ->

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -683,7 +683,7 @@ private fun ChoiceProblemLayout(
 
         answers.choices.fastForEachIndexed { answerIndex, choiceModel ->
             val answerNo = answerIndex + 1
-            val isChecked = correctAnswers == "$answerNo"
+            val isChecked = correctAnswers == "$answerIndex"
             QuackBorderTextField(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -706,7 +706,9 @@ private fun ChoiceProblemLayout(
                 trailingContent = {
                     Column(
                         modifier = Modifier.quackClickable(
-                            onClick = { setCorrectAnswerClick(if (isChecked) "" else "$answerNo") },
+                            onClick = {
+                                setCorrectAnswerClick(if (isChecked) "" else "$answerIndex")
+                            },
                         ),
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
@@ -780,7 +782,7 @@ private fun ImageChoiceProblemLayout(
             itemContent = { answerIndex ->
                 val answerNo = answerIndex + 1
                 val answerItem = answers.imageChoice[answerIndex]
-                val isChecked = correctAnswers == "$answerNo"
+                val isChecked = correctAnswers == "$answerIndex"
 
                 Column(
                     modifier = Modifier
@@ -789,7 +791,11 @@ private fun ImageChoiceProblemLayout(
                         .applyAnimatedQuackBorder(
                             border = QuackBorder(
                                 width = 1.dp,
-                                color = if (isChecked) QuackColor.DuckieOrange else QuackColor.Gray4,
+                                color = if (isChecked) {
+                                    QuackColor.DuckieOrange
+                                } else {
+                                    QuackColor.Gray4
+                                },
                             ),
                         )
                         .padding(12.dp),
@@ -800,7 +806,9 @@ private fun ImageChoiceProblemLayout(
                     ) {
                         QuackRoundCheckBox(
                             modifier = Modifier.quackClickable(
-                                onClick = { setCorrectAnswerClick(if (isChecked) "" else "$answerNo") },
+                                onClick = {
+                                    setCorrectAnswerClick(if (isChecked) "" else "$answerIndex")
+                                },
                             ),
                             checked = isChecked,
                         )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.app.android.feature.ui.create.problem.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,6 +29,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -35,6 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.feature.ui.create.problem.CreateProblemActivity
 import team.duckie.app.android.feature.ui.create.problem.R
 import team.duckie.app.android.feature.ui.create.problem.common.CreateProblemBottomLayout
 import team.duckie.app.android.feature.ui.create.problem.common.ImeActionNext
@@ -46,6 +49,7 @@ import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblem
 import team.duckie.app.android.shared.ui.compose.DuckieGridLayout
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.kotlin.takeBy
+import team.duckie.app.android.util.ui.finishWithAnimation
 import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
 import team.duckie.quackquack.ui.border.QuackBorder
 import team.duckie.quackquack.ui.color.QuackColor
@@ -72,11 +76,17 @@ internal fun ExamInformationScreen(
     viewModel: CreateProblemViewModel = activityViewModel(),
     modifier: Modifier,
 ) {
+    val activity = LocalContext.current as CreateProblemActivity
     val state = viewModel.collectAsState().value.examInformation
     val coroutineScope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
     val lazyListState = rememberLazyListState()
     val focusRequester = remember { FocusRequester() }
+
+    BackHandler {
+        // TODO(riflockle7): 다이얼로그가 필요할 듯 하여 TODO 남김
+        activity.finishWithAnimation()
+    }
 
     LaunchedEffect(Unit) {
         viewModel.getCategories()

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -45,6 +45,7 @@ import team.duckie.app.android.feature.ui.create.problem.common.moveDownFocus
 import team.duckie.app.android.feature.ui.create.problem.viewmodel.CreateProblemViewModel
 import team.duckie.app.android.shared.ui.compose.DuckieGridLayout
 import team.duckie.app.android.util.compose.activityViewModel
+import team.duckie.app.android.util.kotlin.takeBy
 import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
 import team.duckie.quackquack.ui.border.QuackBorder
 import team.duckie.quackquack.ui.color.QuackColor
@@ -153,9 +154,12 @@ internal fun ExamInformationScreen(
                     QuackBasicTextField(
                         text = state.examTitle,
                         onTextChanged = {
-                            if (state.examTitle.length <= ExamTitleMaxLength) {
-                                viewModel.setExamTitle(it)
-                            }
+                            viewModel.setExamTitle(
+                                it.takeBy(
+                                    ExamTitleMaxLength,
+                                    state.examTitle,
+                                ),
+                            )
                         },
                         placeholderText = stringResource(id = R.string.input_exam_title),
                         keyboardOptions = ImeActionNext,
@@ -172,9 +176,12 @@ internal fun ExamInformationScreen(
                             },
                         text = state.examDescription,
                         onTextChanged = {
-                            if (state.examDescription.length <= ExamDescriptionMaxLength) {
-                                viewModel.setExamDescription(it)
-                            }
+                            viewModel.setExamDescription(
+                                it.takeBy(
+                                    ExamDescriptionMaxLength,
+                                    state.examDescription,
+                                ),
+                            )
                         },
                         placeholderText = stringResource(id = R.string.input_exam_description),
                         imeAction = ImeAction.Next,
@@ -187,9 +194,12 @@ internal fun ExamInformationScreen(
                         modifier = Modifier.padding(bottom = 16.dp),
                         text = state.certifyingStatement,
                         onTextChanged = {
-                            if (state.certifyingStatement.length <= CertifyingStatementMaxLength) {
-                                viewModel.setCertifyingStatement(it)
-                            }
+                            viewModel.setCertifyingStatement(
+                                it.takeBy(
+                                    CertifyingStatementMaxLength,
+                                    state.certifyingStatement,
+                                ),
+                            )
                         },
                         placeholderText = stringResource(id = R.string.input_certifying_statement),
                         keyboardActions = KeyboardActions(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/SearchTagScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/SearchTagScreen.kt
@@ -163,7 +163,7 @@ internal fun SearchTagScreen(
                     )
                 }
                 itemsIndexed(
-                    items = state.searchResults,
+                    items = state.searchResults.fastMap { it.name },
                     key = { _, item -> item },
                 ) { index: Int, item: String ->
                     SearchResultText(

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -488,12 +488,6 @@ internal class CreateProblemViewModel @Inject constructor(
     ) = intent {
         val newQuestions = state.createProblem.questions.toMutableList()
         val prevQuestion = newQuestions[questionIndex]
-        val prevQuestionUrlSource = when (prevQuestion) {
-            is Question.Text -> ""
-            is Question.Image -> prevQuestion.imageUrl
-            is Question.Audio -> prevQuestion.audioUrl
-            is Question.Video -> prevQuestion.videoUrl
-        }
         val newQuestion = when (questionType) {
             Question.Type.Text -> Question.Text(
                 title ?: (prevQuestion.text),
@@ -501,17 +495,17 @@ internal class CreateProblemViewModel @Inject constructor(
 
             Question.Type.Image -> Question.Image(
                 title ?: prevQuestion.text,
-                urlSource ?: prevQuestionUrlSource,
+                urlSource ?: prevQuestion.mediaUri,
             )
 
             Question.Type.Audio -> Question.Audio(
                 title ?: prevQuestion.text,
-                urlSource ?: prevQuestionUrlSource,
+                urlSource ?: prevQuestion.mediaUri,
             )
 
             Question.Type.Video -> Question.Video(
                 title ?: prevQuestion.text,
-                urlSource ?: prevQuestionUrlSource,
+                urlSource ?: prevQuestion.mediaUri,
             )
 
             else -> null

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -395,6 +395,9 @@ internal class CreateProblemViewModel @Inject constructor(
     internal fun getExamThumbnail() = intent {
         // 이미 썸네일을 서버로부터 가져온 경우 별다른 처리를 하지 않는다.
         if (container.stateFlow.value.additionalInfo.thumbnail.toString().isNotEmpty()) {
+            reduce {
+                state.copy(createProblemStep = CreateProblemStep.CreateProblem)
+            }
             return@intent
         }
 

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -682,7 +682,7 @@ internal class CreateProblemViewModel @Inject constructor(
         urlSource: String?,
     ): Answer {
         return when (answerType) {
-            Answer.Type.ShortAnswer -> this.toShort(answer)
+            Answer.Type.ShortAnswer -> this.toShort()
             Answer.Type.Choice -> this.toChoice(answerIndex, answer)
             Answer.Type.ImageChoice -> this.toImageChoice(answerIndex, answer, urlSource)
         }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -129,7 +129,9 @@ internal class CreateProblemViewModel @Inject constructor(
                 intent {
                     getSearchUseCase(query = query, page = 1, type = Search.Tags)
                         .onSuccess {
-                            val searchResults = (it as Search.TagSearch).tags.toImmutableList()
+                            val searchResults = (it as Search.TagSearch).tags
+                                .take(TagsMaximumCount)
+                                .toImmutableList()
 
                             reduce {
                                 when (state.findResultType) {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -488,6 +488,12 @@ internal class CreateProblemViewModel @Inject constructor(
     ) = intent {
         val newQuestions = state.createProblem.questions.toMutableList()
         val prevQuestion = newQuestions[questionIndex]
+        val prevQuestionUrlSource = when (prevQuestion) {
+            is Question.Text -> ""
+            is Question.Image -> prevQuestion.imageUrl
+            is Question.Audio -> prevQuestion.audioUrl
+            is Question.Video -> prevQuestion.videoUrl
+        }
         val newQuestion = when (questionType) {
             Question.Type.Text -> Question.Text(
                 title ?: (prevQuestion.text),
@@ -495,17 +501,17 @@ internal class CreateProblemViewModel @Inject constructor(
 
             Question.Type.Image -> Question.Image(
                 title ?: prevQuestion.text,
-                "${urlSource ?: prevQuestion}",
+                urlSource ?: prevQuestionUrlSource,
             )
 
             Question.Type.Audio -> Question.Audio(
                 title ?: prevQuestion.text,
-                "${urlSource ?: prevQuestion}",
+                urlSource ?: prevQuestionUrlSource,
             )
 
             Question.Type.Video -> Question.Video(
                 title ?: prevQuestion.text,
-                "${urlSource ?: prevQuestion}",
+                urlSource ?: prevQuestionUrlSource,
             )
 
             else -> null

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -39,6 +39,7 @@ import team.duckie.app.android.domain.exam.model.Question
 import team.duckie.app.android.domain.exam.model.ThumbnailType
 import team.duckie.app.android.domain.exam.model.getDefaultAnswer
 import team.duckie.app.android.domain.exam.model.toChoice
+import team.duckie.app.android.domain.exam.model.toCorrectAnswerData
 import team.duckie.app.android.domain.exam.model.toImageChoice
 import team.duckie.app.android.domain.exam.model.toShort
 import team.duckie.app.android.domain.exam.usecase.GetExamThumbnailUseCase
@@ -60,7 +61,6 @@ import team.duckie.app.android.util.android.image.MediaUtil
 import team.duckie.app.android.util.kotlin.copy
 import team.duckie.app.android.util.kotlin.duckieClientLogicProblemException
 import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
-import team.duckie.app.android.util.kotlin.fastMap
 import team.duckie.app.android.util.kotlin.fastMapIndexed
 import team.duckie.app.android.util.ui.const.Extras
 import javax.inject.Inject
@@ -188,12 +188,16 @@ internal class CreateProblemViewModel @Inject constructor(
         val createProblemState = container.stateFlow.value.createProblem
         val additionalInfoState = container.stateFlow.value.additionalInfo
 
+        val serverCorrectAnswers =
+            createProblemState.correctAnswers.fastMapIndexed { index, correctAnswer ->
+                correctAnswer.toCorrectAnswerData(createProblemState.answers[index])
+            }
         val problems = createProblemState.questions.fastMapIndexed { index, question ->
             Problem(
                 index,
                 question,
                 createProblemState.answers[index],
-                createProblemState.correctAnswers[index],
+                serverCorrectAnswers[index],
                 createProblemState.hints[index],
                 createProblemState.memos[index],
             )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -93,7 +93,7 @@ internal data class CreateProblemState(
 }
 
 data class SearchScreenData(
-    val searchResults: ImmutableList<String> = persistentListOf(),
+    val searchResults: ImmutableList<Tag> = persistentListOf(),
     val textFieldValue: String = "",
     val results: ImmutableList<Tag> = persistentListOf(),
 )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -17,6 +17,7 @@ import team.duckie.app.android.domain.exam.model.ThumbnailType
 import team.duckie.app.android.domain.exam.model.getDefaultAnswer
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.user.model.User
+import team.duckie.app.android.feature.datastore.me
 import team.duckie.app.android.util.kotlin.duckieResponseFieldNpe
 
 internal data class CreateProblemState(
@@ -50,14 +51,11 @@ internal data class CreateProblemState(
                 category = selectedCategory?.name ?: duckieResponseFieldNpe("선택된 카테고리가 있어야 합니다."),
                 certifyingStatement = certifyingStatement,
                 mainTag = mainTag,
-                // TODO(riflockle7): 유저 데이터 활용 가능해질 시 처리 필요
-                nickName = "nickname",
+                nickName = me.nickname,
                 title = examTitle,
-                // TODO(riflockle7): 기획이 나오는대로 해당 값 처리 방법 구현해야 함
-                type = "text",
+                type = ThumbnailType.Text.value,
             )
 
-        // TODO(riflockle7):
         val selectedCategory: Category?
             get() = if (categorySelection == -1) {
                 null
@@ -95,13 +93,7 @@ internal data class CreateProblemState(
 }
 
 data class SearchScreenData(
-    val searchResults: ImmutableList<String> = persistentListOf(
-        // TODO(EvergreenTree97): Server Request
-        "도로",
-        "도로 주행",
-        "도로 셀카",
-        "도로 패션",
-    ),
+    val searchResults: ImmutableList<String> = persistentListOf(),
     val textFieldValue: String = "",
     val results: ImmutableList<Tag> = persistentListOf(),
 )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/state/CreateProblemState.kt
@@ -84,7 +84,7 @@ internal data class CreateProblemState(
     /** 문제 만들기 3단계 화면에서 사용하는 data 모음 */
     data class AdditionInfo(
         val thumbnail: Any = "",
-        val thumbnailType: ThumbnailType = ThumbnailType.Default,
+        val thumbnailType: ThumbnailType = ThumbnailType.Text,
         val takeTitle: String = "",
         val isSubTagsAdded: Boolean = false,
         val searchSubTags: SearchScreenData = SearchScreenData(),

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mapper/mapper.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mapper/mapper.kt
@@ -7,7 +7,6 @@
 
 package team.duckie.app.android.feature.ui.home.viewmodel.mapper
 
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.recommendation.model.RecommendationJumbotronItem
@@ -20,8 +19,7 @@ import team.duckie.app.android.util.kotlin.fastMap
 internal fun UserFollowing.toUiModel() =
     HomeState.RecommendUserByTopic(
         topic = category.name,
-        users = users?.fastMap(User::toUiModel)?.toPersistentList()
-            ?: persistentListOf(),
+        users = users.fastMap(User::toUiModel).toPersistentList(),
     )
 
 internal fun RecommendationJumbotronItem.toUiModel() =

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/solveproblem/DummyData.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/solveproblem/DummyData.kt
@@ -17,13 +17,12 @@ import team.duckie.app.android.domain.exam.model.ChoiceModel
 import team.duckie.app.android.domain.exam.model.ImageChoiceModel
 import team.duckie.app.android.domain.exam.model.Problem
 import team.duckie.app.android.domain.exam.model.Question
-import team.duckie.app.android.domain.exam.model.ShortModel
 
 val dummyList = persistentListOf(
     Problem(
         id = 0,
         question = Question.Text(text = "신카이 마코토 명작"),
-        answer = Answer.Short(answer = ShortModel("너의 이름은")), // TODO(EvergreenTree97) : shortModel의 text 사라질 예정 https://sungbinland.slack.com/archives/C046SS32SEQ/p1674473739721859?thread_ts=1674472301.086009&cid=C046SS32SEQ
+        answer = Answer.Short(),
         hint = null,
         memo = null,
         correctAnswer = "너의 이름은",

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/solveproblem/answer/AnswerSection.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/solveproblem/answer/AnswerSection.kt
@@ -90,7 +90,7 @@ internal fun LazyListScope.answerSection(
             item {
                 ShortAnswerForm(
                     modifier = Modifier.padding(paddingValues = HorizontalPadding),
-                    answer = answer.answer.text,
+                    answer = answer.correctAnswer,
                     onDone = { inputText -> // TODO(EvergreenTree97): 서버에 보낼 정답 text
                         onClickAnswer(
                             page,

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/solveproblem/screen/SolveProblemScreen.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/solveproblem/screen/SolveProblemScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.feature.ui.solve.problem.solveproblem.SolveProblemActivity
 import team.duckie.app.android.feature.ui.solve.problem.solveproblem.answer.answerSection
 import team.duckie.app.android.feature.ui.solve.problem.solveproblem.common.CloseAndPageTopBar
@@ -79,10 +80,17 @@ internal fun SolveProblemScreen(
                     question = state.problems[pageIndex].question,
                 )
                 // TODO(riflockle7): problem 엔티티 commit
+                val answer = state.problems[pageIndex].answer
                 answerSection(
                     page = pageIndex,
-                    answer = state.problems[pageIndex].answer
-                        ?: duckieResponseFieldNpe("null 이 되면 안됩니다."),
+                    answer = when (answer) {
+                        is Answer.Short -> Answer.Short(
+                            state.problems[pageIndex].correctAnswer
+                                ?: duckieResponseFieldNpe("null 이 되면 안됩니다."),
+                        )
+                        is Answer.Choice, is Answer.ImageChoice -> answer
+                        else -> duckieResponseFieldNpe("해당 분기로 빠질 수 없는 AnswerType 입니다.")
+                    },
                     inputAnswers = state.inputAnswers,
                     onClickAnswer = viewModel::inputAnswer,
                     onSolveProblem = viewModel::moveNextPage,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -233,6 +233,7 @@ jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", ver
 jackson-annotation = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson-core" }
 
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi-core" }
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi-core" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi-core" }
 
 orbit-viewmodel = { module = "org.orbit-mvi:orbit-viewmodel", version.ref = "orbit-core" }
@@ -265,6 +266,6 @@ compose-debug = ["compose-util-tooling-core", "compose-util-customview-pooling-c
 
 ktor-client = ["ktor-jackson", "ktor-client-core", "ktor-client-content-negotiation", "ktor-client-logging", "ktor-client-engine"]
 fuel = ["fuel-core", "fuel-moshi", "fuel-coroutines"]
-moshi = ["moshi-core", "moshi-kotlin"]
+moshi = ["moshi-core", "moshi-kotlin", "moshi-adapters"]
 
 quack-lint = ["quack-lint-core", "quack-lint-quack", "quack-lint-compose"]

--- a/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/strings.kt
+++ b/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/strings.kt
@@ -19,3 +19,15 @@ inline val Number.percents: String
         this is Double -> "${(this * 100).toInt()}%"
         else -> "$this%"
     }
+
+/**
+ * 현재 문자열에서 [최대 허용 길이][maximumLength] 만큼의 문자열을 반환한다.
+ * [최대 허용 길이][maximumLength] 를 넘을 시 [이전 값][prevValue]을 반환한다.
+ */
+fun String.takeBy(maximumLength: Int, prevValue: String): String {
+    return if (this.length > maximumLength) {
+        prevValue
+    } else {
+        this.take(maximumLength)
+    }
+}


### PR DESCRIPTION
- 문제 만들기 화면에서 문제 만들 수 있도록 해놓았습니다. (백앤드 분들의 도움으로 문제를 찾을 수 있었습니다 🙇 )
- 불안정한 내용 태그 걸린 항목은 작업을 미뤘었는데, 검색의 경우엔 사용하는 곳이 꽤 많아 해당 내용 작업도 여기서 진행했습니다.
  (별도로 분리하려 했는데 시간이 촉박할 듯 하여 일단 한 번에 작업 진행했습니다 🙏 )
- 기타 Moshi 적용, 백앤드 변경사항 미반영 내용 마저 반영했습니다.