### PR TITLE
문제 만들기 화면 태그 검색 결과 최대 개수 조정

### DIFF
--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -69,7 +69,7 @@ import team.duckie.app.android.util.kotlin.fastMapIndexed
 import team.duckie.app.android.util.ui.const.Extras
 import javax.inject.Inject
 
-private const val TagsMaximumCount = 4
+private const val TagsMaximumCount = 10
 private const val MinimumProblem = 5
 private const val MaximumProblem = 10
 


### PR DESCRIPTION
4개에서 10개로 수정했습니다.