### PR TITLE
문제 만들기 화면 오류 수정

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/recommendation/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/recommendation/repository/RecommendationRepositoryImpl.kt
@@ -71,7 +71,6 @@ class RecommendationRepositoryImpl @Inject constructor(
             )
         }
 
-    // TODO(riflockle7): GET /recommendations API commit
     @ExperimentalApi
     override suspend fun fetchJumbotrons(page: Int): ImmutableList<Exam> =
         withContext(Dispatchers.IO) {

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/CreateProblemBottomLayout.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/common/CreateProblemBottomLayout.kt
@@ -95,7 +95,7 @@ internal fun CreateProblemBottomLayout(
     tempSaveButtonClick: (() -> Unit)? = null,
     nextButtonText: String,
     nextButtonClick: () -> Unit,
-    isProblemCountValidate: Boolean? = null,
+    isCreateProblemValidate: Boolean? = null,
     isValidateCheck: () -> Boolean,
 ) {
     val isValidate = isValidateCheck()
@@ -107,12 +107,12 @@ internal fun CreateProblemBottomLayout(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             leftButtonClick?.let { createButtonClick ->
-                requireNotNull(isProblemCountValidate)
+                requireNotNull(isCreateProblemValidate)
                 requireNotNull(leftButtonText)
                 Row(
                     modifier = Modifier
                         .quackClickable {
-                            if (!isProblemCountValidate) {
+                            if (isCreateProblemValidate) {
                                 createButtonClick()
                             }
                         }
@@ -122,7 +122,7 @@ internal fun CreateProblemBottomLayout(
                     leftButtonLeadingIcon?.let { QuackImage(src = it, size = DpSize(16.dp, 16.dp)) }
                     QuackSubtitle2(
                         text = leftButtonText,
-                        color = if (isProblemCountValidate) QuackColor.Gray2 else QuackColor.Black,
+                        color = if (isCreateProblemValidate) QuackColor.Black else QuackColor.Gray2,
                     )
                 }
             }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -104,7 +104,6 @@ private const val BottomLayoutId = "CreateProblemScreenBottomLayoutId"
 private const val GalleryListLayoutId = "CreateProblemScreenGalleryListLayoutId"
 
 private const val MaximumChoice = 5
-private const val MinimumProblem = 5
 private const val MaximumProblem = 10
 private const val TextFieldMaxLength = 20
 

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -501,7 +501,7 @@ internal fun CreateProblemScreen(
                             vm.navigateStep(CreateProblemStep.AdditionalInformation)
                         }
                     },
-                    isProblemCountValidate = problemCount in MinimumProblem..MaximumProblem,
+                    isCreateProblemValidate = problemCount < MaximumProblem,
                     isValidateCheck = vm::createProblemIsValidate,
                 )
             },

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -801,6 +801,7 @@ internal class CreateProblemViewModel @Inject constructor(
     /** 문제 만들기 2단계 화면의 유효성을 체크한다. */
     internal fun createProblemIsValidate(): Boolean {
         return with(container.stateFlow.value.createProblem) {
+            val examCountValidate = this.questions.size in 5..10
             val questionsValidate = this.questions.asSequence()
                 .map { it.validate() }
                 .reduce { acc, next -> acc && next }
@@ -811,7 +812,7 @@ internal class CreateProblemViewModel @Inject constructor(
                 .map { it.isNotEmpty() }
                 .reduce { acc, next -> acc && next }
 
-            questionsValidate && answersValidate && correctAnswersValidate
+            examCountValidate && questionsValidate && answersValidate && correctAnswersValidate
         }
     }
 

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -70,6 +70,8 @@ import team.duckie.app.android.util.ui.const.Extras
 import javax.inject.Inject
 
 private const val TagsMaximumCount = 4
+private const val MinimumProblem = 5
+private const val MaximumProblem = 10
 
 @HiltViewModel
 @Suppress("LargeClass")
@@ -801,7 +803,7 @@ internal class CreateProblemViewModel @Inject constructor(
     /** 문제 만들기 2단계 화면의 유효성을 체크한다. */
     internal fun createProblemIsValidate(): Boolean {
         return with(container.stateFlow.value.createProblem) {
-            val examCountValidate = this.questions.size in 5..10
+            val examCountValidate = this.questions.size in MinimumProblem..MaximumProblem
             val questionsValidate = this.questions.asSequence()
                 .map { it.validate() }
                 .reduce { acc, next -> acc && next }

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -866,7 +866,7 @@ internal class CreateProblemViewModel @Inject constructor(
     /** 문제 만들기 3단계 화면의 유효성을 체크한다. */
     private fun additionInfoIsValidate(): Boolean {
         return with(container.stateFlow.value.additionalInfo) {
-            thumbnail.toString().isNotEmpty()
+            thumbnail.toString().isNotEmpty() && takeTitle.isNotEmpty()
         }
     }
 

--- a/feature-ui-detail/src/main/kotlin/team/duckie/app/android/feature/ui/detail/screen/DetailScreen.kt
+++ b/feature-ui-detail/src/main/kotlin/team/duckie/app/android/feature/ui/detail/screen/DetailScreen.kt
@@ -344,7 +344,7 @@ private fun DetailProfileLayout(
         }
         // 공백
         Spacer(modifier = Modifier.weight(1f))
-        // TODO(riflockle7): 추후 팔로우 완료 시에 대한 처리 필요
+
         // 팔로우 버튼
         QuackBody2(
             padding = PaddingValues(


### PR DESCRIPTION
문제 만들기 오류를 수정했습니다
1. 5개 미만일 시 다음 화면으로 넘어가는 내용
2. 시험 시작 버튼 텍스트 유효성추가
3. 태그 검색결과 노출 수 수정 (4 -> 10개)