### PR TITLE
태그 편집 화면 구축 & 태그 추가 화면 공통화 초기 작업

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
         projects.featureUiProfile,
         projects.featureUiSetting,
         projects.featureUiFriends,
+        projects.featureUiTagEdit,
         projects.navigator,
     )
     debugImplementation(libs.analytics.leakcanary)

--- a/data/src/main/kotlin/team/duckie/app/android/data/user/datasource/UserRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/user/datasource/UserRemoteDataSourceImpl.kt
@@ -68,7 +68,7 @@ class UserRemoteDataSourceImpl @Inject constructor(
         val response = client.patch("/users/$id") {
             jsonBody {
                 categories?.let { "favoriteCategories" withInts categories.fastMap { it.id } }
-                tags?.let { "favoriteTags" withInts tags.fastMap { it.id } }
+                tags?.let { "favoriteTagIds" withInts tags.fastMap { it.id } }
                 profileImageUrl?.let { "profileImageUrl" withString profileImageUrl }
                 nickname?.let { "nickName" withString nickname }
                 introduction?.let { "introduction" withString introduction }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/MainActivity.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/MainActivity.kt
@@ -36,6 +36,7 @@ import team.duckie.app.android.navigator.feature.profile.ProfileEditNavigator
 import team.duckie.app.android.navigator.feature.profile.ProfileNavigator
 import team.duckie.app.android.navigator.feature.search.SearchNavigator
 import team.duckie.app.android.navigator.feature.setting.SettingNavigator
+import team.duckie.app.android.navigator.feature.tagedit.TagEditNavigator
 import team.duckie.app.android.shared.ui.compose.dialog.ReportDialog
 import team.duckie.app.android.util.kotlin.AllowMagicNumber
 import team.duckie.app.android.util.ui.BaseActivity
@@ -62,6 +63,9 @@ class MainActivity : BaseActivity() {
 
     @Inject
     lateinit var detailNavigator: DetailNavigator
+
+    @Inject
+    lateinit var tagEditNavigator: TagEditNavigator
 
     @Inject
     lateinit var settingNavigator: SettingNavigator
@@ -126,6 +130,14 @@ class MainActivity : BaseActivity() {
                     },
                     navigateToEditProfile = {
                         profileEditNavigator.navigateFrom(
+                            activity = this,
+                            intentBuilder = {
+                                putExtra(Extras.UserId, it)
+                            },
+                        )
+                    },
+                    navigateToTagEdit = {
+                        tagEditNavigator.navigateFrom(
                             activity = this,
                             intentBuilder = {
                                 putExtra(Extras.UserId, it)

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/MainScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/MainScreen.kt
@@ -101,6 +101,7 @@ internal fun MainScreen(
     state: MainState,
     navigateToUserProfile: (Int) -> Unit,
     navigateToEditProfile: (Int) -> Unit,
+    navigateToTagEdit: (Int) -> Unit,
 ) {
     Layout(
         modifier = Modifier
@@ -172,6 +173,9 @@ internal fun MainScreen(
                         },
                         navigateToEditProfile = { userId ->
                             navigateToEditProfile(userId)
+                        },
+                        navigateToTagEdit = { userId ->
+                            navigateToTagEdit(userId)
                         },
                     )
                 }

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/mypage/MypageScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/mypage/MypageScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import team.duckie.app.android.feature.ui.home.R
 import team.duckie.app.android.feature.ui.home.viewmodel.mypage.MyPageViewModel
 import team.duckie.app.android.feature.ui.home.viewmodel.mypage.MyPageSideEffect
 import team.duckie.app.android.feature.ui.profile.screen.MyProfileScreen

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/mypage/MypageScreen.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/screen/mypage/MypageScreen.kt
@@ -37,6 +37,7 @@ internal fun MyPageScreen(
     navigateToSearch: (String) -> Unit,
     navigateToFriend: (FriendsType, Int) -> Unit,
     navigateToEditProfile: (Int) -> Unit,
+    navigateToTagEdit: (Int) -> Unit,
     viewModel: MyPageViewModel,
 ) {
     val state by viewModel.container.stateFlow.collectAsStateWithLifecycle()
@@ -86,6 +87,10 @@ internal fun MyPageScreen(
                 is MyPageSideEffect.NavigateToEditProfile -> {
                     navigateToEditProfile(sideEffect.userId)
                 }
+
+                is MyPageSideEffect.NavigateToTagEdit -> {
+                    navigateToTagEdit(sideEffect.userId)
+                }
             }
         }
     }
@@ -107,7 +112,7 @@ internal fun MyPageScreen(
                 onClickSetting = viewModel::clickSetting,
                 onClickNotification = viewModel::clickNotification,
                 onClickEditProfile = viewModel::clickEditProfile,
-                onClickEditTag = { viewModel.clickEditTag(context.getString(R.string.provide_after)) },
+                onClickEditTag = viewModel::clickEditTag,
                 onClickExam = viewModel::clickExam,
                 onClickMakeExam = viewModel::clickMakeExam,
                 onClickTag = viewModel::onClickTag,

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageSideEffect.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageSideEffect.kt
@@ -20,6 +20,8 @@ sealed class MyPageSideEffect {
 
     class NavigateToExamDetail(val examId: Int) : MyPageSideEffect()
 
+    class NavigateToTagEdit(val userId: Int) : MyPageSideEffect()
+
     class SendToast(val message: String) : MyPageSideEffect()
 
     class NavigateToSearch(val tagName: String) : MyPageSideEffect()

--- a/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageViewModel.kt
+++ b/feature-ui-home/src/main/kotlin/team/duckie/app/android/feature/ui/home/viewmodel/mypage/MyPageViewModel.kt
@@ -93,8 +93,13 @@ internal class MyPageViewModel @Inject constructor(
         )
     }
 
-    override fun clickEditTag(message: String) = intent {
-        postSideEffect(MyPageSideEffect.SendToast(message))
+    override fun clickEditTag() = intent {
+        postSideEffect(
+            MyPageSideEffect.NavigateToTagEdit(
+                userId = state.userProfile.user?.id
+                    ?: throw DuckieClientLogicProblemException(code = "User is null"),
+            ),
+        )
     }
 
     override fun clickMakeExam() = intent {

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/ProfileActivity.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/ProfileActivity.kt
@@ -44,6 +44,7 @@ import team.duckie.app.android.util.ui.finishWithAnimation
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
+import team.duckie.app.android.util.kotlin.AllowCyclomaticComplexMethod
 
 @AndroidEntryPoint
 class ProfileActivity : BaseActivity() {
@@ -135,6 +136,7 @@ class ProfileActivity : BaseActivity() {
         )
     }
 
+    @AllowCyclomaticComplexMethod
     private fun handleSideEffect(sideEffect: ProfileSideEffect) {
         when (sideEffect) {
             ProfileSideEffect.NavigateToBack -> {

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/ProfileActivity.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/ProfileActivity.kt
@@ -30,6 +30,7 @@ import team.duckie.app.android.navigator.feature.profile.ProfileEditNavigator
 import team.duckie.app.android.navigator.feature.search.SearchNavigator
 import team.duckie.app.android.navigator.feature.setting.SettingNavigator
 import team.duckie.app.android.shared.ui.compose.ErrorScreen
+import team.duckie.app.android.navigator.feature.tagedit.TagEditNavigator
 import team.duckie.app.android.shared.ui.compose.LoadingScreen
 import team.duckie.app.android.shared.ui.compose.dialog.ReportAlreadyExists
 import team.duckie.app.android.util.compose.LaunchOnLifecycle
@@ -56,6 +57,9 @@ class ProfileActivity : BaseActivity() {
 
     @Inject
     lateinit var detailNavigator: DetailNavigator
+
+    @Inject
+    lateinit var tagEditNavigator: TagEditNavigator
 
     @Inject
     lateinit var settingNavigator: SettingNavigator
@@ -109,7 +113,7 @@ class ProfileActivity : BaseActivity() {
                                     onClickSetting = viewModel::clickSetting,
                                     onClickNotification = viewModel::clickNotification,
                                     onClickEditProfile = viewModel::clickEditProfile,
-                                    onClickEditTag = { viewModel.clickEditTag(getString(R.string.provide_after)) },
+                                    onClickEditTag = viewModel::clickEditTag,
                                     onClickExam = viewModel::clickExam,
                                     onClickMakeExam = viewModel::clickMakeExam,
                                     onClickTag = viewModel::onClickTag,
@@ -154,6 +158,15 @@ class ProfileActivity : BaseActivity() {
                     activity = this@ProfileActivity,
                     intentBuilder = {
                         putExtra(Extras.ExamId, sideEffect.examId)
+                    },
+                )
+            }
+
+            is ProfileSideEffect.NavigateToTagEdit -> {
+                tagEditNavigator.navigateFrom(
+                    activity = this@ProfileActivity,
+                    intentBuilder = {
+                        putExtra(Extras.UserId, sideEffect.userId)
                     },
                 )
             }

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/ProfileViewModel.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/ProfileViewModel.kt
@@ -174,8 +174,8 @@ internal class ProfileViewModel @Inject constructor(
         postSideEffect(ProfileSideEffect.NavigateToEditProfile(state.userId))
     }
 
-    override fun clickEditTag(message: String) = intent {
-        postSideEffect(ProfileSideEffect.SendToast(message))
+    override fun clickEditTag() = intent {
+        postSideEffect(ProfileSideEffect.NavigateToTagEdit(state.userId))
     }
 
     override fun clickMakeExam() = intent {

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/intent/MyPageIntent.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/intent/MyPageIntent.kt
@@ -14,7 +14,7 @@ interface MyPageIntent {
 
     fun clickEditProfile()
 
-    fun clickEditTag(message: String)
+    fun clickEditTag()
 
     fun clickMakeExam()
 }

--- a/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/sideeffect/ProfileSideEffect.kt
+++ b/feature-ui-profile/src/main/kotlin/team/duckie/app/android/feature/ui/profile/viewmodel/sideeffect/ProfileSideEffect.kt
@@ -28,6 +28,8 @@ sealed class ProfileSideEffect {
 
     class NavigateToEditProfile(val userId: Int) : ProfileSideEffect()
 
+    class NavigateToTagEdit(val userId: Int) : ProfileSideEffect()
+
     class SendToast(val message: String) : ProfileSideEffect()
 
     class NavigateToFriends(val friendType: FriendsType, val userId: Int) : ProfileSideEffect()

--- a/feature-ui-tag-edit/build.gradle.kts
+++ b/feature-ui-tag-edit/build.gradle.kts
@@ -1,0 +1,37 @@
+import DependencyHandler.Extensions.implementations
+
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+plugins {
+    id(ConventionEnum.AndroidLibrary)
+    id(ConventionEnum.AndroidLibraryCompose)
+    id(ConventionEnum.AndroidHilt)
+}
+
+android {
+    namespace = "team.duckie.app.android.feature.ui.tag.edit"
+}
+
+dependencies {
+    implementations(
+        platform(libs.firebase.bom),
+        projects.di,
+        projects.domain,
+        projects.utilUi,
+        projects.navigator,
+        projects.utilKotlin,
+        projects.utilCompose,
+        projects.sharedUiCompose,
+        libs.orbit.viewmodel,
+        libs.orbit.compose,
+        libs.quack.ui.components,
+        libs.compose.lifecycle.runtime,
+        libs.compose.ui.material, // needs for CircularProgressIndicator
+        libs.firebase.crashlytics,
+    )
+}

--- a/feature-ui-tag-edit/build.gradle.kts
+++ b/feature-ui-tag-edit/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
         projects.navigator,
         projects.utilKotlin,
         projects.utilCompose,
+        projects.utilExceptionHandling,
         projects.sharedUiCompose,
         libs.orbit.viewmodel,
         libs.orbit.compose,

--- a/feature-ui-tag-edit/src/main/AndroidManifest.xml
+++ b/feature-ui-tag-edit/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Designed and developed by Duckie Team, 2022
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name="TagEditActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
@@ -12,6 +12,7 @@ import org.orbitmvi.orbit.viewmodel.observe
 import team.duckie.app.android.feature.ui.tag.edit.screen.TagEditScreen
 import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditSideEffect
 import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditViewModel
+import team.duckie.app.android.util.exception.handling.reporter.reportToCrashlyticsIfNeeded
 import team.duckie.app.android.util.ui.BaseActivity
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
@@ -41,6 +42,18 @@ class TagEditActivity : BaseActivity() {
     }
 
     private fun handleSideEffect(sideEffect: TagEditSideEffect) {
+        when(sideEffect) {
+            is TagEditSideEffect.ReportError -> {
+                sideEffect.exception.reportToCrashlyticsIfNeeded()
+            }
 
+            is TagEditSideEffect.FinishTagEdit -> {
+                finish()
+            }
+
+            TagEditSideEffect.AddTagEdit -> {
+                // TODO(riflockle7): 태그 추가 화면으로 이동
+            }
+        }
     }
 }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
@@ -42,7 +42,7 @@ class TagEditActivity : BaseActivity() {
     }
 
     private fun handleSideEffect(sideEffect: TagEditSideEffect) {
-        when(sideEffect) {
+        when (sideEffect) {
             is TagEditSideEffect.ReportError -> {
                 sideEffect.exception.reportToCrashlyticsIfNeeded()
             }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
@@ -50,10 +50,6 @@ class TagEditActivity : BaseActivity() {
             is TagEditSideEffect.FinishTagEdit -> {
                 finish()
             }
-
-            TagEditSideEffect.AddTagEdit -> {
-                // TODO(riflockle7): 태그 추가 화면으로 이동
-            }
         }
     }
 }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/TagEditActivity.kt
@@ -1,0 +1,46 @@
+package team.duckie.app.android.feature.ui.tag.edit
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.ui.Modifier
+import dagger.hilt.android.AndroidEntryPoint
+import org.orbitmvi.orbit.viewmodel.observe
+import team.duckie.app.android.feature.ui.tag.edit.screen.TagEditScreen
+import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditSideEffect
+import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditViewModel
+import team.duckie.app.android.util.ui.BaseActivity
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.theme.QuackTheme
+
+@AndroidEntryPoint
+class TagEditActivity : BaseActivity() {
+    private val viewModel: TagEditViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            QuackTheme {
+                TagEditScreen(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(color = QuackColor.White.composeColor)
+                        .systemBarsPadding(),
+                )
+            }
+        }
+
+        viewModel.observe(
+            lifecycleOwner = this@TagEditActivity,
+            sideEffect = ::handleSideEffect,
+        )
+    }
+
+    private fun handleSideEffect(sideEffect: TagEditSideEffect) {
+
+    }
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/navigator/impl/TagEditNavigatorImpl.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/navigator/impl/TagEditNavigatorImpl.kt
@@ -1,0 +1,28 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.tag.edit.navigator.impl
+
+import team.duckie.app.android.feature.ui.tag.edit.TagEditActivity
+import android.app.Activity
+import android.content.Intent
+import team.duckie.app.android.navigator.feature.tagedit.TagEditNavigator
+import team.duckie.app.android.util.ui.startActivityWithAnimation
+import javax.inject.Inject
+
+internal class TagEditNavigatorImpl @Inject constructor() : TagEditNavigator {
+    override fun navigateFrom(
+        activity: Activity,
+        intentBuilder: Intent.() -> Intent,
+        withFinish: Boolean,
+    ) {
+        activity.startActivityWithAnimation<TagEditActivity>(
+            intentBuilder = intentBuilder,
+            withFinish = withFinish,
+        )
+    }
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/navigator/module/TagEditNavigatorModule.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/navigator/module/TagEditNavigatorModule.kt
@@ -1,0 +1,25 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.tag.edit.navigator.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import team.duckie.app.android.feature.ui.tag.edit.navigator.impl.TagEditNavigatorImpl
+import team.duckie.app.android.navigator.feature.tagedit.TagEditNavigator
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class TagEditNavigatorModule {
+
+    @Singleton
+    @Binds
+    abstract fun bindTagEditNavigator(navigator: TagEditNavigatorImpl): TagEditNavigator
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
@@ -80,7 +80,7 @@ fun TagEditSuccessScreen(
     modifier: Modifier,
     state: TagEditState.Success,
     onEditFinishClick: () -> Unit,
-    onTrailingClick: () -> Unit,
+    onTrailingClick: (Int) -> Unit,
     onAddTagClick: () -> Unit,
     onTagClick: (Int) -> Unit,
 ) {
@@ -108,7 +108,7 @@ fun TagEditSuccessScreen(
                     color = QuackColor.DuckieOrange,
                     singleLine = true,
                 )
-            }
+            },
         )
 
         // 내 관심 태그 영역

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
@@ -1,0 +1,80 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.tag.edit.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.toPersistentList
+import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.feature.ui.tag.edit.R
+import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditState
+import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditViewModel
+import team.duckie.app.android.shared.ui.compose.ErrorScreen
+import team.duckie.app.android.shared.ui.compose.FavoriteTagSection
+import team.duckie.app.android.shared.ui.compose.LoadingScreen
+import team.duckie.app.android.util.compose.activityViewModel
+import team.duckie.quackquack.ui.component.QuackLargeButton
+import team.duckie.quackquack.ui.component.QuackLargeButtonType
+
+@Composable
+internal fun TagEditScreen(
+    vm: TagEditViewModel = activityViewModel(),
+    modifier: Modifier,
+) {
+    val state = vm.collectAsState().value
+
+    when (state) {
+        is TagEditState.Loading -> LoadingScreen(
+            modifier = modifier,
+            initState = vm::initState,
+        )
+
+        is TagEditState.Success -> TagEditSuccessScreen(
+            modifier = modifier,
+            state = state,
+            onAddTagClick = vm::onAddTagClick,
+            onTagClick = vm::onTagClick,
+        )
+
+        is TagEditState.Error -> ErrorScreen(
+            modifier = modifier,
+            onRetryClick = vm::initState,
+        )
+    }
+}
+
+@Composable
+fun TagEditSuccessScreen(
+    modifier: Modifier,
+    state: TagEditState.Success,
+    onAddTagClick: () -> Unit,
+    onTagClick: (String) -> Unit,
+) {
+    Column {
+        FavoriteTagSection(
+            modifier = modifier,
+            title = stringResource(id = R.string.my_favorite_tag),
+            contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp),
+            tags = state.myTags.map { it.name }.toPersistentList(),
+            emptySection = {
+                QuackLargeButton(
+                    type = QuackLargeButtonType.Compact,
+                    text = stringResource(id = R.string.add_favorite_tag),
+                    onClick = onAddTagClick,
+                )
+            },
+            onTagClick = onTagClick,
+            addButtonTitle = stringResource(id = R.string.add_favorite_tag),
+            onAddTagClick = onAddTagClick,
+        )
+    }
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.feature.ui.tag.edit.R
@@ -28,8 +29,6 @@ import team.duckie.app.android.shared.ui.compose.LoadingScreen
 import team.duckie.app.android.shared.ui.compose.screen.SearchTagScreen
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackLargeButton
-import team.duckie.quackquack.ui.component.QuackLargeButtonType
 import team.duckie.quackquack.ui.component.QuackSubtitle
 import team.duckie.quackquack.ui.component.QuackTopAppBar
 import team.duckie.quackquack.ui.icon.QuackIcon
@@ -40,9 +39,7 @@ internal fun TagEditScreen(
     vm: TagEditViewModel = activityViewModel(),
     modifier: Modifier,
 ) {
-    val state = vm.collectAsState().value
-
-    when (state) {
+    when (val state = vm.collectAsState().value) {
         is TagEditState.Loading -> LoadingScreen(
             modifier = modifier,
             initState = vm::initState,
@@ -64,10 +61,11 @@ internal fun TagEditScreen(
             multiSelectMode = false,
             onCloseClick = vm::onAddFinishClick,
             onBackPressed = vm::onAddFinishClick,
-            onClickSearchListHeader = { vm.onSearchTagClick(0) },
+            onClickSearchListHeader = vm::onSearchTagHeaderClick,
             onClickSearchList = { index -> vm.onSearchTagClick(index) },
             onTextChanged = { newSearchTextValue -> vm.onSearchTextChanged(newSearchTextValue) },
             onSearchTextValidate = { searchTextValue -> vm.onSearchTextValidate(searchTextValue) },
+            searchResults = state.searchResults.map { it.name }.toImmutableList(),
         )
 
         is TagEditState.Error -> ErrorScreen(
@@ -122,13 +120,7 @@ fun TagEditSuccessScreen(
             trailingIcon = QuackIcon.Close,
             onTrailingClick = onTrailingClick,
             tags = state.myTags.map { it.name }.toPersistentList(),
-            emptySection = {
-                QuackLargeButton(
-                    type = QuackLargeButtonType.Compact,
-                    text = stringResource(id = R.string.tag_edit_add_favorite_tag),
-                    onClick = onAddTagClick,
-                )
-            },
+            emptySection = {},
             singleLine = false,
             onTagClick = onTagClick,
             addButtonTitle = stringResource(id = R.string.tag_edit_add_favorite_tag),

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
@@ -7,10 +7,14 @@
 
 package team.duckie.app.android.feature.ui.tag.edit.screen
 
+import android.app.Activity
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toPersistentList
@@ -22,8 +26,13 @@ import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.FavoriteTagSection
 import team.duckie.app.android.shared.ui.compose.LoadingScreen
 import team.duckie.app.android.util.compose.activityViewModel
+import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackLargeButton
 import team.duckie.quackquack.ui.component.QuackLargeButtonType
+import team.duckie.quackquack.ui.component.QuackSubtitle
+import team.duckie.quackquack.ui.component.QuackTopAppBar
+import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.ui.modifier.quackClickable
 
 @Composable
 internal fun TagEditScreen(
@@ -41,6 +50,8 @@ internal fun TagEditScreen(
         is TagEditState.Success -> TagEditSuccessScreen(
             modifier = modifier,
             state = state,
+            onEditFinishClick = vm::onEditFinishClick,
+            onTrailingClick = vm::onTrailingClick,
             onAddTagClick = vm::onAddTagClick,
             onTagClick = vm::onTagClick,
         )
@@ -56,24 +67,57 @@ internal fun TagEditScreen(
 fun TagEditSuccessScreen(
     modifier: Modifier,
     state: TagEditState.Success,
+    onEditFinishClick: () -> Unit,
+    onTrailingClick: () -> Unit,
     onAddTagClick: () -> Unit,
-    onTagClick: (String) -> Unit,
+    onTagClick: (Int) -> Unit,
 ) {
-    Column {
+    val activity = LocalContext.current as Activity
+
+    Column(modifier = modifier) {
+        // 상단 탭바
+        QuackTopAppBar(
+            leadingIcon = QuackIcon.ArrowBack,
+            leadingText = stringResource(R.string.title),
+            onLeadingIconClick = activity::finish,
+            trailingContent = {
+                QuackSubtitle(
+                    modifier = Modifier
+                        .then(Modifier) // prevent Modifier.Companion
+                        .quackClickable(
+                            rippleEnabled = false,
+                            onClick = onEditFinishClick,
+                        )
+                        .padding(
+                            vertical = 4.dp,
+                            horizontal = 16.dp,
+                        ),
+                    text = stringResource(R.string.edit_finish),
+                    color = QuackColor.DuckieOrange,
+                    singleLine = true,
+                )
+            }
+        )
+
+        // 내 관심 태그 영역
         FavoriteTagSection(
-            modifier = modifier,
+            modifier = Modifier.padding(vertical = 20.dp),
             title = stringResource(id = R.string.my_favorite_tag),
-            contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp),
+            horizontalPadding = PaddingValues(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            trailingIcon = QuackIcon.Close,
+            onTrailingClick = onTrailingClick,
             tags = state.myTags.map { it.name }.toPersistentList(),
             emptySection = {
                 QuackLargeButton(
                     type = QuackLargeButtonType.Compact,
-                    text = stringResource(id = R.string.add_favorite_tag),
+                    text = stringResource(id = R.string.tag_edit_add_favorite_tag),
                     onClick = onAddTagClick,
                 )
             },
+            singleLine = false,
             onTagClick = onTagClick,
-            addButtonTitle = stringResource(id = R.string.add_favorite_tag),
+            addButtonTitle = stringResource(id = R.string.tag_edit_add_favorite_tag),
             onAddTagClick = onAddTagClick,
         )
     }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/screen/TagEditScreen.kt
@@ -25,6 +25,7 @@ import team.duckie.app.android.feature.ui.tag.edit.viewmodel.TagEditViewModel
 import team.duckie.app.android.shared.ui.compose.ErrorScreen
 import team.duckie.app.android.shared.ui.compose.FavoriteTagSection
 import team.duckie.app.android.shared.ui.compose.LoadingScreen
+import team.duckie.app.android.shared.ui.compose.screen.SearchTagScreen
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackLargeButton
@@ -54,6 +55,19 @@ internal fun TagEditScreen(
             onTrailingClick = vm::onTrailingClick,
             onAddTagClick = vm::onAddTagClick,
             onTagClick = vm::onTagClick,
+        )
+
+        is TagEditState.AddTag -> SearchTagScreen(
+            modifier = modifier,
+            title = stringResource(id = R.string.add_tag_title),
+            placeholderText = stringResource(id = R.string.add_tag_placeholder),
+            multiSelectMode = false,
+            onCloseClick = vm::onAddFinishClick,
+            onBackPressed = vm::onAddFinishClick,
+            onClickSearchListHeader = { vm.onSearchTagClick(0) },
+            onClickSearchList = { index -> vm.onSearchTagClick(index) },
+            onTextChanged = { newSearchTextValue -> vm.onSearchTextChanged(newSearchTextValue) },
+            onSearchTextValidate = { searchTextValue -> vm.onSearchTextValidate(searchTextValue) },
         )
 
         is TagEditState.Error -> ErrorScreen(

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditSideEffect.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditSideEffect.kt
@@ -1,0 +1,19 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.tag.edit.viewmodel
+
+sealed interface TagEditSideEffect {
+
+    /**
+     * [TagEditViewModel] 의 비즈니스 로직 처리 중에 발생한 예외를 [exception] 으로 받고
+     * 해당 exception 을 [FirebaseCrashlytics] 에 제보합니다.
+     *
+     * @param exception 발생한 예외
+     */
+    class ReportError(val exception: Throwable) : TagEditSideEffect
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditSideEffect.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditSideEffect.kt
@@ -22,11 +22,4 @@ sealed interface TagEditSideEffect {
      * @param needRefresh 새로고침 필요한 지 여부 (ex. 태그 수정 성공했을 때 새로고침 필요)
      */
     class FinishTagEdit(val needRefresh: Boolean) : TagEditSideEffect
-
-    /**
-     * 태그 추가 버튼 클릭 시 동작하는 SideEffect
-     *
-     * @param needRefresh 새로고침 필요한 지 여부 (ex. 태그 수정 성공했을 때 새로고침 필요)
-     */
-    object AddTagEdit : TagEditSideEffect
 }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditSideEffect.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditSideEffect.kt
@@ -8,7 +8,6 @@
 package team.duckie.app.android.feature.ui.tag.edit.viewmodel
 
 sealed interface TagEditSideEffect {
-
     /**
      * [TagEditViewModel] 의 비즈니스 로직 처리 중에 발생한 예외를 [exception] 으로 받고
      * 해당 exception 을 [FirebaseCrashlytics] 에 제보합니다.
@@ -16,4 +15,18 @@ sealed interface TagEditSideEffect {
      * @param exception 발생한 예외
      */
     class ReportError(val exception: Throwable) : TagEditSideEffect
+
+    /**
+     * 태그 수정을 마친 경우 방출하는 SideEffect
+     *
+     * @param needRefresh 새로고침 필요한 지 여부 (ex. 태그 수정 성공했을 때 새로고침 필요)
+     */
+    class FinishTagEdit(val needRefresh: Boolean) : TagEditSideEffect
+
+    /**
+     * 태그 추가 버튼 클릭 시 동작하는 SideEffect
+     *
+     * @param needRefresh 새로고침 필요한 지 여부 (ex. 태그 수정 성공했을 때 새로고침 필요)
+     */
+    object AddTagEdit : TagEditSideEffect
 }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditState.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditState.kt
@@ -11,7 +11,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import team.duckie.app.android.domain.tag.model.Tag
 
-
 sealed class TagEditState {
     object Loading : TagEditState()
 

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditState.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditState.kt
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.tag.edit.viewmodel
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import team.duckie.app.android.domain.tag.model.Tag
+import team.duckie.app.android.domain.user.model.User
+
+
+sealed class TagEditState {
+    object Loading : TagEditState()
+
+    class Success(
+        val me: User,
+        val myTags: ImmutableList<Tag> = persistentListOf(),
+        val categoryTagList: ImmutableList<ImmutableList<Tag>> = persistentListOf(),
+    ) : TagEditState()
+
+    data class Error(val exception: Throwable) : TagEditState()
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditState.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditState.kt
@@ -10,16 +10,18 @@ package team.duckie.app.android.feature.ui.tag.edit.viewmodel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import team.duckie.app.android.domain.tag.model.Tag
-import team.duckie.app.android.domain.user.model.User
 
 
 sealed class TagEditState {
     object Loading : TagEditState()
 
     class Success(
-        val me: User,
         val myTags: ImmutableList<Tag> = persistentListOf(),
         val categoryTagList: ImmutableList<ImmutableList<Tag>> = persistentListOf(),
+    ) : TagEditState()
+
+    class AddTag(
+        val searchResults: ImmutableList<Tag> = persistentListOf(),
     ) : TagEditState()
 
     data class Error(val exception: Throwable) : TagEditState()

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditViewModel.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditViewModel.kt
@@ -32,16 +32,27 @@ internal class TagEditViewModel @Inject constructor(
                         TagEditState.Success(me = me)
                     }
                 }.onFailure {
+                    reduce { TagEditState.Error(it) }
                     postSideEffect(TagEditSideEffect.ReportError(it))
                 }
         }
     }
 
-    fun onAddTagClick() {
-
+    /** 수정완료 버튼 누를 시 동작 */
+    fun onEditFinishClick() {
+        intent { postSideEffect(TagEditSideEffect.FinishTagEdit(true)) }
     }
 
-    fun onTagClick(tag: String) {
+    /** + 직접 태그 추가하기 버튼 클릭 시 동작 */
+    fun onAddTagClick() {
+        intent { postSideEffect(TagEditSideEffect.AddTagEdit) }
+    }
 
+    /** 각 태그 항목의 x 버튼 클릭 시 동작 */
+    fun onTrailingClick() {
+    }
+
+    /** 각 태그 항목 클릭 시 동작 */
+    fun onTagClick(index: Int) {
     }
 }

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditViewModel.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditViewModel.kt
@@ -1,0 +1,47 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.tag.edit.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.domain.user.usecase.GetMeUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+internal class TagEditViewModel @Inject constructor(
+    private val getMeUseCase: GetMeUseCase,
+) : ContainerHost<TagEditState, TagEditSideEffect>, ViewModel() {
+
+    override val container = container<TagEditState, TagEditSideEffect>(TagEditState.Loading)
+
+    fun initState() {
+        intent {
+            getMeUseCase()
+                .onSuccess { me ->
+                    reduce {
+                        TagEditState.Success(me = me)
+                    }
+                }.onFailure {
+                    postSideEffect(TagEditSideEffect.ReportError(it))
+                }
+        }
+    }
+
+    fun onAddTagClick() {
+
+    }
+
+    fun onTagClick(tag: String) {
+
+    }
+}

--- a/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditViewModel.kt
+++ b/feature-ui-tag-edit/src/main/kotlin/team/duckie/app/android/feature/ui/tag/edit/viewmodel/TagEditViewModel.kt
@@ -8,28 +8,46 @@
 package team.duckie.app.android.feature.ui.tag.edit.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.domain.tag.model.Tag
+import team.duckie.app.android.domain.tag.usecase.TagCreateUseCase
+import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.domain.user.usecase.GetMeUseCase
 import javax.inject.Inject
 
 @HiltViewModel
 internal class TagEditViewModel @Inject constructor(
     private val getMeUseCase: GetMeUseCase,
+    private val tagCreateUseCase: TagCreateUseCase,
 ) : ContainerHost<TagEditState, TagEditSideEffect>, ViewModel() {
 
     override val container = container<TagEditState, TagEditSideEffect>(TagEditState.Loading)
 
+    private var me: User = User.empty()
+    private var myTags: ImmutableList<Tag> = persistentListOf()
+
     fun initState() {
         intent {
             getMeUseCase()
-                .onSuccess { me ->
+                .onSuccess { meResponse ->
+                    me = meResponse
+                    myTags = me.favoriteTags?.toImmutableList() ?: persistentListOf()
+
                     reduce {
-                        TagEditState.Success(me = me)
+                        TagEditState.Success(
+                            myTags = me.favoriteTags?.toImmutableList() ?: persistentListOf(),
+                        )
                     }
                 }.onFailure {
                     reduce { TagEditState.Error(it) }
@@ -45,14 +63,38 @@ internal class TagEditViewModel @Inject constructor(
 
     /** + 직접 태그 추가하기 버튼 클릭 시 동작 */
     fun onAddTagClick() {
-        intent { postSideEffect(TagEditSideEffect.AddTagEdit) }
+        intent {
+            reduce { TagEditState.AddTag() }
+        }
     }
 
     /** 각 태그 항목의 x 버튼 클릭 시 동작 */
     fun onTrailingClick() {
     }
 
-    /** 각 태그 항목 클릭 시 동작 */
+    /** 태그 편집 화면에서, 각 태그 항목 클릭 시 동작 */
     fun onTagClick(index: Int) {
+    }
+
+    /** 태그 추가 화면 종료 시 동작 */
+    fun onAddFinishClick() {
+        intent { reduce { TagEditState.Success() } }
+    }
+
+    /** 태그 추가 화면에서, 검색된 항목 클릭 시 동작 */
+    fun onSearchTagClick(index: Int) = viewModelScope.launch {
+    }
+
+    /** 태그 추가 화면에서, 텍스트 내용 변경 시 동작 */
+    fun onSearchTextChanged(newSearchTextValue: String) {
+    }
+
+    /** 태그 추가 화면에서, 텍스트 유효성 체크 */
+    fun onSearchTextValidate(searchTextValue: String): Boolean {
+        return true
+    }
+
+    private suspend fun addMyTag(newTag: Tag) {
+        myTags = myTags.toMutableList().apply { add(newTag) }.toPersistentList()
     }
 }

--- a/feature-ui-tag-edit/src/main/res/values/strings.xml
+++ b/feature-ui-tag-edit/src/main/res/values/strings.xml
@@ -7,8 +7,10 @@
 
 <resources>
     <string name="title">태그 편집</string>
+    <string name="edit_finish">수정완료</string>
 
     <string name="my_favorite_tag">내 관심 태그</string>
+    <!-- TODO(riflockle7): 왜 add_favorite_tag 로 하면 feature-ui-profile 모듈의 resource 가 잡히는 지 모르겠음 -->
+    <string name="tag_edit_add_favorite_tag">+ 직접 태그 추가하기</string>
     <string name="not_yet_add_favorite_tag">추가한 관심태그가 없어요 :(</string>
-    <string name="add_favorite_tag">직접 태그 추가하기</string>
 </resources>

--- a/feature-ui-tag-edit/src/main/res/values/strings.xml
+++ b/feature-ui-tag-edit/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <!-- TODO(riflockle7): 왜 add_favorite_tag 로 하면 feature-ui-profile 모듈의 resource 가 잡히는 지 모르겠음 -->
     <string name="tag_edit_add_favorite_tag">+ 직접 태그 추가하기</string>
     <string name="not_yet_add_favorite_tag">추가한 관심태그가 없어요 :(</string>
+
+    <string name="add_tag_title">태그 추가</string>
+    <string name="add_tag_placeholder">새로 추가할 태그를 검색해주세요.</string>
 </resources>

--- a/feature-ui-tag-edit/src/main/res/values/strings.xml
+++ b/feature-ui-tag-edit/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Designed and developed by Duckie Team, 2022
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+  -->
+
+<resources>
+    <string name="title">태그 편집</string>
+
+    <string name="my_favorite_tag">내 관심 태그</string>
+    <string name="not_yet_add_favorite_tag">추가한 관심태그가 없어요 :(</string>
+    <string name="add_favorite_tag">직접 태그 추가하기</string>
+</resources>

--- a/navigator/src/main/kotlin/team/duckie/app/android/navigator/feature/tagedit/TagEditNavigator.kt
+++ b/navigator/src/main/kotlin/team/duckie/app/android/navigator/feature/tagedit/TagEditNavigator.kt
@@ -1,0 +1,12 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.navigator.feature.tagedit
+
+import team.duckie.app.android.navigator.base.Navigator
+
+interface TagEditNavigator : Navigator

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,7 @@ include(
     ":feature-ui-exam-result",
     ":feature-ui-profile",
     ":feature-ui-friends",
+    ":feature-ui-tag-edit",
     ":shared-ui-compose",
     ":util-ui",
     ":util-kotlin",

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/FavoriteTagSection.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/FavoriteTagSection.kt
@@ -40,6 +40,7 @@ import team.duckie.quackquack.ui.icon.QuackIcon
  * @param onAddTagClick 태그 추가 버튼 클릭 시 처리
  * @param addButtonTitle 추가 버튼 제목
  */
+@Suppress("unused")
 @Composable
 fun FavoriteTagSection(
     modifier: Modifier = Modifier,
@@ -47,7 +48,7 @@ fun FavoriteTagSection(
     horizontalPadding: PaddingValues = PaddingValues(0.dp),
     verticalArrangement: Arrangement.HorizontalOrVertical = Arrangement.spacedBy(0.dp),
     trailingIcon: QuackIcon? = null,
-    onTrailingClick: (() -> Unit)? = null,
+    onTrailingClick: ((Int) -> Unit)? = null,
     singleLine: Boolean = true,
     emptySection: @Composable () -> Unit,
     tags: ImmutableList<String>,

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/FavoriteTagSection.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/FavoriteTagSection.kt
@@ -1,0 +1,107 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.shared.ui.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackHeadLine2
+import team.duckie.quackquack.ui.component.QuackLazyVerticalGridTag
+import team.duckie.quackquack.ui.component.QuackSingeLazyRowTag
+import team.duckie.quackquack.ui.component.QuackTagType
+import team.duckie.quackquack.ui.component.QuackTitle2
+import team.duckie.quackquack.ui.icon.QuackIcon
+
+/**
+ * 관심태그 섹션
+ *
+ * @param modifier [Modifier]
+ * @param title 상단 타이틀 제목
+ * @param horizontalPadding 좌우 패딩. 기본값은 0dp
+ * @param verticalArrangement Column 내 각 컴포넌트 내 패딩. 기본값은 0dp
+ * @param trailingIcon 태그 항목 뒤에 덧붙는 아이콘
+ * @param onTrailingClick 태그 항목 뒤에 덧붙는 아이콘 클릭 시 처리
+ * @param singleLine 태그 목록이 한 줄로 표현되는지 여부
+ * @param emptySection 태그 목록이 비어있을 때 보여줄 화면
+ * @param tags 보여줄 태그 목록
+ * @param onTagClick 태그 클릭 시 처리
+ * @param onAddTagClick 태그 추가 버튼 클릭 시 처리
+ * @param addButtonTitle 추가 버튼 제목
+ */
+@Composable
+fun FavoriteTagSection(
+    modifier: Modifier = Modifier,
+    title: String,
+    horizontalPadding: PaddingValues = PaddingValues(0.dp),
+    verticalArrangement: Arrangement.HorizontalOrVertical = Arrangement.spacedBy(0.dp),
+    trailingIcon: QuackIcon? = null,
+    onTrailingClick: (() -> Unit)? = null,
+    singleLine: Boolean = true,
+    emptySection: @Composable () -> Unit,
+    tags: ImmutableList<String>,
+    onTagClick: (Int) -> Unit,
+    onAddTagClick: (() -> Unit)? = null,
+    addButtonTitle: String? = null,
+) {
+    val tagList = remember(tags) { tags }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = verticalArrangement,
+    ) {
+        // 제목
+        QuackTitle2(
+            text = title,
+            modifier = Modifier.padding(horizontalPadding),
+        )
+
+        if (tags.isEmpty()) {
+            // 태그가 없을 경우 표시되는 Section
+            emptySection()
+        } else {
+            if (singleLine) {
+                // 한 줄로 표현되는 태그 목록
+                QuackSingeLazyRowTag(
+                    items = tagList,
+                    contentPadding = horizontalPadding,
+                    tagType = QuackTagType.Circle(trailingIcon),
+                    onClick = { index -> onTagClick(index) },
+                )
+            } else {
+                // 여러 줄로 표현되는 태그 목록
+                QuackLazyVerticalGridTag(
+                    contentPadding = horizontalPadding,
+                    horizontalSpace = 4.dp,
+                    items = tagList,
+                    tagType = QuackTagType.Circle(trailingIcon),
+                    onClick = { index -> onTagClick(index) },
+                    itemChunkedSize = 4,
+                )
+            }
+        }
+
+        // 추가 버튼
+        onAddTagClick?.let { onAddClick ->
+            require(!addButtonTitle.isNullOrEmpty())
+
+            QuackHeadLine2(
+                text = addButtonTitle,
+                padding = horizontalPadding,
+                color = QuackColor.DuckieOrange,
+                onClick = onAddClick,
+            )
+        }
+    }
+}

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
@@ -1,0 +1,188 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.shared.ui.compose.screen
+
+import android.util.Log
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
+import team.duckie.app.android.shared.ui.compose.ImeSpacer
+import team.duckie.app.android.shared.ui.compose.R
+import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
+import team.duckie.quackquack.ui.component.QuackBasicTextField
+import team.duckie.quackquack.ui.component.QuackBody1
+import team.duckie.quackquack.ui.component.QuackLazyVerticalGridTag
+import team.duckie.quackquack.ui.component.QuackTagType
+import team.duckie.quackquack.ui.component.QuackTopAppBar
+import team.duckie.quackquack.ui.icon.QuackIcon
+
+@Composable
+fun SearchTagScreen(
+    modifier: Modifier,
+    title: String,
+    placeholderText: String,
+    multiSelectMode: Boolean,
+    onCloseClick: () -> Unit,
+    onBackPressed: () -> Unit,
+    onTagClick: (index: Int) -> Unit = {},
+    onClickCloseTag: (index: Int) -> Unit = {},
+    onClickSearchListHeader: () -> Unit = {},
+    onClickSearchList: (index: Int) -> Unit = {},
+    onTextChanged: (newSearchTextValue: String) -> Unit,
+    onSearchTextValidate: (searchTextValue: String) -> Boolean = { true },
+    tags: ImmutableList<String> = persistentListOf(),
+    bottomLayout: @Composable (() -> Unit)? = null,
+) {
+    if (tags.isNotEmpty()) {
+        require(onTagClick != {})
+        require(onClickCloseTag != {})
+    }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    val focusRequester = remember { FocusRequester() }
+    val searchTextFieldValue = remember { mutableStateOf("") }
+
+    BackHandler {
+        onBackPressed()
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Column(modifier = modifier.navigationBarsPadding()) {
+        QuackTopAppBar(
+            leadingText = title,
+            trailingIcon = QuackIcon.Close,
+            onTrailingIconClick = onCloseClick,
+        )
+
+        if (multiSelectMode) {
+            // TODO(riflockle7): 추후 꽥꽥에서, 전체 너비만큼 태그 Composable 을 넣을 수 있는 Composable 적용 필요
+            QuackLazyVerticalGridTag(
+                contentPadding = PaddingValues(
+                    top = 16.dp,
+                    start = 16.dp,
+                    end = 16.dp,
+                ),
+                horizontalSpace = 4.dp,
+                items = tags,
+                tagType = QuackTagType.Circle(QuackIcon.Close),
+                onClick = { onTagClick(it) },
+                itemChunkedSize = 3,
+            )
+        }
+
+        QuackBasicTextField(
+            modifier = Modifier
+                .padding(
+                    top = 16.dp,
+                    start = 16.dp,
+                    end = 16.dp,
+                )
+                .focusRequester(focusRequester),
+            leadingIcon = QuackIcon.Search,
+            text = searchTextFieldValue.value,
+            onTextChanged = { textFieldValue ->
+                Log.i("riflockle7", "textFieldValue: $textFieldValue")
+                searchTextFieldValue.value = textFieldValue
+                onTextChanged(textFieldValue)
+            },
+            placeholderText = placeholderText,
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    Log.i("riflockle7", "onSearchTextValidate $searchTextFieldValue")
+                    if (onSearchTextValidate(searchTextFieldValue.value)) {
+                        coroutineScope.launch { onClickSearchListHeader() }
+                    }
+                },
+            ),
+        )
+
+        QuackAnimatedVisibility(
+            modifier = Modifier.padding(
+                top = 8.dp,
+                start = 16.dp,
+                end = 16.dp,
+            ),
+            visible = searchTextFieldValue.value.isNotEmpty(),
+        ) {
+            LazyColumn {
+                item {
+                    SearchTagItemScreen(
+                        text = stringResource(
+                            id = R.string.tag_header_title,
+                            searchTextFieldValue.value,
+                        ),
+                        onClick = {
+                            if (onSearchTextValidate(searchTextFieldValue.value)) {
+                                coroutineScope.launch { onClickSearchListHeader() }
+                            }
+                        },
+                    )
+                }
+
+                itemsIndexed(
+                    items = tags,
+                    key = { _, item -> item },
+                ) { index: Int, item: String ->
+                    SearchTagItemScreen(
+                        text = item,
+                        onClick = {
+                            if (onSearchTextValidate(searchTextFieldValue.value)) {
+                                coroutineScope.launch { onClickSearchList(index) }
+                            }
+                        },
+                    )
+                }
+            }
+        }
+
+        if (multiSelectMode) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            bottomLayout?.let { it() }
+
+            ImeSpacer()
+        }
+    }
+}
+
+@Composable
+private fun SearchTagItemScreen(
+    text: String,
+    onClick: () -> Unit,
+) {
+    QuackBody1(
+        modifier = Modifier.fillMaxWidth(),
+        padding = PaddingValues(vertical = 12.dp),
+        text = text,
+        onClick = onClick,
+    )
+}

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
@@ -7,7 +7,6 @@
 
 package team.duckie.app.android.shared.ui.compose.screen
 
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues

--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
@@ -51,11 +51,12 @@ fun SearchTagScreen(
     onBackPressed: () -> Unit,
     onTagClick: (index: Int) -> Unit = {},
     onClickCloseTag: (index: Int) -> Unit = {},
-    onClickSearchListHeader: () -> Unit = {},
+    onClickSearchListHeader: (tag: String) -> Unit = {},
     onClickSearchList: (index: Int) -> Unit = {},
     onTextChanged: (newSearchTextValue: String) -> Unit,
     onSearchTextValidate: (searchTextValue: String) -> Boolean = { true },
     tags: ImmutableList<String> = persistentListOf(),
+    searchResults: ImmutableList<String> = persistentListOf(),
     bottomLayout: @Composable (() -> Unit)? = null,
 ) {
     if (tags.isNotEmpty()) {
@@ -110,16 +111,16 @@ fun SearchTagScreen(
             leadingIcon = QuackIcon.Search,
             text = searchTextFieldValue.value,
             onTextChanged = { textFieldValue ->
-                Log.i("riflockle7", "textFieldValue: $textFieldValue")
                 searchTextFieldValue.value = textFieldValue
                 onTextChanged(textFieldValue)
             },
             placeholderText = placeholderText,
             keyboardActions = KeyboardActions(
                 onDone = {
-                    Log.i("riflockle7", "onSearchTextValidate $searchTextFieldValue")
                     if (onSearchTextValidate(searchTextFieldValue.value)) {
-                        coroutineScope.launch { onClickSearchListHeader() }
+                        coroutineScope.launch {
+                            onClickSearchListHeader(searchTextFieldValue.value)
+                        }
                     }
                 },
             ),
@@ -134,30 +135,32 @@ fun SearchTagScreen(
             visible = searchTextFieldValue.value.isNotEmpty(),
         ) {
             LazyColumn {
-                item {
-                    SearchTagItemScreen(
-                        text = stringResource(
-                            id = R.string.tag_header_title,
-                            searchTextFieldValue.value,
-                        ),
-                        onClick = {
-                            if (onSearchTextValidate(searchTextFieldValue.value)) {
-                                coroutineScope.launch { onClickSearchListHeader() }
-                            }
-                        },
-                    )
+                if (onSearchTextValidate(searchTextFieldValue.value)) {
+                    item {
+                        SearchTagItemScreen(
+                            text = stringResource(
+                                id = R.string.tag_header_title,
+                                searchTextFieldValue.value,
+                            ),
+                            onClick = {
+                                if (onSearchTextValidate(searchTextFieldValue.value)) {
+                                    coroutineScope.launch {
+                                        onClickSearchListHeader(searchTextFieldValue.value)
+                                    }
+                                }
+                            },
+                        )
+                    }
                 }
 
                 itemsIndexed(
-                    items = tags,
+                    items = searchResults,
                     key = { _, item -> item },
                 ) { index: Int, item: String ->
                     SearchTagItemScreen(
                         text = item,
                         onClick = {
-                            if (onSearchTextValidate(searchTextFieldValue.value)) {
-                                coroutineScope.launch { onClickSearchList(index) }
-                            }
+                            coroutineScope.launch { onClickSearchList(index) }
                         },
                     )
                 }

--- a/shared-ui-compose/src/main/res/values/strings.xml
+++ b/shared-ui-compose/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
     <string name="report">신고하기</string>
     <string name="report_success">신고가 정상 접수되었어요!</string>
     <string name="check">확인</string>
+
+    <string name="tag_header_title">+%s 추가하기</string>
 </resources>


### PR DESCRIPTION
notion ticket link: https://www.notion.so/duckie-team/35cad265c58141b0b991b7f24e01b334?pvs=4

1. 태그 편집 화면 기능을 만들었습니다.
2. 태그 추가 화면이 이곳 저곳에서 쓰일듯 하여 공통화 초기 작업을 수행했습니다.
    추후 아래 화면에서 추가 작업 예정입니다.
    - 문제 만들기 (1 / 3단계)
    - 온보딩 화면 -> 이 화면은 고민중
3. 카테고리 추가 화면은 없어질 수도 있다고 해서 데이터만 만들어 놓았습니다.
---

이미 추가한 태그를 또 추가하는 경우 겹쳐 처리되었어서, 로직엔 문제가 없다고 판단했습니다.
이견이 있다면 comment 부탁드립니다.