### PR TITLE
문제 만들기에서 뒤로가기 시 다이얼로그에서 확인을 눌러도 바로 나가지지 않음

### DIFF
--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/screen/ExamInformationScreen.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.app.android.feature.ui.create.problem.screen
 
+import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
@@ -32,6 +33,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -79,6 +81,7 @@ internal fun ExamInformationScreen(
     viewModel: CreateProblemViewModel = activityViewModel(),
     modifier: Modifier,
 ) {
+    val activity = LocalContext.current as Activity
     val state = viewModel.collectAsState().value.examInformation
     val coroutineScope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
@@ -270,7 +273,7 @@ internal fun ExamInformationScreen(
         rightButtonText = stringResource(id = R.string.ok),
         rightButtonOnClick = {
             createProblemExitDialogVisible = false
-            viewModel.finishCreateProblem()
+            activity.finish()
         },
         onDismissRequest = { createProblemExitDialogVisible = false },
     )

--- a/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
+++ b/feature-ui-create-problem/src/main/kotlin/team/duckie/app/android/feature/ui/create/problem/viewmodel/CreateProblemViewModel.kt
@@ -276,7 +276,7 @@ internal class CreateProblemViewModel @Inject constructor(
     }
 
     /** 문제 만들기 화면을 종료한다. */
-    internal fun finishCreateProblem() = intent {
+    private fun finishCreateProblem() = intent {
         postSideEffect(CreateProblemSideEffect.FinishActivity)
     }
 


### PR DESCRIPTION
https://www.notion.so/duckie-team/bf5461540b764085af10ea9058ed9dc4?pvs=4

이전 이슈에서 문제가 되었던 내용을 참고하여 문제 요소를 최대한 없앴습니다.
- Screen 에서는 sideEffect 를 post 하지 않도록 했습니다.
- 앱 종료 시 활용하는 SideEffect 방출은 viewModel 에서만 활용합니다

---

사실 이것도 완벽한 해결책은 아닙니다. (가끔 발현되는 걸 확인했습니다.)
하지만 일단 앱 차원에서 할 수 있는 최대한의 내용을 했습니다.