### PR TITLE
Resolve #349

### DIFF
--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/AdditionalInfoScreen.kt
@@ -259,7 +259,7 @@ internal fun AdditionalInformationScreen(
                     AdditionalThumbnailLayout(thumbnail = selectedGalleryImage) {
                         keyboard?.hide()
                         coroutineScope.launch {
-                            sheetState.animateTo(ModalBottomSheetValue.Expanded)
+                            sheetState.show()
                         }
                     }
 

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/CreateProblemScreen.kt
@@ -311,7 +311,7 @@ internal fun CreateProblemScreen(
                                         coroutineShape.launch {
                                             selectedQuestionIndex = questionIndex
                                             keyboard?.hide()
-                                            sheetState.animateTo(ModalBottomSheetValue.Expanded)
+                                            sheetState.show()
                                         }
                                     },
                                     answer = correctAnswer,
@@ -360,7 +360,7 @@ internal fun CreateProblemScreen(
                                         coroutineShape.launch {
                                             selectedQuestionIndex = questionIndex
                                             keyboard?.hide()
-                                            sheetState.animateTo(ModalBottomSheetValue.Expanded)
+                                            sheetState.show()
                                         }
                                     },
                                     answers = answers,
@@ -422,7 +422,7 @@ internal fun CreateProblemScreen(
                                         coroutineShape.launch {
                                             selectedQuestionIndex = questionIndex
                                             keyboard?.hide()
-                                            sheetState.animateTo(ModalBottomSheetValue.Expanded)
+                                            sheetState.show()
                                         }
                                     },
                                     answers = answers,
@@ -489,7 +489,7 @@ internal fun CreateProblemScreen(
                     leftButtonClick = {
                         coroutineShape.launch {
                             keyboard?.hide()
-                            sheetState.animateTo(ModalBottomSheetValue.Expanded)
+                            sheetState.show()
                         }
                     },
                     tempSaveButtonText = stringResource(id = R.string.create_problem_temp_save_button),

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/3_TagScreen.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/3_TagScreen.kt
@@ -368,7 +368,7 @@ private fun TagSelection(
                 color = QuackColor.DuckieOrange,
                 onClick = {
                     coroutineScope.launch {
-                        sheetState.animateTo(ModalBottomSheetValue.Expanded)
+                        sheetState.show()
                     }
                 },
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ androidx-annotation = "1.5.0"
 # compose
 compose-core = "1.3.1"
 compose-foundation = "1.4.0-beta01" # use alpha for HorizontalPager
-compose-material = "1.4.0-alpha03"
+compose-material = "1.4.0"
 compose-runtime = "1.4.0-rc01" # use alpha for SnapshotStateList#toList
 compose-lifecycle = "2.6.0-alpha03" # use alpha for StateFlow#collectAsStateWithLifecycle
 compose-compiler = "1.4.3"


### PR DESCRIPTION
## Issue

- close #349 

### 에러 상황
compose-material에 ModalBottomSheetLayout 안에 있는 ScrollContainerInfo가 없어져
ModalBottomSheetLayout를 호출 할 경우 앱이 터지는 오류 발생

### 개선
* compose-material 버전 업그레이드
