### PR TITLE
fix: 온보딩(가이드) 진입 조건 수정

### DIFF
--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/OnboardActivity.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/OnboardActivity.kt
@@ -223,7 +223,7 @@ class OnboardActivity : BaseActivity() {
                 }
                 changeActivityWithAnimation<HomeActivity>(
                     intentBuilder = {
-                        putExtra(Extras.StartGuide, true)
+                        putExtra(Extras.StartGuide, sideEffect.isNewUser)
                     },
                 )
             }

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/OnboardViewModel.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/OnboardViewModel.kt
@@ -172,7 +172,7 @@ internal class OnboardViewModel @AssistedInject constructor(
 
     fun finishOnboard(newMe: User) = intent {
         setMeUseCase(newMe)
-        postSideEffect(OnboardSideEffect.FinishOnboard("${newMe.id}"))
+        postSideEffect(OnboardSideEffect.FinishOnboard(state.isNewUser, "${newMe.id}"))
     }
 
     // validation
@@ -285,13 +285,16 @@ internal class OnboardViewModel @AssistedInject constructor(
         joinUseCase(kakaoAccessToken)
             .onSuccess { response ->
                 reduce {
-                    state.copy(me = response.user)
+                    state.copy(
+                        me = response.user,
+                        isNewUser = response.isNewUser || response.user.status == UserStatus.NEW,
+                    )
                 }
                 postSideEffect(OnboardSideEffect.UpdateAccessToken(response.accessToken))
                 postSideEffect(OnboardSideEffect.AttachAccessTokenToHeader(response.accessToken))
                 postSideEffect(
                     OnboardSideEffect.Joined(
-                        isNewUser = response.isNewUser || response.user.status == UserStatus.NEW,
+                        isNewUser = state.isNewUser,
                         me = response.user,
                     ),
                 )

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/sideeffect/OnboardSideEffect.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/sideeffect/OnboardSideEffect.kt
@@ -33,7 +33,7 @@ internal sealed class OnboardSideEffect {
     class NicknameDuplicateChecked(val isUsable: Boolean) : OnboardSideEffect()
 
     @RequiredStep(OnboardStep.Activity, OnboardStep.Tag)
-    class FinishOnboard(val userId: String?) : OnboardSideEffect()
+    class FinishOnboard(val isNewUser: Boolean, val userId: String?) : OnboardSideEffect()
 
     class ReportError(val exception: Throwable) : OnboardSideEffect()
 }

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/state/OnboardState.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/state/OnboardState.kt
@@ -25,6 +25,7 @@ internal data class OnboardState(
     val galleryImages: List<String> = emptyList(),
     val categories: List<Category> = emptyList(),
     val selectedCategories: List<Category> = emptyList(),
+    val isNewUser: Boolean = false,
 ) : Parcelable
 
 /** ProfileScreen 의 state */


### PR DESCRIPTION
## Issue

- close #423 

## Overview (Required)

- Kakao의 `NewUser` 정보를 통해서 기기당 온보딩(가이드)을 1회만 띄워주도록 변경
