### PR TITLE
resolves #326

### DIFF
--- a/domain/src/main/kotlin/team/duckie/app/android/domain/kakao/repository/KakaoRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/kakao/repository/KakaoRepository.kt
@@ -12,4 +12,6 @@ import androidx.compose.runtime.Immutable
 @Immutable
 interface KakaoRepository {
     suspend fun getAccessToken(): String
+
+    suspend fun loginWithWebView(): String
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/kakao/usecase/GetKakaoAccessTokenUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/kakao/usecase/GetKakaoAccessTokenUseCase.kt
@@ -9,12 +9,28 @@ package team.duckie.app.android.domain.kakao.usecase
 
 import androidx.compose.runtime.Immutable
 import team.duckie.app.android.domain.kakao.repository.KakaoRepository
+import team.duckie.app.android.util.kotlin.exception.isKakaoTalkNotSupportAccount
 
+/**
+ * 카카오 AccessToken 을 가져오는 유즈케이스
+ *
+ * https://devtalk.kakao.com/t/topic/128009
+ * 위 이슈로 인해서 카카오톡에서 NotSupportException 을 발생시킬 경우
+ * WebView 를 통해 로그인을 시도합니다.
+ */
 @Immutable
 class GetKakaoAccessTokenUseCase(private val repository: KakaoRepository) {
     suspend operator fun invoke(): Result<String> {
         return runCatching {
             repository.getAccessToken()
+        }.onFailure { exception ->
+            when {
+                exception.isKakaoTalkNotSupportAccount -> {
+                    return runCatching {
+                        repository.loginWithWebView()
+                    }
+                }
+            }
         }
     }
 }

--- a/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/exception/constant.kt
+++ b/util-kotlin/src/main/kotlin/team/duckie/app/android/util/kotlin/exception/constant.kt
@@ -27,6 +27,9 @@ object ExceptionCode {
     // Third party
     const val KAKAOTALK_IS_INSTALLED_BUT_NOT_CONNECTED_ACCOUNT =
         "KAKAO_TALK_INSTALLED_BUT_NOT_CONNECTED_ACCOUNT"
+
+    const val KAKAOTALK_NOT_SUPPORT_EXCEPTION =
+        "KAKAOTALK_NOT_SUPPORT_EXCEPTION"
 }
 
 val Throwable.isTagAlreadyExist: Boolean
@@ -48,3 +51,6 @@ val Throwable.isLoginRequireCode: Boolean
 
 val Throwable.isKakaoTalkNotConnectedAccount: Boolean
     get() = (this as? DuckieThirdPartyException)?.code == ExceptionCode.KAKAOTALK_IS_INSTALLED_BUT_NOT_CONNECTED_ACCOUNT
+
+val Throwable.isKakaoTalkNotSupportAccount: Boolean
+    get() = (this as? DuckieThirdPartyException)?.code == ExceptionCode.KAKAOTALK_NOT_SUPPORT_EXCEPTION


### PR DESCRIPTION
## Issue

- close #326 

## Overview (Required)

카카오톡이 설치되어 있을 때, 로그인이 되어있지 않다면 에러가 나는 문제를 해결했습니다.

https://devtalk.kakao.com/t/topic/128009
해당 이슈는 카카오에서 이미 진행 중인 이슈로 해당 오류가 발생 할 경우
카카오계정 로그인으로 처리되도록 개선하였습니다.