### PR TITLE
fix: Kakao Login Crash

### DIFF
--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/1_ProfileScreen.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/screen/1_ProfileScreen.kt
@@ -62,6 +62,7 @@ import team.duckie.app.android.feature.ui.onboard.common.TitleAndDescription
 import team.duckie.app.android.feature.ui.onboard.constant.OnboardStep
 import team.duckie.app.android.feature.ui.onboard.viewmodel.OnboardViewModel
 import team.duckie.app.android.feature.ui.onboard.viewmodel.state.ProfileScreenState
+import team.duckie.app.android.shared.ui.compose.constant.SharedIcon
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.compose.asLoose
 import team.duckie.app.android.util.compose.rememberToast
@@ -172,7 +173,7 @@ internal fun ProfileScreen(vm: OnboardViewModel = activityViewModel()) {
         }
 
     var photoPickerVisible by remember { mutableStateOf(false) }
-    var profilePhoto by remember { mutableStateOf<Any>(vm.profileImageUrl) }
+    var profilePhoto by remember { mutableStateOf<Any>(vm.profileImageUrl ?: "") }
 
     var profilePhotoLastSelectionIndex by remember { mutableStateOf<Int?>(null) }
     val profilePhotoSelections = remember {
@@ -368,7 +369,7 @@ private fun ProfilePhoto(
         targetState = profilePhoto,
     ) { photo ->
         QuackImage(
-            src = photo,
+            src = if (photo == "") SharedIcon.ic_default_profile else photo,
             size = ProfilePhotoSize,
             contentScale = ContentScale.Crop,
             onClick = openPhotoPicker ?: {}, // required when onLongClick is used

--- a/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/OnboardViewModel.kt
+++ b/feature-ui-onboard/src/main/kotlin/team/duckie/app/android/feature/ui/onboard/viewmodel/OnboardViewModel.kt
@@ -138,7 +138,7 @@ internal class OnboardViewModel @AssistedInject constructor(
 
     val me get() = requireNotNull(container.stateFlow.value.me) { "User is not initialized." }
 
-    val profileImageUrl get() = requireNotNull(container.stateFlow.value.me?.profileImageUrl) { "User.profileImageUrl is not initialized." }
+    val profileImageUrl: String? get() = container.stateFlow.value.me?.profileImageUrl
 
     /* ----- Onboard Logic ----- */
 


### PR DESCRIPTION

## Overview (Required)

[QA Board](https://www.notion.so/duckie-team/73136a86eb834db592dfe00d7f868dea?pvs=4)
[Crashlytics](https://console.firebase.google.com/u/0/project/duckie-c3963/crashlytics/app/android:team.duckie.app.android/issues/80177b88d7e9f9588a77abea8b2a7b48?time=last-seven-days&sessionEventKey=643D193203E2000169900D6160D7A8F4_1801402733991545119)

- 카카오 로그인 시 crash가 발생하는 현상을 해결했습니다.
- profileImageUrl을 nullable로 처리해주었습니다.
