### PR TITLE
header 중에 x-duckie-version 값에 숫자만 들어가도록 처리

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -31,6 +31,11 @@ android {
 
     defaultConfig {
         buildConfigField("String", "APP_VERSION_NAME", "\"$VersionName\"")
+        // 정규식 패턴 설정
+        val pattern = Regex("\\d+\\.\\d+\\.\\d+")
+        // 정규식 패턴에 맞게 검색하여 결과 출력
+        val versionNameNumber = pattern.findAll(VersionName).map { it.value }.first()
+        buildConfigField("String", "APP_VERSION_NAME_NUMBER", "\"$versionNameNumber\"")
         manifestPlaceholders["KAKAO_MANIFEST_SCHEME"] =
             gradleLocalProperties(rootDir).getProperty("KAKAO_MANIFEST_SCHEME")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
@@ -76,7 +76,7 @@ private object AuthorizationHeaderClient {
             contentType(ContentType.Application.Json)
             headers {
                 append(DuckieHttpHeaders.DeviceName, DeviceName)
-                append(DuckieHttpHeaders.Version, BuildConfig.APP_VERSION_NAME)
+                append(DuckieHttpHeaders.Version, BuildConfig.APP_VERSION_NAME_NUMBER)
                 append(DuckieHttpHeaders.Client, ClientName)
             }
         }

--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/FuelClient.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/FuelClient.kt
@@ -44,7 +44,7 @@ internal object FuelClient {
             baseHeaders = mutableMapOf(
                 DuckieHttpHeaders.Client to ClientName,
                 DuckieHttpHeaders.DeviceName to DeviceName,
-                DuckieHttpHeaders.Version to BuildConfig.APP_VERSION_NAME,
+                DuckieHttpHeaders.Version to BuildConfig.APP_VERSION_NAME_NUMBER,
                 Headers.CONTENT_TYPE to ContentTypeValues.ApplicationJson,
             ).apply {
                 addDuckieAuthorizationHeaderIfNeeded(headerKey = DuckieHttpHeaders.Authorization)

--- a/data/src/test/kotlin/team/duckie/app/android/data/RegexTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/RegexTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data
+
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class RegexTest {
+
+    private val versionRegex = Regex("\\d+\\.\\d+\\.\\d+")
+
+    @Test
+    fun `version name with characters must consist of numbers and periods`() {
+        val versionName = "MVP-1.0.1"
+        val expectVersionName = "1.0.1"
+        val versionNameNumber = versionRegex.findAll(versionName).map { it.value }.first()
+        expectThat(versionNameNumber).isEqualTo(expectVersionName)
+    }
+
+    @Test
+    fun `version name with double digit number must consist of numbers and periods`() {
+        val versionName = "11.0.1"
+        val expectVersionName = "11.0.1"
+        val versionNameNumber = versionRegex.findAll(versionName).map { it.value }.first()
+        expectThat(versionNameNumber).isEqualTo(expectVersionName)
+    }
+}


### PR DESCRIPTION
관련 논의 쓰레드 : https://sungbinland.slack.com/archives/C043MKB4TJN/p1681916032300699

- 정규식을 활용하여 숫자값만 추출하였습니다. 
  해당 값은 data 모듈 내에서 `BuildConfig.APP_VERSION_NAME_NUMBER` 으로 가져올 수 있습니다.