### PR TITLE
fix: 검색 탭 잘못된 padding 수정

### DIFF
--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/search/SearchMainScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/search/SearchMainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -77,7 +76,7 @@ internal fun SearchMainScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .fillMaxHeight()
+                    .height(36.dp)
                     .background(
                         color = QuackColor.Gray4.composeColor,
                         shape = RoundedCornerShape(
@@ -89,8 +88,7 @@ internal fun SearchMainScreen(
                     ) {
                         vm.navigateToSearch()
                     }
-                    .padding(start = 12.dp)
-                    .padding(horizontal = 8.dp),
+                    .padding(start = 12.dp),
                 contentAlignment = Alignment.CenterStart,
             ) {
                 QuackBody1(

--- a/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/screen/SearchActivity.kt
+++ b/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/screen/SearchActivity.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.firebase.crashlytics.ktx.crashlytics

--- a/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/screen/SearchActivity.kt
+++ b/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/screen/SearchActivity.kt
@@ -21,11 +21,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.google.firebase.crashlytics.ktx.crashlytics
@@ -43,9 +45,9 @@ import team.duckie.app.android.navigator.feature.detail.DetailNavigator
 import team.duckie.app.android.navigator.feature.profile.ProfileNavigator
 import team.duckie.app.android.shared.ui.compose.DuckieCircularProgressIndicator
 import team.duckie.app.android.shared.ui.compose.ErrorScreen
+import team.duckie.app.android.shared.ui.compose.constant.SharedIcon
 import team.duckie.app.android.shared.ui.compose.quack.QuackNoUnderlineTextField
 import team.duckie.app.android.util.compose.collectAndHandleState
-import team.duckie.app.android.util.compose.systemBarPaddings
 import team.duckie.app.android.util.ui.BaseActivity
 import team.duckie.app.android.util.ui.const.Extras
 import team.duckie.app.android.util.ui.finishWithAnimation
@@ -95,13 +97,13 @@ class SearchActivity : BaseActivity() {
 
             QuackTheme {
                 Box(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .systemBarsPadding(),
                     contentAlignment = Alignment.Center,
                 ) {
                     Column(
-                        modifier = Modifier
-                            .background(QuackColor.White.composeColor)
-                            .padding(systemBarPaddings),
+                        modifier = Modifier.background(QuackColor.White.composeColor),
                     ) {
                         SearchTextFieldTopBar(
                             modifier = Modifier.padding(SearchHorizontalPadding),
@@ -111,6 +113,9 @@ class SearchActivity : BaseActivity() {
                             },
                             onPrevious = {
                                 finishWithAnimation()
+                            },
+                            clearSearchKeyword = {
+                                vm.clearSearchKeyword()
                             },
                         )
                         QuackAnimatedContent(
@@ -194,12 +199,13 @@ private fun SearchTextFieldTopBar(
     modifier: Modifier = Modifier,
     searchKeyword: String,
     onSearchKeywordChanged: (String) -> Unit,
+    clearSearchKeyword: () -> Unit,
     onPrevious: () -> Unit,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp),
+            .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
     ) {
@@ -215,6 +221,9 @@ private fun SearchTextFieldTopBar(
                 onSearchKeywordChanged(keyword)
             },
             placeholderText = stringResource(id = R.string.try_search),
+            trailingIcon = SharedIcon.ic_textfield_delete_16,
+            trailingIconOnClick = clearSearchKeyword,
+            trailingEndPadding = 13.dp,
         )
     }
 }

--- a/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/viewmodel/SearchViewModel.kt
+++ b/feature-ui-search/src/main/kotlin/team/duckie/app/android/feature/ui/search/viewmodel/SearchViewModel.kt
@@ -196,6 +196,11 @@ internal class SearchViewModel @Inject constructor(
         }
     }
 
+    /** 검색 키워드를 초기화 합니다.*/
+    fun clearSearchKeyword() {
+        updateSearchKeyword(keyword = "")
+    }
+
     /** 검색 키워드가 없다면 검색 화면으로 이동하고, 검색 키워드가 있다면 검색 결과로 이동한다. */
     private fun refreshSearchStep(keyword: String) = intent {
         if (keyword.isEmpty()) {

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/quack/QuackNoUnderlineTextField.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/quack/QuackNoUnderlineTextField.kt
@@ -7,47 +7,139 @@
 
 package team.duckie.app.android.shared.ui.compose.quack
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import team.duckie.quackquack.ui.component.QuackBasic2TextField
+import team.duckie.app.android.util.kotlin.runIf
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
-/**
- * [QuackBasic2TextField] 를 변형해서 구현한 underline이 없는 TextField
- */
 @Composable
 fun QuackNoUnderlineTextField(
     modifier: Modifier = Modifier,
     text: String,
     onTextChanged: (text: String) -> Unit,
     placeholderText: String? = null,
-    leadingStartPadding: Dp = 0.dp,
-    leadingIcon: QuackIcon? = null,
-    leadingIconOnClick: (() -> Unit)? = null,
     trailingEndPadding: Dp = 0.dp,
     trailingIcon: QuackIcon? = null,
     trailingIconOnClick: (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
     keyboardActions: KeyboardActions = KeyboardActions(),
 ) {
-    QuackBasic2TextField(
-        modifier = modifier,
-        text = text,
-        onTextChanged = onTextChanged,
-        placeholderText = placeholderText,
-        leadingStartPadding = leadingStartPadding,
-        leadingIcon = leadingIcon,
-        leadingIconOnClick = leadingIconOnClick,
-        trailingEndPadding = trailingEndPadding,
-        trailingIcon = trailingIcon,
-        trailingIconOnClick = trailingIconOnClick,
+    val quackTextFieldColors = QuackColor.DuckieOrange.composeColor
+    val isPlaceholder = text.isEmpty()
+
+    val inputTypography = remember(
+        key1 = isPlaceholder,
+    ) {
+        QuackTextStyle.Subtitle.runIf(
+            condition = isPlaceholder,
+        ) {
+            change(
+                color = QuackColor.Gray2,
+            )
+        }.asComposeStyle()
+    }
+
+    BasicTextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = QuackColor.White.composeColor,
+            )
+            .padding(
+                paddingValues = PaddingValues(
+                    top = 8.dp,
+                    bottom = 8.dp,
+                    start = 12.dp,
+                ),
+            ),
+        value = text,
+        onValueChange = onTextChanged,
+        textStyle = inputTypography,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
-        showIndicatorLine = false,
+        singleLine = true,
+        cursorBrush = SolidColor(
+            value = quackTextFieldColors,
+        ),
+        decorationBox = { textField ->
+            TextFieldDecoration(
+                textField = textField,
+                isPlaceholder = isPlaceholder,
+                placeholderText = placeholderText,
+                trailingIcon = trailingIcon,
+                trailingEndPadding = trailingEndPadding,
+                trailingIconOnClick = trailingIconOnClick,
+            )
+        },
     )
+}
+
+@Composable
+private fun TextFieldDecoration(
+    textField: @Composable () -> Unit,
+    isPlaceholder: Boolean,
+    placeholderText: String?,
+    trailingIcon: QuackIcon?,
+    trailingEndPadding: Dp = 0.dp,
+    trailingIconOnClick: (() -> Unit)?,
+) {
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        textField()
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isPlaceholder && placeholderText != null) {
+                Box(
+                    propagateMinConstraints = true,
+                ) {
+                    Text(
+                        text = placeholderText,
+                        style = QuackTextStyle.Body1.asComposeStyle().copy(
+                            color = QuackColor.Gray2.composeColor,
+                        ),
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            } else {
+                null
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            if (trailingIcon != null) {
+                QuackImage(
+                    src = trailingIcon,
+                    modifier = Modifier.padding(end = trailingEndPadding),
+                    onClick = trailingIconOnClick,
+                    size = DpSize(24.dp, 24.dp),
+                    rippleEnabled = false,
+                )
+            }
+        }
+    }
 }

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/quack/QuackNoUnderlineTextField.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/quack/QuackNoUnderlineTextField.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import team.duckie.app.android.util.kotlin.runIf
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 @Composable

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/quack/QuackNoUnderlineTextField.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/quack/QuackNoUnderlineTextField.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.app.android.shared.ui.compose.quack
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -41,7 +42,8 @@ fun QuackNoUnderlineTextField(
     onTextChanged: (text: String) -> Unit,
     placeholderText: String? = null,
     trailingEndPadding: Dp = 0.dp,
-    trailingIcon: QuackIcon? = null,
+    @DrawableRes
+    trailingIcon: Int? = null,
     trailingIconOnClick: (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
     keyboardActions: KeyboardActions = KeyboardActions(),
@@ -101,7 +103,8 @@ private fun TextFieldDecoration(
     textField: @Composable () -> Unit,
     isPlaceholder: Boolean,
     placeholderText: String?,
-    trailingIcon: QuackIcon?,
+    @DrawableRes
+    trailingIcon: Int?,
     trailingEndPadding: Dp = 0.dp,
     trailingIconOnClick: (() -> Unit)?,
 ) {
@@ -136,7 +139,7 @@ private fun TextFieldDecoration(
                     src = trailingIcon,
                     modifier = Modifier.padding(end = trailingEndPadding),
                     onClick = trailingIconOnClick,
-                    size = DpSize(24.dp, 24.dp),
+                    size = DpSize(16.dp, 16.dp),
                     rippleEnabled = false,
                 )
             }

--- a/shared-ui-compose/src/main/res/drawable/ic_textfield_delete_16.xml
+++ b/shared-ui-compose/src/main/res/drawable/ic_textfield_delete_16.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16h-16z"/>
+    <path
+        android:pathData="M15,8C15,4.134 11.866,1 8,1C4.134,1 1,4.134 1,8C1,11.866 4.134,15 8,15C11.866,15 15,11.866 15,8Z"
+        android:strokeAlpha="0.2"
+        android:fillColor="#222222"
+        android:fillAlpha="0.2"/>
+    <path
+        android:strokeWidth="1"
+        android:pathData="M10,6L6,10"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="round"/>
+    <path
+        android:strokeWidth="1"
+        android:pathData="M6,6L10,10"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="round"/>
+  </group>
+</vector>


### PR DESCRIPTION
## Issue

- close https://www.notion.so/duckie-team/5fe5db1de9d34d72b2db7b92b5231a27?pvs=4

## Overview (Required)

- padding 값이 QuackTextField 내부에 private으로 존재해서, QuackNoUnderlineTextField를 직접 구현했습니다.
- TextField에 Delete 아이콘을 추가했습니다.
- 검색 탭의 잘못된 padding값을 조정했습니다.

