### PR TITLE
challenge(quiz) API 구현

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/datasource/QuizDataSource.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/datasource/QuizDataSource.kt
@@ -1,0 +1,18 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.datasource
+
+import team.duckie.app.android.data.quiz.model.PatchQuizBody
+import team.duckie.app.android.domain.quiz.model.Quiz
+import team.duckie.app.android.domain.quiz.model.QuizResult
+
+interface QuizDataSource {
+    suspend fun postQuiz(examId: Int): Quiz
+    suspend fun getQuizs(examId: Int): QuizResult
+    suspend fun patchQuiz(body: PatchQuizBody): Boolean
+}

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/datasource/QuizRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/datasource/QuizRemoteDataSourceImpl.kt
@@ -1,0 +1,60 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.datasource
+
+import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.client.statement.bodyAsText
+import team.duckie.app.android.data._datasource.client
+import team.duckie.app.android.data._exception.util.responseCatching
+import team.duckie.app.android.data._util.toStringJsonMap
+import team.duckie.app.android.data.quiz.mapper.toDomain
+import team.duckie.app.android.data.quiz.model.GetQuizResponse
+import team.duckie.app.android.data.quiz.model.PatchQuizBody
+import team.duckie.app.android.data.quiz.model.PostQuizResponse
+import team.duckie.app.android.domain.quiz.model.Quiz
+import team.duckie.app.android.domain.quiz.model.QuizResult
+import team.duckie.app.android.util.kotlin.exception.duckieResponseFieldNpe
+import javax.inject.Inject
+
+class QuizRemoteDataSourceImpl @Inject constructor() : QuizDataSource {
+    override suspend fun postQuiz(examId: Int): Quiz {
+        val response = client.post {
+            url("/challenges")
+            setBody(examId)
+        }
+        return responseCatching(
+            response,
+            PostQuizResponse::toDomain,
+        )
+    }
+
+    override suspend fun getQuizs(examId: Int): QuizResult {
+        val response = client.get {
+            url("/challenges/$examId")
+        }
+        return responseCatching(
+            response,
+            GetQuizResponse::toDomain,
+        )
+    }
+
+    override suspend fun patchQuiz(body: PatchQuizBody): Boolean {
+        val response = client.patch {
+            url("/challenges")
+            setBody(body)
+        }
+        return responseCatching(response.status.value, response.bodyAsText()) { responseBody ->
+            val json = responseBody.toStringJsonMap()
+            json["success"]?.toBoolean() ?: duckieResponseFieldNpe("success")
+        }
+    }
+}

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/mapper/mapper.kt
@@ -1,0 +1,38 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.mapper
+
+import team.duckie.app.android.data.exam.mapper.toDomain
+import team.duckie.app.android.data.quiz.model.GetQuizResponse
+import team.duckie.app.android.data.quiz.model.PostQuizResponse
+import team.duckie.app.android.data.user.mapper.toDomain
+import team.duckie.app.android.domain.quiz.model.Quiz
+import team.duckie.app.android.domain.quiz.model.QuizResult
+import team.duckie.app.android.util.kotlin.exception.duckieResponseFieldNpe
+
+internal fun PostQuizResponse.toDomain() = Quiz(
+    id = id ?: duckieResponseFieldNpe("${this::class.java.simpleName}.id"),
+    time = time ?: duckieResponseFieldNpe("${this::class.java.simpleName}.time"),
+    correctProblemCount = correctProblemCount
+        ?: duckieResponseFieldNpe("${this::class.java.simpleName}.correctProblemCount"),
+    exam = exam?.toDomain() ?: duckieResponseFieldNpe("${this::class.java.simpleName}.exam"),
+    score = score ?: duckieResponseFieldNpe("${this::class.java.simpleName}.score"),
+    user = user?.toDomain() ?: duckieResponseFieldNpe("${this::class.java.simpleName}.user"),
+)
+
+internal fun GetQuizResponse.toDomain() = QuizResult(
+    id = id ?: duckieResponseFieldNpe("${this::class.java.simpleName}.id"),
+    time = time ?: duckieResponseFieldNpe("${this::class.java.simpleName}.time"),
+    correctProblemCount = correctProblemCount
+        ?: duckieResponseFieldNpe("${this::class.java.simpleName}.correctProblemCount"),
+    exam = exam?.toDomain() ?: duckieResponseFieldNpe("${this::class.java.simpleName}.exam"),
+    score = score ?: duckieResponseFieldNpe("${this::class.java.simpleName}.score"),
+    user = user?.toDomain() ?: duckieResponseFieldNpe("${this::class.java.simpleName}.user"),
+    wrongProblem = wrongProblem?.toDomain()
+        ?: duckieResponseFieldNpe("${this::class.java.simpleName}.wrongProblem"),
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/GetQuizResponse.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/GetQuizResponse.kt
@@ -1,0 +1,30 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import team.duckie.app.android.data.exam.model.ExamData
+import team.duckie.app.android.data.exam.model.ProblemData
+import team.duckie.app.android.data.user.model.UserResponse
+
+internal data class GetQuizResponse(
+    @JsonProperty("id")
+    val id: Int? = null,
+    @JsonProperty("correctProblemCount")
+    val correctProblemCount: Int? = null,
+    @JsonProperty("exam")
+    val exam: ExamData? = null,
+    @JsonProperty("score")
+    val score: Int? = null,
+    @JsonProperty("time")
+    val time: Int? = null,
+    @JsonProperty("user")
+    val user: UserResponse? = null,
+    @JsonProperty("wrongProblem")
+    val wrongProblem: ProblemData? = null,
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/PatchQuizBody.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/PatchQuizBody.kt
@@ -1,0 +1,19 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class PatchQuizBody(
+    @JsonProperty("problemId")
+    val problemId: Int? = null,
+    @JsonProperty("correctProblemCount")
+    val correctProblemCount: Int? = null,
+    @JsonProperty("time")
+    val time: Int? = null,
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/PostQuizResponse.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/PostQuizResponse.kt
@@ -1,0 +1,27 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import team.duckie.app.android.data.exam.model.ExamData
+import team.duckie.app.android.data.user.model.UserResponse
+
+internal data class PostQuizResponse(
+    @JsonProperty("id")
+    val id: Int? = null,
+    @JsonProperty("correctProblemCount")
+    val correctProblemCount: Int? = null,
+    @JsonProperty("exam")
+    val exam: ExamData? = null,
+    @JsonProperty("score")
+    val score: Int? = null,
+    @JsonProperty("time")
+    val time: Int? = null,
+    @JsonProperty("user")
+    val user: UserResponse? = null,
+)

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/repository/QuizRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/repository/QuizRepositoryImpl.kt
@@ -1,0 +1,41 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.data.quiz.repository
+
+import team.duckie.app.android.data.quiz.datasource.QuizDataSource
+import team.duckie.app.android.data.quiz.model.PatchQuizBody
+import team.duckie.app.android.domain.quiz.model.Quiz
+import team.duckie.app.android.domain.quiz.model.QuizResult
+import team.duckie.app.android.domain.quiz.repository.QuizRepository
+import javax.inject.Inject
+
+class QuizRepositoryImpl @Inject constructor(
+    private val quizDataSource: QuizDataSource,
+) : QuizRepository {
+    override suspend fun makeQuiz(examId: Int): Quiz {
+        return quizDataSource.postQuiz(examId)
+    }
+
+    override suspend fun getQuiz(examId: Int): QuizResult {
+        return quizDataSource.getQuizs(examId)
+    }
+
+    override suspend fun updateQuiz(
+        correctProblemCount: Int,
+        time: Int?,
+        problemId: Int?,
+    ): Boolean {
+        return quizDataSource.patchQuiz(
+            body = PatchQuizBody(
+                correctProblemCount = correctProblemCount,
+                time = time,
+                problemId = problemId,
+            ),
+        )
+    }
+}

--- a/di/src/main/kotlin/team/duckie/app/android/di/datasource/BindsModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/datasource/BindsModule.kt
@@ -17,6 +17,8 @@ import team.duckie.app.android.data.exam.datasource.ExamInfoDataSource
 import team.duckie.app.android.data.exam.datasource.ExamInfoLocalDataSourceImpl
 import team.duckie.app.android.data.notification.datasource.NotificationDataSource
 import team.duckie.app.android.data.notification.datasource.NotificationRemoteDataSourceImpl
+import team.duckie.app.android.data.quiz.datasource.QuizDataSource
+import team.duckie.app.android.data.quiz.datasource.QuizRemoteDataSourceImpl
 import team.duckie.app.android.data.ranking.datasource.RankingDataSource
 import team.duckie.app.android.data.ranking.datasource.RankingRemoteDataSourceImpl
 import team.duckie.app.android.data.report.datasource.ReportRemoteDataSource
@@ -63,4 +65,8 @@ abstract class BindsModule {
     @Singleton
     @Binds
     abstract fun provideReportRemoteDataSource(impl: ReportRemoteDataSourceImpl): ReportRemoteDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindsQuizRemoteDataSource(impl: QuizRemoteDataSourceImpl): QuizDataSource
 }

--- a/di/src/main/kotlin/team/duckie/app/android/di/repository/BindsModule.kt
+++ b/di/src/main/kotlin/team/duckie/app/android/di/repository/BindsModule.kt
@@ -15,6 +15,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import team.duckie.app.android.data.auth.repository.AuthRepositoryImpl
 import team.duckie.app.android.data.category.repository.CategoryRepositoryImpl
+import team.duckie.app.android.data.quiz.repository.QuizRepositoryImpl
 import team.duckie.app.android.data.device.repository.DeviceRepositoryImpl
 import team.duckie.app.android.data.exam.repository.ExamRepositoryImpl
 import team.duckie.app.android.data.examInstance.repository.ExamInstanceRepositoryImpl
@@ -33,6 +34,7 @@ import team.duckie.app.android.data.terms.repository.TermsRepositoryImpl
 import team.duckie.app.android.data.user.repository.UserRepositoryImpl
 import team.duckie.app.android.domain.auth.repository.AuthRepository
 import team.duckie.app.android.domain.category.repository.CategoryRepository
+import team.duckie.app.android.domain.quiz.repository.QuizRepository
 import team.duckie.app.android.domain.device.repository.DeviceRepository
 import team.duckie.app.android.domain.exam.repository.ExamRepository
 import team.duckie.app.android.domain.examInstance.repository.ExamInstanceRepository
@@ -49,6 +51,7 @@ import team.duckie.app.android.domain.search.repository.SearchRepository
 import team.duckie.app.android.domain.tag.repository.TagRepository
 import team.duckie.app.android.domain.terms.repository.TermsRepository
 import team.duckie.app.android.domain.user.repository.UserRepository
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -105,5 +108,9 @@ abstract class BindsModule {
     abstract fun provideNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
 
     @Binds
-    abstract fun provideReportRepository(imple: ReportRepositoryImpl): ReportRepository
+    abstract fun provideReportRepository(impl: ReportRepositoryImpl): ReportRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsQuizRepository(impl: QuizRepositoryImpl): QuizRepository
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/model/Quiz.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/model/Quiz.kt
@@ -1,0 +1,22 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.quiz.model
+
+import androidx.compose.runtime.Immutable
+import team.duckie.app.android.domain.exam.model.Exam
+import team.duckie.app.android.domain.user.model.User
+
+@Immutable
+data class Quiz(
+    val id: Int,
+    val correctProblemCount: Int,
+    val exam: Exam,
+    val score: Int,
+    val time: Int,
+    val user: User,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/model/QuizResult.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/model/QuizResult.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.quiz.model
+
+import androidx.compose.runtime.Immutable
+import team.duckie.app.android.domain.exam.model.Exam
+import team.duckie.app.android.domain.exam.model.Problem
+import team.duckie.app.android.domain.user.model.User
+
+@Immutable
+data class QuizResult(
+    val id: Int,
+    val correctProblemCount: Int,
+    val exam: Exam,
+    val score: Int,
+    val time: Int,
+    val user: User,
+    val wrongProblem: Problem,
+)

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/repository/QuizRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/repository/QuizRepository.kt
@@ -1,0 +1,25 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.quiz.repository
+
+import androidx.compose.runtime.Immutable
+import team.duckie.app.android.domain.quiz.model.Quiz
+import team.duckie.app.android.domain.quiz.model.QuizResult
+
+@Immutable
+interface QuizRepository {
+    suspend fun makeQuiz(examId: Int): Quiz
+
+    suspend fun getQuiz(examId: Int): QuizResult
+
+    suspend fun updateQuiz(
+        correctProblemCount: Int,
+        time: Int?,
+        problemId: Int?,
+    ): Boolean
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/GetQuizUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/GetQuizUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.quiz.usecase
+
+import team.duckie.app.android.domain.quiz.repository.QuizRepository
+import javax.inject.Inject
+
+class GetQuizUseCase @Inject constructor(
+    private val repository: QuizRepository,
+) {
+    suspend operator fun invoke(examId: Int) = runCatching {
+        repository.getQuiz(examId)
+    }
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/MakeQuizUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/MakeQuizUseCase.kt
@@ -1,0 +1,21 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.quiz.usecase
+
+import androidx.compose.runtime.Immutable
+import team.duckie.app.android.domain.quiz.repository.QuizRepository
+import javax.inject.Inject
+
+@Immutable
+class MakeQuizUseCase @Inject constructor(
+    private val repository: QuizRepository,
+) {
+    suspend operator fun invoke(examId: Int) = runCatching {
+        repository.makeQuiz(examId)
+    }
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/UpdateQuizUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/UpdateQuizUseCase.kt
@@ -1,0 +1,29 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.domain.quiz.usecase
+
+import androidx.compose.runtime.Immutable
+import team.duckie.app.android.domain.quiz.repository.QuizRepository
+import javax.inject.Inject
+
+@Immutable
+class UpdateQuizUseCase @Inject constructor(
+    private val repository: QuizRepository,
+) {
+    suspend operator fun invoke(
+        correctProblemCount: Int,
+        time: Int?,
+        problemId: Int?,
+    ) = runCatching {
+        repository.updateQuiz(
+            correctProblemCount = correctProblemCount,
+            time = time,
+            problemId = problemId,
+        )
+    }
+}

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/search/usecase/GetSearchUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/search/usecase/GetSearchUseCase.kt
@@ -11,9 +11,12 @@ import androidx.compose.runtime.Immutable
 import team.duckie.app.android.domain.recommendation.model.SearchType
 import team.duckie.app.android.domain.search.model.Search
 import team.duckie.app.android.domain.search.repository.SearchRepository
+import javax.inject.Inject
 
 @Immutable
-class GetSearchUseCase(private val repository: SearchRepository) {
+class GetSearchUseCase @Inject constructor(
+    private val repository: SearchRepository,
+) {
     suspend operator fun invoke(query: String, page: Int, type: SearchType): Result<Search> {
         return runCatching {
             repository.getSearch(query, page, type)


### PR DESCRIPTION
## Overview (Required)
덕퀴즈(챌린지) 생성 : https://www.notion.so/duckie-team/POST-challenges-7dd001df833c49948a7dfcd90b653963?pvs=4
덕퀴즈(챌린지) 정보 가져오기 : https://www.notion.so/duckie-team/GET-challenges-id-c251e373a58c42579ff19405e1b1ebb0?pvs=4
덕퀴즈(챌린지) 업데이트하기 : https://www.notion.so/duckie-team/PATCH-challenges-id-ea80cd7be6a14fd586473f0787523c40?pvs=4