### PR TITLE
logging 방식 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
         libs.firebase.crashlytics,
         libs.login.kakao, // for KakaoSDK initialization
         libs.quack.ui.components, // for debug setting
+        libs.logging.timber,
         projects.presentation, // for launch IntroActivity
         projects.utilKotlin,
         projects.featureUiExamResult,

--- a/app/src/main/kotlin/team/duckie/app/android/App.kt
+++ b/app/src/main/kotlin/team/duckie/app/android/App.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.HiltAndroidApp
 import team.duckie.app.android.util.kotlin.seconds
 import team.duckie.quackquack.ui.animation.QuackAnimationMillis
 import team.duckie.quackquack.ui.modifier.QuackAlwaysShowRipple
+import timber.log.Timber
 
 @HiltAndroidApp
 class App : Application() {
@@ -24,6 +25,9 @@ class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
         libs.bundles.fuel,
         libs.bundles.moshi,
         libs.bundles.ktor.client,
+        libs.logging.timber,
         projects.domain,
         projects.utilKotlin,
         projects.pluginKtorClient,

--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
@@ -26,6 +26,7 @@ import io.ktor.serialization.jackson.jackson
 import team.duckie.app.android.data.BuildConfig
 import team.duckie.app.android.util.kotlin.seconds
 import team.duckie.app.ktor.client.plugin.DuckieAuthorizationHeaderOrNothingPlugin
+import timber.log.Timber
 
 /** token 이 필요한 HttpClient */
 internal var client = AuthorizationHeaderClient()
@@ -94,7 +95,7 @@ private object AuthorizationHeaderClient {
         install(plugin = Logging) {
             logger = object : Logger {
                 override fun log(message: String) {
-                   println(message)
+                   Timber.e(message)
                 }
             }
             level = LogLevel.ALL

--- a/data/src/main/kotlin/team/duckie/app/android/data/file/repository/FileRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/file/repository/FileRepositoryImpl.kt
@@ -17,6 +17,7 @@ import team.duckie.app.android.data._util.toStringJsonMap
 import team.duckie.app.android.domain.file.repository.FileRepository
 import team.duckie.app.android.util.kotlin.AllowMagicNumber
 import team.duckie.app.android.util.kotlin.exception.duckieResponseFieldNpe
+import timber.log.Timber
 
 class FileRepositoryImpl @Inject constructor(private val client: Fuel) : FileRepository {
     override suspend fun upload(file: File, type: String): String {
@@ -30,7 +31,7 @@ class FileRepositoryImpl @Inject constructor(private val client: Fuel) : FileRep
             .progress { readBytes, totalBytes ->
                 @AllowMagicNumber(because = "100")
                 val progress = readBytes.toFloat() / totalBytes.toFloat() * 100
-                println("Uploading... $progress%")
+                Timber.e("Uploading... $progress%")
             }
         val response = request.awaitString().toStringJsonMap()
         return response["url"] ?: duckieResponseFieldNpe("url")

--- a/data/src/test/kotlin/team/duckie/app/android/data/CategoryRepositoryTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/CategoryRepositoryTest.kt
@@ -21,6 +21,7 @@ import team.duckie.app.android.data.dummy.CategoryDummyResponse
 import team.duckie.app.android.data.util.ApiTest
 import team.duckie.app.android.data.util.buildMockHttpClient
 import team.duckie.app.android.domain.category.repository.CategoryRepository
+import timber.log.Timber
 
 class CategoryRepositoryTest : ApiTest(
     isMock = true,
@@ -37,7 +38,7 @@ class CategoryRepositoryTest : ApiTest(
 
             expectThat(actual).containsExactly(expected)
         } else {
-            println(actual.first())
+            Timber.e(actual.first().toString())
             expectThat(actual).isNotEmpty()
         }
     }

--- a/data/src/test/kotlin/team/duckie/app/android/data/ExamRepositoryTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/ExamRepositoryTest.kt
@@ -22,6 +22,7 @@ import team.duckie.app.android.data.exam.repository.ExamRepositoryImpl
 import team.duckie.app.android.data.util.ApiTest
 import team.duckie.app.android.data.util.buildMockHttpClient
 import team.duckie.app.android.domain.exam.repository.ExamRepository
+import timber.log.Timber
 
 class ExamRepositoryTest : ApiTest(
     client = buildMockHttpClient(content = ExamDummyResponse.RawData),
@@ -38,7 +39,7 @@ class ExamRepositoryTest : ApiTest(
 
             expectThat(actual).isEqualTo(expected)
         } else {
-            println(actual)
+            Timber.e(actual.toString())
         }
     }
 }

--- a/data/src/test/kotlin/team/duckie/app/android/data/SearchRepositoryTest.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/SearchRepositoryTest.kt
@@ -33,7 +33,7 @@ class SearchRepositoryTest : ApiTest(
 //
 //            expectThat(actual).isEqualTo(expected)
 //        } else {
-//            println(actual)
+//            Timber.e(actual.toString())
 //        }
         expectThat(true).isTrue()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,6 +121,9 @@ test-androidx-runner = "1.5.2"
 test-parameter-injector = "1.11"
 test-turbine = "0.12.3"
 
+# logging
+logging-timber = "5.0.1"
+
 [plugins]
 gms-google-service = { id = "com.google.gms.google-services", version.ref = "plugin-build-google-service" }
 
@@ -261,6 +264,8 @@ test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 test-ktor-client = { module = "io.ktor:ktor-client-mock", version.ref = "ktor-core" }
 test-ktor-server = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor-core" }
 test-orbit = { module = "org.orbit-mvi:orbit-test", version.ref = "orbit-core" }
+
+logging-timber = { module = "com.jakewharton.timber:timber", version.ref = "logging-timber" }
 
 detekt-plugin-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "plugin-code-detekt" }
 

--- a/plugin-ktor-client/build.gradle.kts
+++ b/plugin-ktor-client/build.gradle.kts
@@ -5,6 +5,7 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+import DependencyHandler.Extensions.implementations
 import DependencyHandler.Extensions.testImplementations
 
 plugins {
@@ -14,7 +15,7 @@ plugins {
 
 dependencies {
     detektPlugins(libs.detekt.plugin.formatting)
-    implementation(libs.ktor.client.core)
+    implementations(libs.ktor.client.core)
     testImplementations(
         libs.ktor.client.engine,
         libs.test.coroutines,

--- a/plugin-ktor-client/src/test/kotlin/team/duckie/app/ktor/client/plugin/util/LoggingHeadersPlugin.kt
+++ b/plugin-ktor-client/src/test/kotlin/team/duckie/app/ktor/client/plugin/util/LoggingHeadersPlugin.kt
@@ -15,13 +15,12 @@ val LoggingRequestHeadersPlugin = createClientPlugin(
     createConfiguration = ::LogWriterConfig,
 ) {
     on(SendingRequest) { request, _ ->
-        println("Request headers:")
         request.headers.entries().forEach(pluginConfig::printHeader)
     }
 }
 
 class LogWriterConfig {
-    var writer: (log: String) -> Unit = ::println
+    var writer: (log: String) -> Unit = {}
 }
 
 private fun LogWriterConfig.printHeader(entry: Map.Entry<String, List<String>>) {


### PR DESCRIPTION
## Overview (Required)
release 에서도 로그가 남는다는 문제로 인해, println을 [Timber](https://github.com/JakeWharton/timber)로 대체하였습니다.
Timber를 사용하면 다음과 같은 이점이 있습니다.
- `Timber.e("message")` 형식으로 간단하게 사용할 수 있습니다.
- debug build에서만 로그를 확인할 수 있습니다.