### PR TITLE
에러 페이지 대응

### DIFF
--- a/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/screen/ExamResultScreen.kt
+++ b/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/screen/ExamResultScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.feature.ui.exam.result.ExamResultActivity
 import team.duckie.app.android.feature.ui.exam.result.R
+import team.duckie.app.android.feature.ui.exam.result.viewmodel.ExamResultState
 import team.duckie.app.android.feature.ui.exam.result.viewmodel.ExamResultViewModel
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.quack.QuackCrossfade
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.quackquack.ui.border.QuackBorder
@@ -99,13 +101,13 @@ internal fun ExamResultScreen(
             }
         },
     ) { padding ->
-        QuackCrossfade(targetState = state.isReportLoading) {
+        QuackCrossfade(targetState = state) {
             when (it) {
-                true -> {
+                is ExamResultState.Loading -> {
                     LoadingIndicator()
                 }
 
-                false -> {
+                is ExamResultState.Success -> {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -115,9 +117,17 @@ internal fun ExamResultScreen(
                     ) {
                         QuackImage(
                             modifier = Modifier.fillMaxSize(),
-                            src = state.reportUrl,
+                            src = it.reportUrl,
                         )
                     }
+                }
+
+                is ExamResultState.Error -> {
+                    ErrorScreen(
+                        Modifier,
+                        false,
+                        onRetryClick = viewModel::initState,
+                    )
                 }
             }
         }

--- a/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/viewmodel/ExamResultState.kt
+++ b/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/viewmodel/ExamResultState.kt
@@ -7,7 +7,14 @@
 
 package team.duckie.app.android.feature.ui.exam.result.viewmodel
 
-data class ExamResultState(
-    val isReportLoading: Boolean = true,
-    val reportUrl: String = "",
-)
+sealed class ExamResultState {
+    object Loading: ExamResultState()
+
+    data class Success(
+        val reportUrl: String = "",
+    ): ExamResultState()
+
+    data class Error(
+        val exception: Throwable,
+    ): ExamResultState()
+}

--- a/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/viewmodel/ExamResultState.kt
+++ b/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/viewmodel/ExamResultState.kt
@@ -8,13 +8,13 @@
 package team.duckie.app.android.feature.ui.exam.result.viewmodel
 
 sealed class ExamResultState {
-    object Loading: ExamResultState()
+    object Loading : ExamResultState()
 
     data class Success(
         val reportUrl: String = "",
-    ): ExamResultState()
+    ) : ExamResultState()
 
     data class Error(
         val exception: Throwable,
-    ): ExamResultState()
+    ) : ExamResultState()
 }

--- a/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/viewmodel/ExamResultViewModel.kt
+++ b/feature-ui-exam-result/src/main/java/team/duckie/app/android/feature/ui/exam/result/viewmodel/ExamResultViewModel.kt
@@ -31,7 +31,7 @@ class ExamResultViewModel @Inject constructor(
 ) : ViewModel(),
     ContainerHost<ExamResultState, ExamResultSideEffect> {
     override val container: Container<ExamResultState, ExamResultSideEffect> = container(
-        ExamResultState(),
+        ExamResultState.Loading,
     )
 
     fun initState() {
@@ -51,20 +51,20 @@ class ExamResultViewModel @Inject constructor(
         submitted: ExamInstanceSubmitBody,
     ) = intent {
         reduce {
-            state.copy(isReportLoading = true)
+            ExamResultState.Loading
         }
         makeExamInstanceSubmitUseCase(
             id = examId,
             body = submitted,
         ).onSuccess { submit: ExamInstanceSubmit ->
             reduce {
-                state.copy(
-                    isReportLoading = false,
-                    reportUrl = submit.examScoreImageUrl,
-                )
+                ExamResultState.Success(reportUrl = submit.examScoreImageUrl)
             }
         }.onFailure {
             it.printStackTrace()
+            reduce {
+                ExamResultState.Error(exception = it)
+            }
             postSideEffect(ExamResultSideEffect.ReportError(it))
         }
     }

--- a/feature-ui-friends/src/main/java/team/duckie/app/android/feature/ui/friends/FriendsScreen.kt
+++ b/feature-ui-friends/src/main/java/team/duckie/app/android/feature/ui/friends/FriendsScreen.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 import team.duckie.app.android.feature.ui.friends.viewmodel.FriendsViewModel
 import team.duckie.app.android.feature.ui.friends.viewmodel.state.FriendsState
 import team.duckie.app.android.shared.ui.compose.BackPressedHeadLine2TopAppBar
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.NoItemScreen
 import team.duckie.app.android.shared.ui.compose.Spacer
 import team.duckie.app.android.shared.ui.compose.UserFollowingLayout
@@ -86,29 +87,37 @@ internal fun FriendScreen(
             pageCount = FriendsType.values().size,
             state = pagerState,
         ) { index ->
-            FriendScreenInternal(
-                isLoading = state.isLoading,
-                isMine = state.isMine,
-                type = FriendsType.fromIndex(index),
-                state = state,
-                onClickFollowByFollower = { userId, follow ->
-                    viewModel.followUser(
-                        userId = userId,
-                        isFollowing = follow,
-                        type = FriendsType.Follower,
-                    )
-                },
-                onClickFollowByFollowing = { userId, follow ->
-                    viewModel.followUser(
-                        userId = userId,
-                        isFollowing = follow,
-                        type = FriendsType.Following,
-                    )
-                },
-                onClickUserProfile = { userId ->
-                    viewModel.navigateToUserProfile(userId)
-                },
-            )
+            if (state.isError) {
+                ErrorScreen(
+                    Modifier,
+                    false,
+                    onRetryClick = { viewModel.initState() },
+                )
+            } else {
+                FriendScreenInternal(
+                    isLoading = state.isLoading,
+                    isMine = state.isMine,
+                    type = FriendsType.fromIndex(index),
+                    state = state,
+                    onClickFollowByFollower = { userId, follow ->
+                        viewModel.followUser(
+                            userId = userId,
+                            isFollowing = follow,
+                            type = FriendsType.Follower,
+                        )
+                    },
+                    onClickFollowByFollowing = { userId, follow ->
+                        viewModel.followUser(
+                            userId = userId,
+                            isFollowing = follow,
+                            type = FriendsType.Following,
+                        )
+                    },
+                    onClickUserProfile = { userId ->
+                        viewModel.navigateToUserProfile(userId)
+                    },
+                )
+            }
         }
     }
 }

--- a/feature-ui-friends/src/main/java/team/duckie/app/android/feature/ui/friends/viewmodel/state/FriendsState.kt
+++ b/feature-ui-friends/src/main/java/team/duckie/app/android/feature/ui/friends/viewmodel/state/FriendsState.kt
@@ -16,6 +16,7 @@ internal data class FriendsState(
     val me: User ? = null,
 
     val isLoading: Boolean = true,
+    val isError: Boolean = false,
     val isMine: Boolean = true,
 
     val followers: ImmutableList<Friend> = skeletonFriends,

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/home/HomeScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/home/HomeScreen.kt
@@ -83,7 +83,7 @@ internal fun HomeScreen(
                 when {
                     state.isError -> ErrorScreen(
                         modifier = Modifier.fillMaxSize(),
-                        onRetryClick = vm::fetchJumbotrons
+                        onRetryClick = vm::fetchJumbotrons,
                     )
 
                     page == HomeStep.HomeRecommendScreen -> HomeRecommendScreen(

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/home/HomeScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.feature.ui.home.constants.HomeStep
 import team.duckie.app.android.feature.ui.home.viewmodel.home.HomeSideEffect
 import team.duckie.app.android.feature.ui.home.viewmodel.home.HomeViewModel
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.dialog.ReportBottomSheetDialog
 import team.duckie.app.android.shared.ui.compose.quack.QuackCrossfade
 import team.duckie.app.android.util.exception.handling.reporter.reportToCrashlyticsIfNeeded
@@ -79,8 +80,13 @@ internal fun HomeScreen(
             QuackCrossfade(
                 targetState = state.homeSelectedIndex,
             ) { page ->
-                when (page) {
-                    HomeStep.HomeRecommendScreen -> HomeRecommendScreen(
+                when {
+                    state.isError -> ErrorScreen(
+                        modifier = Modifier.fillMaxSize(),
+                        onRetryClick = vm::fetchJumbotrons
+                    )
+
+                    page == HomeStep.HomeRecommendScreen -> HomeRecommendScreen(
                         state = state,
                         homeViewModel = vm,
                         navigateToCreateProblem = navigateToCreateProblem,
@@ -94,7 +100,7 @@ internal fun HomeScreen(
                         },
                     )
 
-                    HomeStep.HomeFollowingScreen -> if (state.isFollowingExist) {
+                    page == HomeStep.HomeFollowingScreen -> if (state.isFollowingExist) {
                         HomeRecommendFollowingExamScreen(
                             modifier = Modifier.padding(HomeHorizontalPadding),
                             state = state,

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/mypage/MypageScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/mypage/MypageScreen.kt
@@ -7,15 +7,20 @@
 
 package team.duckie.app.android.feature.ui.home.screen.mypage
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.feature.ui.home.R
 import team.duckie.app.android.feature.ui.home.viewmodel.mypage.MyPageViewModel
 import team.duckie.app.android.feature.ui.home.viewmodel.mypage.MyPageSideEffect
 import team.duckie.app.android.feature.ui.profile.screen.MyProfileScreen
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
+import team.duckie.app.android.shared.ui.compose.LoadingScreen
 import team.duckie.app.android.shared.ui.compose.dialog.ReportAlreadyExists
 import team.duckie.app.android.util.compose.LaunchOnLifecycle
 import team.duckie.app.android.util.compose.ToastWrapper
@@ -86,17 +91,28 @@ internal fun MyPageScreen(
     }
 
     with(state) {
-        MyProfileScreen(
-            userProfile = userProfile,
-            isLoading = isLoading,
-            onClickSetting = viewModel::clickSetting,
-            onClickNotification = viewModel::clickNotification,
-            onClickEditProfile = viewModel::clickEditProfile,
-            onClickEditTag = { viewModel.clickEditTag(context.getString(R.string.provide_after)) },
-            onClickExam = viewModel::clickExam,
-            onClickMakeExam = viewModel::clickMakeExam,
-            onClickTag = viewModel::onClickTag,
-            onClickFriend = navigateToFriend,
-        )
+        if (isLoading) {
+            LoadingScreen(initState = {})
+        } else if (isError) {
+            ErrorScreen(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding(),
+                onRetryClick = viewModel::getUserProfile,
+            )
+        } else {
+            MyProfileScreen(
+                userProfile = userProfile,
+                isLoading = false,
+                onClickSetting = viewModel::clickSetting,
+                onClickNotification = viewModel::clickNotification,
+                onClickEditProfile = viewModel::clickEditProfile,
+                onClickEditTag = { viewModel.clickEditTag(context.getString(R.string.provide_after)) },
+                onClickExam = viewModel::clickExam,
+                onClickMakeExam = viewModel::clickMakeExam,
+                onClickTag = viewModel::onClickTag,
+                onClickFriend = navigateToFriend,
+            )
+        }
     }
 }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/ranking/RankingScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/ranking/RankingScreen.kt
@@ -14,6 +14,7 @@ package team.duckie.app.android.feature.ui.home.screen.ranking
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
@@ -38,6 +39,7 @@ import team.duckie.app.android.feature.ui.home.constants.RankingPage
 import team.duckie.app.android.feature.ui.home.viewmodel.ranking.RankingSideEffect
 import team.duckie.app.android.feature.ui.home.viewmodel.ranking.RankingViewModel
 import team.duckie.app.android.shared.ui.compose.Create
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.component.QuackMainTab
 import team.duckie.quackquack.ui.icon.QuackIcon
@@ -67,9 +69,7 @@ internal fun RankingScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.fetchPopularTags()
-        viewModel.getExams()
-        viewModel.getUserRankings()
+        viewModel.refresh()
     }
 
     LaunchedEffect(Unit) {
@@ -117,35 +117,45 @@ internal fun RankingScreen(
                 )
             },
         )
-        QuackMainTab(
-            titles = tabs,
-            selectedTabIndex = state.selectedTab,
-            onTabSelected = {
-                viewModel.setSelectedTab(it)
-                coroutineScope.launch {
-                    pagerState.animateScrollToPage(it)
-                }
-            },
-        )
-        HorizontalPager(
-            modifier = Modifier.fillMaxSize(),
-            state = pagerState,
-            pageCount = tabs.size,
-            key = { tabs[it] },
-        ) { page ->
-            when (page) {
-                RankingPage.Examinee.index -> {
-                    ExamineeSection(
-                        viewModel = viewModel,
-                        lazyListState = lazyListState,
-                    )
-                }
 
-                RankingPage.Exam.index -> {
-                    ExamSection(
-                        viewModel = viewModel,
-                        lazyGridState = lazyGridState,
-                    )
+        if (state.isError) {
+            ErrorScreen(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding(),
+                onRetryClick = viewModel::refresh,
+            )
+        } else {
+            QuackMainTab(
+                titles = tabs,
+                selectedTabIndex = state.selectedTab,
+                onTabSelected = {
+                    viewModel.setSelectedTab(it)
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(it)
+                    }
+                },
+            )
+            HorizontalPager(
+                modifier = Modifier.fillMaxSize(),
+                state = pagerState,
+                pageCount = tabs.size,
+                key = { tabs[it] },
+            ) { page ->
+                when (page) {
+                    RankingPage.Examinee.index -> {
+                        ExamineeSection(
+                            viewModel = viewModel,
+                            lazyListState = lazyListState,
+                        )
+                    }
+
+                    RankingPage.Exam.index -> {
+                        ExamSection(
+                            viewModel = viewModel,
+                            lazyGridState = lazyGridState,
+                        )
+                    }
                 }
             }
         }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/home/HomeState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/home/HomeState.kt
@@ -17,6 +17,8 @@ import team.duckie.app.android.feature.ui.home.constants.HomeStep
 internal data class HomeState(
     val me: User? = null,
 
+    val isError: Boolean = false,
+
     val isHomeRecommendLoading: Boolean = false,
     val isHomeRecommendFollowingExamLoading: Boolean = false,
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/home/HomeViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/home/HomeViewModel.kt
@@ -126,21 +126,21 @@ internal class HomeViewModel @Inject constructor(
     }
 
     /** 홈 화면의 jumbotron을 가져온다. */
-    private fun fetchJumbotrons() = intent {
-        updateHomeRecommendLoading(true)
+    internal fun fetchJumbotrons() = intent {
+        startHomeRecommendLoading()
         fetchJumbotronsUseCase()
             .onSuccess { jumbotrons ->
                 reduce {
                     state.copy(
+                        isHomeRecommendLoading = false,
                         jumbotrons = jumbotrons
                             .fastMap(Exam::toJumbotronModel)
                             .toPersistentList(),
                     )
                 }
             }.onFailure { exception ->
+                reduce { state.copy(isHomeRecommendLoading = false, isError = true) }
                 postSideEffect(HomeSideEffect.ReportError(exception))
-            }.also {
-                updateHomeRecommendLoading(false)
             }
     }
 
@@ -248,11 +248,9 @@ internal class HomeViewModel @Inject constructor(
     }
 
     /** 홈 화면의 추천 탭의 로딩 상태를 [loading]으로 바꾼다. */
-    private fun updateHomeRecommendLoading(
-        loading: Boolean,
-    ) = intent {
+    private fun startHomeRecommendLoading() = intent {
         reduce {
-            state.copy(isHomeRecommendLoading = loading)
+            state.copy(isHomeRecommendLoading = true, isError = false)
         }
     }
 
@@ -261,7 +259,7 @@ internal class HomeViewModel @Inject constructor(
         loading: Boolean,
     ) = intent {
         reduce {
-            state.copy(isHomeRecommendFollowingExamLoading = loading)
+            state.copy(isHomeRecommendFollowingExamLoading = loading, isError = false)
         }
     }
 
@@ -273,6 +271,7 @@ internal class HomeViewModel @Inject constructor(
             state.copy(
                 isHomeRecommendPullRefreshLoading = loading,
                 isHomeRecommendLoading = loading, // for skeleton UI
+                isError = false,
             )
         }
     }
@@ -285,6 +284,7 @@ internal class HomeViewModel @Inject constructor(
             state.copy(
                 isHomeRecommendFollowingExamRefreshLoading = loading,
                 isHomeRecommendFollowingExamLoading = loading, // for skeleton UI
+                isError = false,
             )
         }
     }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageState.kt
@@ -13,6 +13,7 @@ import team.duckie.app.android.feature.ui.profile.dummy.skeletonUserProfile
 
 internal data class MyPageState(
     val isLoading: Boolean = true,
+    val isError: Boolean = false,
     val userProfile: UserProfile = skeletonUserProfile(),
     val me: User? = null,
 )

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageViewModel.kt
@@ -50,7 +50,7 @@ internal class MyPageViewModel @Inject constructor(
                             state.copy(
                                 isLoading = false,
                                 isError = false,
-                                userProfile = profile
+                                userProfile = profile,
                             )
                         }
                     }.onFailure {
@@ -66,8 +66,7 @@ internal class MyPageViewModel @Inject constructor(
         postSideEffect(MyPageSideEffect.NavigateToSearch(tag))
     }
 
-    private fun startLoading(
-    ) = intent {
+    private fun startLoading() = intent {
         reduce {
             state.copy(isLoading = true, isError = false)
         }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageViewModel.kt
@@ -31,12 +31,14 @@ internal class MyPageViewModel @Inject constructor(
 
     override val container = container<MyPageState, MyPageSideEffect>(MyPageState())
     fun getUserProfile() = intent {
-        updateLoading(true)
+        startLoading()
+
         val job = viewModelScope.launch {
             getMeUseCase()
                 .onSuccess { me ->
                     reduce { state.copy(me = me) }
                 }.onFailure {
+                    reduce { state.copy(isLoading = false, isError = true) }
                     postSideEffect(MyPageSideEffect.ReportError(it))
                 }
         }.apply { join() }
@@ -45,26 +47,29 @@ internal class MyPageViewModel @Inject constructor(
                 viewModelScope.launch {
                     fetchUserProfileUseCase(it.id).onSuccess { profile ->
                         reduce {
-                            state.copy(userProfile = profile)
+                            state.copy(
+                                isLoading = false,
+                                isError = false,
+                                userProfile = profile
+                            )
                         }
                     }.onFailure {
+                        reduce { state.copy(isLoading = false, isError = true) }
                         postSideEffect(MyPageSideEffect.ReportError(it))
                     }
                 }
             }
         }
-        updateLoading(false)
     }
 
     fun onClickTag(tag: String) = intent {
         postSideEffect(MyPageSideEffect.NavigateToSearch(tag))
     }
 
-    private fun updateLoading(
-        loading: Boolean,
+    private fun startLoading(
     ) = intent {
         reduce {
-            state.copy(isLoading = loading)
+            state.copy(isLoading = true, isError = false)
         }
     }
 

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/ranking/RankingState.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/ranking/RankingState.kt
@@ -15,6 +15,7 @@ import team.duckie.app.android.util.kotlin.fastMap
 
 internal data class RankingState(
     val isTagLoading: Boolean = true,
+    val isError: Boolean = false,
     val isPagingDataLoading: Boolean = true,
     val selectedTab: Int = 0,
     val examTags: ImmutableList<Tag> = skeletonTags,

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/ranking/RankingViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/ranking/RankingViewModel.kt
@@ -46,8 +46,13 @@ internal class RankingViewModel @Inject constructor(
     private val _userRankings = MutableStateFlow(PagingData.from(skeletonExamineeItems))
     val userRankings: Flow<PagingData<User>> = _userRankings
 
-    fun getUserRankings() = intent {
-        updatePagingDataLoading(true)
+    fun refresh() {
+        fetchPopularTags()
+        getExams()
+        getUserRankings()
+    }
+
+    private fun getUserRankings() = intent {
         getUserRankingsUseCase()
             .cachedIn(viewModelScope)
             .catch {
@@ -55,11 +60,10 @@ internal class RankingViewModel @Inject constructor(
             }
             .collect { pagingUser ->
                 _userRankings.value = pagingUser
-                updatePagingDataLoading(false)
             }
     }
 
-    fun getExams() = with(container.stateFlow.value) {
+    private fun getExams() = with(container.stateFlow.value) {
         val tagId = run {
             val index = tagSelections.indexOf(true)
             if (index == 0) {
@@ -104,19 +108,25 @@ internal class RankingViewModel @Inject constructor(
             }
     }
 
-    fun fetchPopularTags() = intent {
-        updateTagLoading(true)
+    private fun fetchPopularTags() = intent {
+        startTagLoading()
         fetchPopularTagsUseCase()
             .onSuccess { tags ->
                 reduce {
                     state.copy(
+                        isTagLoading = false,
                         examTags = tags.addAllTag(),
                         tagSelections = tags.fastMap { false }.toImmutableList().addAllSelection(),
                     )
                 }
-                updateTagLoading(false)
             }
             .onFailure { exception ->
+                reduce {
+                    state.copy(
+                        isTagLoading = false,
+                        isError = true,
+                    )
+                }
                 postSideEffect(RankingSideEffect.ReportError(exception))
             }
     }
@@ -171,12 +181,12 @@ internal class RankingViewModel @Inject constructor(
         }
     }
 
-    private fun updateTagLoading(
-        loading: Boolean,
+    private fun startTagLoading(
     ) = intent {
         reduce {
             state.copy(
-                isTagLoading = loading,
+                isTagLoading = true,
+                isError = false,
             )
         }
     }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/ranking/RankingViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/ranking/RankingViewModel.kt
@@ -181,8 +181,7 @@ internal class RankingViewModel @Inject constructor(
         }
     }
 
-    private fun startTagLoading(
-    ) = intent {
+    private fun startTagLoading() = intent {
         reduce {
             state.copy(
                 isTagLoading = true,

--- a/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/screen/NoticationScreen.kt
+++ b/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/screen/NoticationScreen.kt
@@ -7,7 +7,6 @@
 
 package team.duckie.app.android.feature.ui.notification.screen
 
-import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +14,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -27,7 +27,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.feature.ui.notification.R
 import team.duckie.app.android.feature.ui.notification.viewmodel.NotificationViewModel
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.NoItemScreen
+import team.duckie.app.android.shared.ui.compose.quack.QuackCrossfade
 import team.duckie.app.android.shared.ui.compose.skeleton
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.kotlin.getDiffDayFromToday
@@ -58,9 +60,20 @@ internal fun NotificationScreen(
             leadingText = stringResource(id = R.string.notification),
             onLeadingIconClick = viewModel::clickBackPress,
         )
-        Crossfade(state.notifications.isEmpty()) { isEmpty ->
-            when (isEmpty) {
-                true -> {
+        QuackCrossfade(
+            targetState = state.notifications.isEmpty(),
+        ) { isEmpty ->
+            when {
+                state.isError -> {
+                    ErrorScreen(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .statusBarsPadding(),
+                        onRetryClick = viewModel::getNotifications,
+                    )
+                }
+
+                isEmpty -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center,
@@ -72,7 +85,7 @@ internal fun NotificationScreen(
                     }
                 }
 
-                false -> {
+                else -> {
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()

--- a/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/viewmodel/NotificationState.kt
+++ b/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/viewmodel/NotificationState.kt
@@ -12,5 +12,6 @@ import team.duckie.app.android.domain.notification.model.Notification
 
 data class NotificationState(
     val isLoading: Boolean = true,
+    val isError: Boolean = false,
     val notifications: ImmutableList<Notification> = skeletonNotifications,
 )

--- a/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/viewmodel/NotificationViewModel.kt
+++ b/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/viewmodel/NotificationViewModel.kt
@@ -31,17 +31,24 @@ internal class NotificationViewModel @Inject constructor(
         container<NotificationState, NotificationSideEffect>(NotificationState())
 
     fun getNotifications() = intent {
-        updateLoading(true)
+        startLoading()
         getNotificationsUseCase().onSuccess { notifications ->
             reduce {
-                state.copy(notifications = notifications.toImmutableList())
+                state.copy(
+                    isLoading = false,
+                    isError = false,
+                    notifications = notifications.toImmutableList(),
+                )
             }
         }.onFailure {
             reduce {
-                state.copy(notifications = emptyList<Notification>().toImmutableList())
+                state.copy(
+                    isLoading = false,
+                    isError = true,
+                    notifications = emptyList<Notification>().toImmutableList(),
+                )
             }
         }
-        updateLoading(false)
     }
 
     fun clickBackPress() = intent { postSideEffect(NotificationSideEffect.FinishActivity) }
@@ -54,8 +61,9 @@ internal class NotificationViewModel @Inject constructor(
         }
     }
 
-    private suspend fun SimpleSyntax<NotificationState, *>.updateLoading(isLoading: Boolean) =
+    private suspend fun startLoading() = intent {
         reduce {
-            state.copy(isLoading = isLoading)
+            state.copy(isLoading = true, isError = false)
         }
+    }
 }

--- a/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/viewmodel/NotificationViewModel.kt
+++ b/feature-ui-notification/src/main/kotlin/team/duckie/app/android/feature/ui/notification/viewmodel/NotificationViewModel.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/ProfileActivity.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/ProfileActivity.kt
@@ -10,7 +10,9 @@ package team.duckie.app.android.feature.ui.profile
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -27,6 +29,7 @@ import team.duckie.app.android.navigator.feature.notification.NotificationNaviga
 import team.duckie.app.android.navigator.feature.profile.ProfileEditNavigator
 import team.duckie.app.android.navigator.feature.search.SearchNavigator
 import team.duckie.app.android.navigator.feature.setting.SettingNavigator
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.LoadingScreen
 import team.duckie.app.android.shared.ui.compose.dialog.ReportAlreadyExists
 import team.duckie.app.android.util.compose.LaunchOnLifecycle
@@ -37,6 +40,7 @@ import team.duckie.app.android.util.kotlin.exception.isReportAlreadyExists
 import team.duckie.app.android.util.ui.BaseActivity
 import team.duckie.app.android.util.ui.const.Extras
 import team.duckie.app.android.util.ui.finishWithAnimation
+import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
 
@@ -72,15 +76,28 @@ class ProfileActivity : BaseActivity() {
             systemBarPaddings
             val state by viewModel.container.stateFlow.collectAsStateWithLifecycle()
             QuackTheme {
-                when (state.isLoading) {
-                    true -> {
+                when {
+                    state.isLoading -> {
                         LoadingScreen(
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(color = QuackColor.White.composeColor)
+                                .statusBarsPadding(),
                             initState = { viewModel.init() },
                         )
                     }
 
-                    false -> {
+                    state.isError -> {
+                        ErrorScreen(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(color = QuackColor.White.composeColor)
+                                .statusBarsPadding(),
+                            onRetryClick = { viewModel.init() },
+                        )
+                    }
+
+                    else -> {
                         when (state.isMe) {
                             true -> {
                                 LaunchOnLifecycle {
@@ -88,7 +105,7 @@ class ProfileActivity : BaseActivity() {
                                 }
                                 MyProfileScreen(
                                     userProfile = state.userProfile,
-                                    isLoading = state.isLoading,
+                                    isLoading = false,
                                     onClickSetting = viewModel::clickSetting,
                                     onClickNotification = viewModel::clickNotification,
                                     onClickEditProfile = viewModel::clickEditProfile,

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/state/ProfileState.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/state/ProfileState.kt
@@ -13,6 +13,7 @@ import team.duckie.app.android.feature.ui.profile.dummy.skeletonUserProfile
 
 data class ProfileState(
     val isLoading: Boolean = true,
+    val isError: Boolean = false,
     val userProfile: UserProfile = skeletonUserProfile(),
     val me: User? = null,
     val isMe: Boolean = false,

--- a/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/screen/SearchActivity.kt
+++ b/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/screen/SearchActivity.kt
@@ -119,8 +119,8 @@ class SearchActivity : BaseActivity() {
                             when (step) {
                                 SearchStep.Search -> SearchScreen(vm = vm)
                                 SearchStep.SearchResult -> {
-                                    if (state.isSearchProblemError
-                                        && state.tagSelectedTab == SearchResultStep.DuckExam
+                                    if (state.isSearchProblemError &&
+                                        state.tagSelectedTab == SearchResultStep.DuckExam
                                     ) {
                                         ErrorScreen(
                                             modifier = Modifier
@@ -131,8 +131,8 @@ class SearchActivity : BaseActivity() {
                                                 vm.fetchSearchExams(state.searchKeyword)
                                             },
                                         )
-                                    } else if (state.isSearchUserError
-                                        && state.tagSelectedTab == SearchResultStep.User
+                                    } else if (state.isSearchUserError &&
+                                        state.tagSelectedTab == SearchResultStep.User
                                     ) {
                                         ErrorScreen(
                                             modifier = Modifier

--- a/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/viewmodel/state/SearchState.kt
+++ b/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/viewmodel/state/SearchState.kt
@@ -30,6 +30,8 @@ import team.duckie.app.android.feature.ui.search.constants.SearchStep
 internal data class SearchState(
     val me: User? = null,
     val isSearchLoading: Boolean = false,
+    val isSearchProblemError: Boolean = false,
+    val isSearchUserError: Boolean = false,
     val searchStep: SearchStep = SearchStep.Search,
     val recentSearch: ImmutableList<String> = persistentListOf(),
     val recommendSearchs: Flow<PagingData<Tag>> = flow { PagingData.empty<Tag>() },

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/SolveProblemActivity.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/SolveProblemActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,6 +29,7 @@ import team.duckie.app.android.feature.ui.solve.problem.screen.SolveProblemScree
 import team.duckie.app.android.feature.ui.solve.problem.viewmodel.SolveProblemViewModel
 import team.duckie.app.android.feature.ui.solve.problem.viewmodel.sideeffect.SolveProblemSideEffect
 import team.duckie.app.android.navigator.feature.examresult.ExamResultNavigator
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.quack.QuackCrossfade
 import team.duckie.app.android.util.ui.BaseActivity
 import team.duckie.app.android.util.ui.const.Extras
@@ -61,11 +63,21 @@ class SolveProblemActivity : BaseActivity() {
                         .systemBarsPadding()
                         .navigationBarsPadding()
                         .imePadding(),
-                    targetState = state.isProblemsLoading,
-                ) { isLoading ->
-                    when (isLoading) {
-                        true -> {
+                    targetState = state,
+                ) {
+                    when {
+                        state.isProblemsLoading -> {
                             LoadingIndicator()
+                        }
+
+                        state.isError -> {
+                            ErrorScreen(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .statusBarsPadding(),
+                                isNetworkError = false,
+                                onRetryClick = viewModel::initState,
+                            )
                         }
 
                         else -> {

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/SolveProblemViewModel.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/SolveProblemViewModel.kt
@@ -49,7 +49,8 @@ internal class SolveProblemViewModel @Inject constructor(
     }
 
     private suspend fun getProblems(examId: Int) = intent {
-        reduce { state.copy(isProblemsLoading = true) }
+        reduce { state.copy(isProblemsLoading = true, isError = false) }
+
         getExamInstanceUseCase(id = examId).onSuccess { examInstance ->
             val problemInstances = examInstance.problemInstances?.toImmutableList()
             if (problemInstances == null) {
@@ -65,6 +66,9 @@ internal class SolveProblemViewModel @Inject constructor(
             }
         }.onFailure {
             it.printStackTrace()
+            reduce {
+                state.copy(isError = true, isProblemsLoading = false)
+            }
             postSideEffect(SolveProblemSideEffect.ReportError(it))
         }
     }

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/state/SolveProblemState.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/state/SolveProblemState.kt
@@ -14,6 +14,7 @@ import team.duckie.app.android.domain.examInstance.model.ProblemInstance
 internal data class SolveProblemState(
     val examId: Int = -1,
     val isProblemsLoading: Boolean = true,
+    val isError: Boolean = false,
     val currentPageIndex: Int = 0,
     val problems: ImmutableList<ProblemInstance> = persistentListOf(),
     val inputAnswers: ImmutableList<InputAnswer> = persistentListOf(),


### PR DESCRIPTION
### 티켓 명세
[노션 티켓 링크](https://www.notion.so/duckie-team/b7bddf9fb1c04e26b90bcb219cdda3f7?pvs=4)

### 부연 설명
- 에러 페이지는 `보통 처음에 화면 띄워질 때` 필요한 페이지이므로, 온보딩은 따로 대응하지 않았습니다.
- 다시 시도 버튼을 누를 시 initState 나 init 함수들을 실행하도록 처리했습니다.
- 일부 병렬 실행 케이스에 대해서는 슬랙에서 논의 후 작업 진행했습니다. ([ref](https://duckie-team.slack.com/archives/C054F0B725T/p1682695135852749))
- 홈 화면은 점보트론에 대해서만 갱신해주도록 했는데 문제가 있다고 판단되면 comment 부탁드립니다.