### PR TITLE
Resolve #378

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
@@ -28,12 +28,10 @@ import team.duckie.app.android.util.kotlin.seconds
 import team.duckie.app.ktor.client.plugin.DuckieAuthorizationHeaderOrNothingPlugin
 
 /** token 이 필요한 HttpClient */
-@Deprecated(message = "fuel 로 변경 예정 (#180)")
 internal var client = AuthorizationHeaderClient()
     private set
 
 /** token 이 필요 없는 HttpClient */
-@Deprecated(message = "fuel 로 변경 예정 (#180)")
 @Suppress("unused")
 internal var noAuthClient = AuthorizationHeaderClient(false)
     private set

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/datasource/UserRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/datasource/UserRemoteDataSourceImpl.kt
@@ -11,6 +11,7 @@ import com.github.kittinunf.fuel.Fuel
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.patch
+import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -77,7 +78,11 @@ class UserRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun nicknameValidateCheck(nickname: String): Boolean {
-        val response = client.get("/users/$nickname/duplicate-check")
+        val response = client.post("/users/duplicate-check") {
+            jsonBody {
+                "nickName" withString nickname
+            }
+        }
 
         return responseCatching(response.status.value, response.bodyAsText()) { body ->
             val json = body.toStringJsonMap()


### PR DESCRIPTION
## Issue

- close #378 

## Overview (Required)

- 닉네임 중복 확인 API가 업데이트 되서, 온보딩이 동작하지 않는 오류 발생
- POST /user/duplicate-check 를 업데이트해서 해결
- KTor deprecated를 제거했습니다.
