### PR TITLE
resolve #325

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/recommendation/repository/RecommendationRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/recommendation/repository/RecommendationRepositoryImpl.kt
@@ -71,7 +71,7 @@ class RecommendationRepositoryImpl @Inject constructor(
         }
 
     @ExperimentalApi
-    override suspend fun fetchJumbotrons(page: Int): ImmutableList<Exam> =
+    override suspend fun fetchJumbotrons(): ImmutableList<Exam> =
         withContext(Dispatchers.IO) {
             val (_, response) = fuel
                 .get(

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/recommendation/repository/RecommendationRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/recommendation/repository/RecommendationRepository.kt
@@ -19,5 +19,5 @@ import team.duckie.app.android.domain.recommendation.model.RecommendationItem
 interface RecommendationRepository {
     fun fetchRecommendations(): Flow<PagingData<RecommendationItem>>
 
-    suspend fun fetchJumbotrons(page: Int): ImmutableList<Exam>
+    suspend fun fetchJumbotrons(): ImmutableList<Exam>
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/recommendation/usecase/FetchJumbotronsUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/recommendation/usecase/FetchJumbotronsUseCase.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class FetchJumbotronsUseCase @Inject constructor(
     private val repository: RecommendationRepository,
 ) {
-    suspend operator fun invoke(page: Int = 1) = runCatching {
-        repository.fetchJumbotrons(page = page)
+    suspend operator fun invoke() = runCatching {
+        repository.fetchJumbotrons()
     }
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/recommendation/usecase/FetchRecommendationsUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/recommendation/usecase/FetchRecommendationsUseCase.kt
@@ -15,6 +15,6 @@ import javax.inject.Inject
 class FetchRecommendationsUseCase @Inject constructor(
     private val repository: RecommendationRepository,
 ) {
-    operator fun invoke() =
+    suspend operator fun invoke() =
         repository.fetchRecommendations()
 }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeActivity.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeActivity.kt
@@ -109,7 +109,7 @@ class HomeActivity : BaseActivity() {
                         // TODO(limsaehyun): 추후에 QuackCrossfade 로 교체 필요
                         Crossfade(
                             modifier = Modifier.layoutId(HomeCrossFacadeLayoutId),
-                            targetState = state.step,
+                            targetState = state.bottomNavigationStep,
                         ) { page ->
                             when (page) {
                                 BottomNavigationStep.HomeScreen -> DuckieHomeScreen()
@@ -141,7 +141,7 @@ class HomeActivity : BaseActivity() {
                         )
                         DuckTestBottomNavigation(
                             modifier = Modifier.layoutId(HomeBottomNavigationViewLayoutId),
-                            selectedIndex = state.step.index,
+                            selectedIndex = state.bottomNavigationStep.index,
                             onClick = { index ->
                                 homeViewModel.navigationPage(
                                     BottomNavigationStep.toStep(index),

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendExamScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendExamScreen.kt
@@ -62,7 +62,7 @@ internal fun HomeRecommendExamScreen(
     val homeLoadingMypageToastMessage = stringResource(id = R.string.home_loading_mypage_toast)
 
     LaunchedEffect(Unit) {
-        vm.fetchRecommendFollowingTest()
+        vm.fetchRecommendExam()
     }
 
     LazyColumn(

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendExamScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendExamScreen.kt
@@ -8,7 +8,6 @@
 package team.duckie.app.android.feature.ui.home.screen
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,11 +15,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -30,36 +27,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import kotlinx.collections.immutable.ImmutableList
 import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.feature.ui.home.R
 import team.duckie.app.android.feature.ui.home.component.HomeTopAppBar
 import team.duckie.app.android.feature.ui.home.constants.HomeStep
 import team.duckie.app.android.feature.ui.home.viewmodel.HomeViewModel
-import team.duckie.app.android.feature.ui.home.viewmodel.state.HomeState
-import team.duckie.app.android.shared.ui.compose.DuckieCircularProgressIndicator
-import team.duckie.app.android.shared.ui.compose.UserFollowingLayout
+import team.duckie.app.android.shared.ui.compose.skeleton
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.compose.rememberToast
-import team.duckie.app.android.util.kotlin.fastForEach
-import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody3
-import team.duckie.quackquack.ui.component.QuackDivider
-import team.duckie.quackquack.ui.component.QuackHeadLine2
 import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.component.QuackSubtitle2
-import team.duckie.quackquack.ui.component.QuackTitle2
 import team.duckie.quackquack.ui.modifier.quackClickable
 import team.duckie.quackquack.ui.shape.SquircleShape
 import team.duckie.quackquack.ui.util.DpSize
 
+internal const val ThumbnailRatio = 4f / 3f
+
+private val HomeProfileSize: DpSize = DpSize(
+    all = 24.dp,
+)
+
 @Composable
-internal fun HomeRecommendFollowingTestScreen(
+internal fun HomeRecommendExamScreen(
     modifier: Modifier = Modifier,
     vm: HomeViewModel = activityViewModel(),
 ) {
@@ -69,10 +63,6 @@ internal fun HomeRecommendFollowingTestScreen(
 
     LaunchedEffect(Unit) {
         vm.fetchRecommendFollowingTest()
-    }
-
-    QuackAnimatedVisibility(visible = state.isHomeLoading) {
-        DuckieCircularProgressIndicator()
     }
 
     LazyColumn(
@@ -93,7 +83,7 @@ internal fun HomeRecommendFollowingTestScreen(
         }
 
         itemsIndexed(
-            items = state.recommendFollowingTest,
+            items = state.recommendExam,
         ) { _, maker ->
             TestCoverWithMaker(
                 profile = maker.owner.profileImgUrl,
@@ -102,108 +92,18 @@ internal fun HomeRecommendFollowingTestScreen(
                 tier = maker.owner.tier,
                 favoriteTag = maker.owner.favoriteTag,
                 onClickUserProfile = {
-                    // TODO(limsaehyun): 유저의 profile 로 이동
+                    // TODO(limsaehyun): 마이페이지로 이동
                     toast.invoke(homeLoadingMypageToastMessage)
                 },
                 onClickTestCover = {
                     vm.navigateToHomeDetail(maker.examId)
                 },
                 cover = maker.coverUrl,
+                isLoading = state.isHomeRecommendExamLoading,
             )
         }
     }
 }
-
-@Composable
-internal fun HomeRecommendFollowingScreen(
-    modifier: Modifier = Modifier,
-    vm: HomeViewModel = activityViewModel(),
-) {
-    val state = vm.collectAsState().value
-
-    LaunchedEffect(Unit) {
-        vm.fetchRecommendFollowing()
-    }
-
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-    ) {
-        item {
-            HomeTopAppBar(
-                selectedTabIndex = state.homeSelectedIndex.index,
-                onTabSelected = { step ->
-                    vm.changedHomeScreen(HomeStep.toStep(step))
-                },
-                onClickedCreate = {
-                    vm.navigateToCreateProblem()
-                },
-            )
-        }
-
-        item {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(164.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                QuackHeadLine2(
-                    text = stringResource(id = R.string.home_following_initial_title),
-                    align = TextAlign.Center,
-                )
-            }
-        }
-
-        items(
-            items = state.recommendFollowing,
-        ) { categories ->
-            HomeFollowingInitialRecommendUsers(
-                modifier = Modifier.padding(bottom = 16.dp),
-                topic = categories.topic,
-                recommendUser = categories.users,
-                onClickFollowing = { userId, isFollowing ->
-                    vm.followUser(userId, isFollowing)
-                },
-            )
-        }
-    }
-}
-
-@Composable
-private fun HomeFollowingInitialRecommendUsers(
-    modifier: Modifier = Modifier,
-    topic: String,
-    recommendUser: ImmutableList<HomeState.RecommendUserByTopic.User>,
-    onClickFollowing: (Int, Boolean) -> Unit,
-) {
-    Column(
-        modifier = modifier,
-    ) {
-        QuackDivider()
-        QuackTitle2(
-            modifier = Modifier.padding(
-                top = 24.dp,
-                bottom = 12.dp,
-            ),
-            text = topic,
-        )
-        recommendUser.fastForEach { user ->
-            UserFollowingLayout(
-                userId = user.userId,
-                profileImgUrl = user.profileImgUrl,
-                nickname = user.nickname,
-                favoriteTag = user.favoriteTag,
-                tier = user.tier,
-                isFollowing = user.isFollowing,
-                onClickFollow = {
-                    onClickFollowing(user.userId, it)
-                },
-            )
-        }
-    }
-}
-
-internal const val ThumbnailRatio = 4f / 3f
 
 @Composable
 private fun TestCoverWithMaker(
@@ -216,6 +116,7 @@ private fun TestCoverWithMaker(
     favoriteTag: String,
     onClickTestCover: () -> Unit,
     onClickUserProfile: () -> Unit,
+    isLoading: Boolean,
 ) {
     Column(
         modifier = modifier,
@@ -227,7 +128,8 @@ private fun TestCoverWithMaker(
                 .clip(RoundedCornerShape(8.dp))
                 .quackClickable {
                     onClickTestCover()
-                },
+                }
+                .skeleton(isLoading),
             model = cover,
             contentDescription = null,
             contentScale = ContentScale.FillBounds,
@@ -240,13 +142,10 @@ private fun TestCoverWithMaker(
             tier = tier,
             favoriteTag = favoriteTag,
             onClickUserProfile = onClickUserProfile,
+            isLoading = isLoading,
         )
     }
 }
-
-private val HomeProfileSize: DpSize = DpSize(
-    all = 24.dp,
-)
 
 @Composable
 private fun TestMakerLayout(
@@ -256,6 +155,7 @@ private fun TestMakerLayout(
     name: String,
     tier: String,
     favoriteTag: String,
+    isLoading: Boolean,
     onClickUserProfile: (() -> Unit)? = null,
 ) {
     Row(
@@ -263,6 +163,7 @@ private fun TestMakerLayout(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         QuackImage(
+            modifier = Modifier.skeleton(isLoading),
             src = profile,
             size = HomeProfileSize,
             shape = SquircleShape,
@@ -273,11 +174,18 @@ private fun TestMakerLayout(
             },
         )
         Column(modifier = Modifier.padding(start = 8.dp)) {
-            QuackSubtitle2(text = title)
+            QuackSubtitle2(
+                modifier = Modifier.skeleton(isLoading),
+                text = title,
+            )
             Row(modifier = Modifier.padding(top = 4.dp)) {
-                QuackBody3(text = name)
+                QuackBody3(
+                    modifier = Modifier.skeleton(isLoading),
+                    text = name,
+                )
                 Spacer(modifier = Modifier.width(8.dp))
                 QuackBody3(
+                    modifier = Modifier.skeleton(isLoading),
                     text = "$tier · $favoriteTag",
                     color = QuackColor.Gray2,
                 )

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendFollowingExamScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendFollowingExamScreen.kt
@@ -53,7 +53,7 @@ private val HomeProfileSize: DpSize = DpSize(
 )
 
 @Composable
-internal fun HomeRecommendExamScreen(
+internal fun HomeRecommendFollowingExamScreen(
     modifier: Modifier = Modifier,
     vm: HomeViewModel = activityViewModel(),
 ) {
@@ -62,7 +62,7 @@ internal fun HomeRecommendExamScreen(
     val homeLoadingMypageToastMessage = stringResource(id = R.string.home_loading_mypage_toast)
 
     LaunchedEffect(Unit) {
-        vm.fetchRecommendExam()
+        vm.fetchRecommendFollowingExam()
     }
 
     LazyColumn(
@@ -83,7 +83,7 @@ internal fun HomeRecommendExamScreen(
         }
 
         itemsIndexed(
-            items = state.recommendExam,
+            items = state.recommendFollowingExam,
         ) { _, maker ->
             TestCoverWithMaker(
                 profile = maker.owner.profileImgUrl,
@@ -99,7 +99,7 @@ internal fun HomeRecommendExamScreen(
                     vm.navigateToHomeDetail(maker.examId)
                 },
                 cover = maker.coverUrl,
-                isLoading = state.isHomeRecommendExamLoading,
+                isLoading = state.isHomeRecommendFollowingExamLoading,
             )
         }
     }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendFollowingScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendFollowingScreen.kt
@@ -1,0 +1,126 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.home.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.feature.ui.home.R
+import team.duckie.app.android.feature.ui.home.component.HomeTopAppBar
+import team.duckie.app.android.feature.ui.home.constants.HomeStep
+import team.duckie.app.android.feature.ui.home.viewmodel.HomeViewModel
+import team.duckie.app.android.feature.ui.home.viewmodel.state.HomeState
+import team.duckie.app.android.shared.ui.compose.UserFollowingLayout
+import team.duckie.app.android.util.compose.activityViewModel
+import team.duckie.app.android.util.kotlin.fastForEach
+import team.duckie.quackquack.ui.component.QuackDivider
+import team.duckie.quackquack.ui.component.QuackHeadLine2
+import team.duckie.quackquack.ui.component.QuackTitle2
+
+@Composable
+internal fun HomeRecommendFollowingScreen(
+    modifier: Modifier = Modifier,
+    vm: HomeViewModel = activityViewModel(),
+) {
+    val state = vm.collectAsState().value
+
+    LaunchedEffect(Unit) {
+        vm.fetchRecommendFollowing()
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        item {
+            HomeTopAppBar(
+                selectedTabIndex = state.homeSelectedIndex.index,
+                onTabSelected = { step ->
+                    vm.changedHomeScreen(HomeStep.toStep(step))
+                },
+                onClickedCreate = {
+                    vm.navigateToCreateProblem()
+                },
+            )
+        }
+
+        item {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(164.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                QuackHeadLine2(
+                    text = stringResource(id = R.string.home_following_initial_title),
+                    align = TextAlign.Center,
+                )
+            }
+        }
+
+        items(
+            items = state.recommendFollowing,
+        ) { categories ->
+            HomeFollowingInitialRecommendUsers(
+                modifier = Modifier.padding(bottom = 16.dp),
+                topic = categories.topic,
+                recommendUser = categories.users,
+                onClickFollowing = { userId, isFollowing ->
+                    vm.followUser(userId, isFollowing)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeFollowingInitialRecommendUsers(
+    modifier: Modifier = Modifier,
+    topic: String,
+    recommendUser: ImmutableList<HomeState.RecommendUserByTopic.User>,
+    onClickFollowing: (Int, Boolean) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        QuackDivider()
+        QuackTitle2(
+            modifier = Modifier.padding(
+                top = 24.dp,
+                bottom = 12.dp,
+            ),
+            text = topic,
+        )
+        recommendUser.fastForEach { user ->
+            UserFollowingLayout(
+                userId = user.userId,
+                profileImgUrl = user.profileImgUrl,
+                nickname = user.nickname,
+                favoriteTag = user.favoriteTag,
+                tier = user.tier,
+                isFollowing = user.isFollowing,
+                onClickFollow = {
+                    onClickFollowing(user.userId, it)
+                },
+            )
+        }
+    }
+}

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -67,7 +67,7 @@ import team.duckie.quackquack.ui.component.QuackLargeButtonType
 
 private val HomeHorizontalPadding = PaddingValues(horizontal = 16.dp)
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
 internal fun HomeRecommendScreen(
     modifier: Modifier = Modifier,
@@ -81,7 +81,7 @@ internal fun HomeRecommendScreen(
     val pullRefreshState = rememberPullRefreshState(
         refreshing = state.isHomeRecommendLoading,
         onRefresh = {
-            vm.fetchRecommendFollowing()
+            vm.fetchRecommendFollowing(forcedLoading = true)
         },
     )
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -79,7 +79,7 @@ internal fun HomeRecommendScreen(
     val lazyRecommendations = vm.recommendations.collectAsLazyPagingItems()
 
     val pullRefreshState = rememberPullRefreshState(
-        refreshing = state.isHomeRecommendLoading,
+        refreshing = state.isHomeRecommendPullRefreshLoading,
         onRefresh = {
             vm.refreshRecommendations(forceLoading = true)
         },
@@ -157,7 +157,7 @@ internal fun HomeRecommendScreen(
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = state.isHomeRecommendLoading,
+            refreshing = state.isHomeRecommendPullRefreshLoading,
             state = pullRefreshState,
         )
     }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -31,8 +31,6 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -81,7 +79,7 @@ internal fun HomeRecommendScreen(
     val lazyRecommendations = vm.recommendations.collectAsLazyPagingItems()
 
     val pullRefreshState = rememberPullRefreshState(
-        refreshing = state.isHomeLoading,
+        refreshing = state.isHomeRecommendLoading,
         onRefresh = {
             vm.fetchRecommendFollowing()
         },
@@ -124,7 +122,7 @@ internal fun HomeRecommendScreen(
                                 examId = examId,
                             )
                         },
-                        isLoading = state.isHomeLoading,
+                        isLoading = state.isHomeRecommendLoading,
                     )
                 }
             }
@@ -153,13 +151,13 @@ internal fun HomeRecommendScreen(
                     exams = item?.exams?.toImmutableList() ?: persistentListOf(),
                     onExamClicked = { examId -> vm.navigateToHomeDetail(examId) },
                     onTagClicked = { tag -> vm.navigateToSearch(tag) },
-                    isLoading = state.isHomeLoading,
+                    isLoading = state.isHomeRecommendLoading,
                 )
             }
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = state.isHomeLoading,
+            refreshing = state.isHomeRecommendLoading,
             state = pullRefreshState,
         )
     }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeRecommendScreen.kt
@@ -81,7 +81,7 @@ internal fun HomeRecommendScreen(
     val pullRefreshState = rememberPullRefreshState(
         refreshing = state.isHomeRecommendLoading,
         onRefresh = {
-            vm.fetchRecommendFollowing(forcedLoading = true)
+            vm.refreshRecommendations(forceLoading = true)
         },
     )
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeScreen.kt
@@ -41,7 +41,7 @@ internal fun DuckieHomeScreen(
                 }
                 HomeStep.HomeFollowingScreen -> {
                     if (state.isFollowingExist) {
-                        HomeRecommendFollowingTestScreen(
+                        HomeRecommendExamScreen(
                             modifier = Modifier.padding(HomeHorizontalPadding),
                         )
                     } else {

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/HomeScreen.kt
@@ -41,7 +41,7 @@ internal fun DuckieHomeScreen(
                 }
                 HomeStep.HomeFollowingScreen -> {
                     if (state.isFollowingExist) {
-                        HomeRecommendExamScreen(
+                        HomeRecommendFollowingExamScreen(
                             modifier = Modifier.padding(HomeHorizontalPadding),
                         )
                     } else {

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/search/SearchMainScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/search/SearchMainScreen.kt
@@ -51,7 +51,6 @@ internal fun SearchMainScreen(
 
     LaunchedEffect(Unit) {
         vm.fetchPopularTags()
-        vm.fetchRecentExam()
     }
 
     Column(

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/HomeViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/HomeViewModel.kt
@@ -100,10 +100,10 @@ internal class HomeViewModel @Inject constructor(
         forceLoading: Boolean = false,
     ) {
         viewModelScope.launch {
-            updateHomeRecommendLoading(true)
+            updateHomeRecommendPullRefreshLoading(true)
             fetchRecommendations()
             if (forceLoading) delay(pullToRefreshMinLoadingDelay)
-            updateHomeRecommendLoading(false)
+            updateHomeRecommendPullRefreshLoading(false)
         }
     }
 
@@ -241,6 +241,17 @@ internal class HomeViewModel @Inject constructor(
     ) = intent {
         reduce {
             state.copy(isHomeRecommendFollowingExamLoading = loading)
+        }
+    }
+
+    private fun updateHomeRecommendPullRefreshLoading(
+        loading: Boolean,
+    ) = intent {
+        reduce {
+            state.copy(
+                isHomeRecommendPullRefreshLoading = loading,
+                isHomeRecommendLoading = loading, // 스캘레톤 UI를 위해 업데이트
+            )
         }
     }
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/HomeViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/HomeViewModel.kt
@@ -92,7 +92,7 @@ internal class HomeViewModel @Inject constructor(
 
     /** 홈 화면의 jumbotron을 가져온다. */
     private fun fetchJumbotrons() = intent {
-        updateHomeLoading(true)
+        updateHomeRecommendLoading(true)
         fetchJumbotronsUseCase()
             .onSuccess { jumbotrons ->
                 reduce {
@@ -105,7 +105,7 @@ internal class HomeViewModel @Inject constructor(
             }.onFailure { exception ->
                 postSideEffect(HomeSideEffect.ReportError(exception))
             }.also {
-                updateHomeLoading(false)
+                updateHomeRecommendLoading(false)
             }
     }
 
@@ -123,12 +123,12 @@ internal class HomeViewModel @Inject constructor(
 
     /** 팔로워들의 추천 덕질고사들을 가져온다. */
     fun fetchRecommendFollowingTest() = intent {
-        updateHomeLoading(true)
+        updateHomeRecommendFollowingLoading(true)
         fetchExamMeFollowingUseCase()
             .onSuccess { exams ->
                 reduce {
                     state.copy(
-                        recommendFollowingTest = exams
+                        recommendExam = exams
                             .fastMap(Exam::toFollowingModel)
                             .toPersistentList(),
                     )
@@ -145,13 +145,13 @@ internal class HomeViewModel @Inject constructor(
                 }
                 postSideEffect(HomeSideEffect.ReportError(exception))
             }.also {
-                updateHomeLoading(false)
+                updateHomeRecommendFollowingLoading(false)
             }
     }
 
     /** 추천 팔로워들을 가져온다. */
     fun fetchRecommendFollowing() = intent {
-        updateHomeLoading(true)
+        updateHomeRecommendLoading(true)
         fetchUserFollowingUseCase(requireNotNull(state.me?.id))
             .onSuccess { userFollowing ->
                 reduce {
@@ -172,7 +172,7 @@ internal class HomeViewModel @Inject constructor(
                 }
                 postSideEffect(HomeSideEffect.ReportError(exception))
             }.also {
-                updateHomeLoading(false)
+                updateHomeRecommendLoading(false)
             }
     }
 
@@ -221,14 +221,21 @@ internal class HomeViewModel @Inject constructor(
             }
     }
 
-    /** 홈 화면의 로딩 상태를 [loading]으로 바꿉니다. */
-    private fun updateHomeLoading(
+    /** 홈 화면의 추천 탭의 로딩 상태를 [loading]으로 바꿉니다. */
+    private fun updateHomeRecommendLoading(
         loading: Boolean,
     ) = intent {
         reduce {
-            state.copy(
-                isHomeLoading = loading,
-            )
+            state.copy(isHomeRecommendLoading = loading)
+        }
+    }
+
+    /** 홈 화면의 팔로잉 탭의 로딩 상태를 [loading]으로 바꿉니다. */
+    private fun updateHomeRecommendFollowingLoading(
+        loading: Boolean,
+    ) = intent {
+        reduce {
+            state.copy(isHomeRecommendExamLoading = loading)
         }
     }
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/dummy/SkeletonData.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/dummy/SkeletonData.kt
@@ -8,6 +8,7 @@
 package team.duckie.app.android.feature.ui.home.viewmodel.dummy
 
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.recommendation.model.ExamType
 import team.duckie.app.android.domain.recommendation.model.RecommendationItem
@@ -40,3 +41,12 @@ internal val skeletonRecommendationItems = listOf(
         ),
     ),
 )
+
+internal val skeletonRecommendExam = (0..2).map {
+    HomeState.RecommendExam(
+        coverUrl = "",
+        title = randomString(12),
+        examId = 1,
+        owner = HomeState.RecommendExam.User.empty().copy(nickname = randomString(3)),
+    )
+}.toPersistentList()

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mapper/mapper.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mapper/mapper.kt
@@ -41,11 +41,11 @@ internal fun User.toUiModel() =
     )
 
 internal fun Exam.toFollowingModel() =
-    HomeState.FollowingTest(
+    HomeState.RecommendExam(
         coverUrl = thumbnailUrl,
         title = title,
         examId = this.id,
-        owner = HomeState.FollowingTest.User(
+        owner = HomeState.RecommendExam.User(
             nickname = user?.nickname ?: "",
             profileImgUrl = user?.profileImageUrl ?: "",
             favoriteTag = user?.duckPower?.tag?.name ?: "",

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
@@ -8,12 +8,9 @@
 package team.duckie.app.android.feature.ui.home.viewmodel.state
 
 import androidx.compose.runtime.Immutable
-import androidx.paging.PagingData
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import team.duckie.app.android.domain.exam.model.ExamInfo
 import team.duckie.app.android.domain.recommendation.model.ExamType
-import team.duckie.app.android.domain.recommendation.model.RecommendationItem
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.feature.ui.home.constants.BottomNavigationStep
@@ -25,7 +22,7 @@ internal data class HomeState(
     val me: User? = null,
 
     val isHomeRecommendLoading: Boolean = false,
-    val isHomeRecommendExamLoading: Boolean = false,
+    val isHomeRecommendFollowingExamLoading: Boolean = false,
 
     val bottomNavigationStep: BottomNavigationStep = BottomNavigationStep.HomeScreen,
     val homeSelectedIndex: HomeStep = HomeStep.HomeRecommendScreen,
@@ -35,7 +32,7 @@ internal data class HomeState(
 
     val isFollowingExist: Boolean = true,
     val recommendFollowing: ImmutableList<RecommendUserByTopic> = persistentListOf(),
-    val recommendExam: ImmutableList<RecommendExam> = skeletonRecommendExam,
+    val recommendFollowingExam: ImmutableList<RecommendExam> = skeletonRecommendExam,
 
     val popularTags: ImmutableList<Tag> = persistentListOf(),
 ) {

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
@@ -24,6 +24,8 @@ internal data class HomeState(
     val isHomeRecommendLoading: Boolean = false,
     val isHomeRecommendFollowingExamLoading: Boolean = false,
 
+    val isHomeRecommendPullRefreshLoading: Boolean = false,
+
     val bottomNavigationStep: BottomNavigationStep = BottomNavigationStep.HomeScreen,
     val homeSelectedIndex: HomeStep = HomeStep.HomeRecommendScreen,
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
@@ -23,10 +23,11 @@ import team.duckie.app.android.feature.ui.home.viewmodel.dummy.skeletonRecommend
 
 internal data class HomeState(
     val me: User? = null,
+
     val isHomeRecommendLoading: Boolean = false,
     val isHomeRecommendExamLoading: Boolean = false,
 
-    val step: BottomNavigationStep = BottomNavigationStep.HomeScreen,
+    val bottomNavigationStep: BottomNavigationStep = BottomNavigationStep.HomeScreen,
     val homeSelectedIndex: HomeStep = HomeStep.HomeRecommendScreen,
 
     val jumbotrons: ImmutableList<HomeRecommendJumbotron> = skeletonJumbotrons,
@@ -35,10 +36,6 @@ internal data class HomeState(
     val isFollowingExist: Boolean = true,
     val recommendFollowing: ImmutableList<RecommendUserByTopic> = persistentListOf(),
     val recommendExam: ImmutableList<RecommendExam> = skeletonRecommendExam,
-
-    val recommendations: PagingData<RecommendationItem> = PagingData.empty(),
-
-    val recentExam: ImmutableList<ExamInfo> = persistentListOf(),
 
     val popularTags: ImmutableList<Tag> = persistentListOf(),
 ) {

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/state/HomeState.kt
@@ -19,10 +19,12 @@ import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.feature.ui.home.constants.BottomNavigationStep
 import team.duckie.app.android.feature.ui.home.constants.HomeStep
 import team.duckie.app.android.feature.ui.home.viewmodel.dummy.skeletonJumbotrons
+import team.duckie.app.android.feature.ui.home.viewmodel.dummy.skeletonRecommendExam
 
 internal data class HomeState(
     val me: User? = null,
-    val isHomeLoading: Boolean = false,
+    val isHomeRecommendLoading: Boolean = false,
+    val isHomeRecommendExamLoading: Boolean = false,
 
     val step: BottomNavigationStep = BottomNavigationStep.HomeScreen,
     val homeSelectedIndex: HomeStep = HomeStep.HomeRecommendScreen,
@@ -32,7 +34,7 @@ internal data class HomeState(
 
     val isFollowingExist: Boolean = true,
     val recommendFollowing: ImmutableList<RecommendUserByTopic> = persistentListOf(),
-    val recommendFollowingTest: ImmutableList<FollowingTest> = persistentListOf(),
+    val recommendExam: ImmutableList<RecommendExam> = skeletonRecommendExam,
 
     val recommendations: PagingData<RecommendationItem> = PagingData.empty(),
 
@@ -41,14 +43,14 @@ internal data class HomeState(
     val popularTags: ImmutableList<Tag> = persistentListOf(),
 ) {
     /**
-     * 팔로잉의 덕질고사 추천 피드 data class [FollowingTest]
+     * 팔로잉의 덕질고사 추천 피드 data class [RecommendExam]
      *
      * @param coverUrl 덕질고사 커버 이미지 url
      * @param title 덕질고사 제목
      * @param owner 덕질고사 만든이
      */
     @Immutable
-    data class FollowingTest(
+    data class RecommendExam(
         val coverUrl: String,
         val title: String,
         val examId: Int,
@@ -67,7 +69,28 @@ internal data class HomeState(
             val profileImgUrl: String,
             val favoriteTag: String,
             val tier: String,
-        )
+        ) {
+            /**
+             * [User] 의 Empty Model 입니다.
+             * 초기화 혹은 Skeleton UI 등에 필요한 Mock Data 로 쓰입니다.
+             */
+            companion object {
+                fun empty() = User("", "", "", "")
+            }
+        }
+
+        /**
+         * [RecommendExam] 의 Empty Model 입니다.
+         * 초기화 혹은 Skeleton UI 등에 필요한 Mock Data 로 쓰입니다.
+         */
+        companion object {
+            fun empty() = RecommendExam(
+                "",
+                "",
+                0,
+                User.empty(),
+            )
+        }
     }
 
     /**


### PR DESCRIPTION
## Issue

- close #325 

## Overview (Required)

- 홈 팔로잉의 덕질고사 추천 페이지와 초기 팔로잉 추천 페이지를 다른 파일로 나누었습니다.
- 홈 화면의 팔로잉 탭에서 로딩이 제대로 작동되지 않아 고치면서 스켈레톤 UI도 적용했습니다.
- 홈의 로딩 상태와 PullToRefresh 상태가 동일하게 사용되어 초기에 PullRefreshIndicator가 나오는 현상을 둘의 상태를 분리해서 해결했습니다.
- PullRefresh 가 작동되도록 하였고, 사용자에게 새로고침이 됐음을 인지시키기 위해 최소한의 로딩 시간 (0.5초)를 적용했습니다.
