### PR TITLE
설정 화면에 versionCode 나오는 방식 변경 & MVP 제거

### DIFF
--- a/build-logic/src/main/kotlin/AppVersionNameProvider.kt
+++ b/build-logic/src/main/kotlin/AppVersionNameProvider.kt
@@ -14,5 +14,6 @@ class AppVersionNameProvider : Plugin<Project> {
 
     companion object App {
         const val VersionName = ApplicationConstants.versionName
+        const val VersionCode = ApplicationConstants.versionCode
     }
 }

--- a/build-logic/src/main/kotlin/team/duckie/app/android/convention/ApplicationConstants.kt
+++ b/build-logic/src/main/kotlin/team/duckie/app/android/convention/ApplicationConstants.kt
@@ -17,6 +17,6 @@ internal object ApplicationConstants {
     const val targetSdk = 33
     const val compileSdk = 33
     const val versionCode = 6
-    const val versionName = "MVP-1.0.1"
+    const val versionName = "1.0.1"
     val javaVersion = JavaVersion.VERSION_17
 }

--- a/feature-ui-setting/build.gradle.kts
+++ b/feature-ui-setting/build.gradle.kts
@@ -5,6 +5,7 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+import AppVersionNameProvider.App.VersionCode
 import AppVersionNameProvider.App.VersionName
 import DependencyHandler.Extensions.implementations
 
@@ -23,7 +24,7 @@ android {
     }
 
     defaultConfig {
-        buildConfigField("String", "APP_VERSION_NAME", "\"$VersionName\"")
+        buildConfigField("String", "APP_VERSION_NAME", "\"$VersionName.$VersionCode\"")
     }
 }
 


### PR DESCRIPTION
생각해보니 크게 작업할 게 없는 내용이어서 이렇게 작업했습니다.
(history slack: https://duckie-team.slack.com/archives/C054HU0DHGA/p1682857473302919)

작업 내용
1. 설정 화면에 versionCode 나오는 방식을 변경했습니다.
  `${versionName}` -> `${versionName}.${versionCode}`
  
2. MVP 도 제거하기로 이야기가 된 것 같아, 해당 내용도 여기에서 반영했습니다. (cc @EvergreenTree97)

---

### 기타 앞광고
QA 하기 쉬운 방법에 대해서도 요즘 고민해보고 있습니다.
ex. 배포용 flavor 를 만들어서 versionName 및 versionCode 를 floating 으로 띄워주기 등

아이디어 있으면 #386 에 바로 올려주세요~ (@goddoro, @EvergreenTree97, @limsaehyun)