### PR TITLE
덕퀴즈 시작 화면 구현

### DIFF
--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/StartExamScreen.kt
@@ -7,50 +7,36 @@
 
 package team.duckie.app.android.feature.ui.start.exam.screen
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.orbitmvi.orbit.compose.collectAsState
-import team.duckie.app.android.feature.ui.start.exam.R
+import team.duckie.app.android.feature.ui.start.exam.screen.exam.StartExamInputScreen
+import team.duckie.app.android.feature.ui.start.exam.screen.quiz.StartQuizInputScreen
 import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamState
 import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamViewModel
-import team.duckie.app.android.shared.ui.compose.ImeSpacer
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
-import team.duckie.quackquack.ui.component.QuackHeadLine1
-import team.duckie.quackquack.ui.component.QuackLargeButton
-import team.duckie.quackquack.ui.component.QuackLargeButtonType
 import team.duckie.quackquack.ui.component.QuackTitle1
-import team.duckie.quackquack.ui.component.QuackTopAppBar
-import team.duckie.quackquack.ui.component.internal.QuackText
-import team.duckie.quackquack.ui.icon.QuackIcon
-import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 @Composable
 internal fun StartExamScreen(
     modifier: Modifier,
     viewModel: StartExamViewModel = activityViewModel(),
-) = when (viewModel.collectAsState().value) {
+) = when (val state = viewModel.collectAsState().value) {
     is StartExamState.Loading -> StartExamLoadingScreen(modifier, viewModel)
-    is StartExamState.Input -> StartExamInputScreen(modifier, viewModel)
+    is StartExamState.Input -> {
+        if (state.isQuiz) {
+            StartQuizInputScreen(modifier, viewModel)
+        } else {
+            StartExamInputScreen(modifier, viewModel)
+        }
+    }
+
     is StartExamState.Error -> StartExamErrorScreen(modifier, viewModel)
 }
 
@@ -77,70 +63,6 @@ private fun StartExamLoadingScreen(modifier: Modifier, viewModel: StartExamViewM
 }
 
 /**
- * 시험 시작 입력 화면
- * @see [StartExamState.Input]
- */
-@Composable
-internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewModel) {
-    val state =
-        viewModel.container.stateFlow.collectAsStateWithLifecycle().value as StartExamState.Input
-
-    val certifyingStatement: String = remember(state.certifyingStatement) {
-        state.certifyingStatement
-    }
-    val certifyingStatementText: String = remember(state.certifyingStatementInputText) {
-        state.certifyingStatementInputText
-    }
-
-    Column(modifier = modifier) {
-        // 상단 탭바
-        QuackTopAppBar(
-            leadingIcon = QuackIcon.ArrowBack,
-            onLeadingIconClick = viewModel::finishStartExam,
-        )
-
-        // 제목
-        QuackHeadLine1(
-            modifier = Modifier.padding(
-                top = 16.dp,
-                start = 16.dp,
-                end = 16.dp,
-            ),
-            text = stringResource(id = R.string.title),
-        )
-
-        // 필적 확인 문구 TextField
-        StartExamTextField(
-            modifier = Modifier.padding(
-                top = 28.dp,
-                start = 16.dp,
-                end = 16.dp,
-            ),
-            text = certifyingStatementText,
-            onTextChanged = viewModel::inputCertifyingStatement,
-            placeholderText = certifyingStatement,
-        )
-
-        // 여백
-        Spacer(modifier = Modifier.weight(1f))
-
-        // 시험시작 버튼
-        QuackLargeButton(
-            modifier = Modifier.padding(
-                vertical = 12.dp,
-                horizontal = 16.dp,
-            ),
-            type = QuackLargeButtonType.Fill,
-            text = stringResource(id = R.string.start_button),
-            enabled = viewModel.startExamValidate(),
-            onClick = viewModel::startSolveProblem,
-        )
-
-        ImeSpacer()
-    }
-}
-
-/**
  * 시험 시작 에러 화면
  * @see [StartExamState.Error]
  */
@@ -156,53 +78,4 @@ private fun StartExamErrorScreen(modifier: Modifier, viewModel: StartExamViewMod
             text = "에러입니다\nTODO$viewModel\n추후 데이터 다시 가져오기 로직 넣어야 합니다.",
         )
     }
-}
-
-/**
- * [시험 시작 화면][StartExamScreen]에서 활용하는 TextField
- * 기존 [QuackGrayscaleTextField] 와 차이가 있다면, placeholder 가 계속 유지된다.
- *
- * // TODO(riflockle7): 추후 QuackQuack 라이브러리에서 해당 기능 제공 시 아래 코드 제거 및 대체 필요
- */
-@Composable
-internal fun StartExamTextField(
-    modifier: Modifier = Modifier,
-    text: String,
-    alwaysPlaceholderVisible: Boolean = true,
-    placeholderText: String,
-    onTextChanged: (text: String) -> Unit,
-    imeAction: ImeAction = ImeAction.Done,
-    keyboardActions: KeyboardActions = KeyboardActions(),
-) {
-    BasicTextField(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(color = QuackColor.Gray4.composeColor)
-            .padding(
-                vertical = 17.dp,
-                horizontal = 20.dp,
-            ),
-        value = text,
-        onValueChange = onTextChanged,
-        textStyle = QuackTextStyle.Body1.asComposeStyle(),
-        keyboardOptions = KeyboardOptions(imeAction = imeAction),
-        keyboardActions = keyboardActions,
-        singleLine = true,
-        cursorBrush = QuackColor.Black.toBrush(),
-        decorationBox = { textField ->
-            Box(propagateMinConstraints = true) {
-                // TODO(riflockle7): 추후 QuackTextFieldCommonBody1Placeholder 내용에 반영 필요
-                if (alwaysPlaceholderVisible || text.isEmpty()) {
-                    QuackText(
-                        text = placeholderText,
-                        style = QuackTextStyle.Body1.change(color = QuackColor.Gray2),
-                    )
-                }
-            }
-
-            Box(propagateMinConstraints = true) {
-                textField()
-            }
-        },
-    )
 }

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/exam/StartExamInputScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/exam/StartExamInputScreen.kt
@@ -1,0 +1,152 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.screen.exam
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.duckie.app.android.feature.ui.start.exam.R
+import team.duckie.app.android.feature.ui.start.exam.screen.StartExamScreen
+import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamState
+import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamViewModel
+import team.duckie.app.android.shared.ui.compose.ImeSpacer
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
+import team.duckie.quackquack.ui.component.QuackHeadLine1
+import team.duckie.quackquack.ui.component.QuackLargeButton
+import team.duckie.quackquack.ui.component.QuackLargeButtonType
+import team.duckie.quackquack.ui.component.QuackTopAppBar
+import team.duckie.quackquack.ui.component.internal.QuackText
+import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.ui.textstyle.QuackTextStyle
+
+/**
+ * 시험 시작 입력 화면
+ * @see [StartExamState.Input]
+ */
+@Composable
+internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewModel) {
+    val state =
+        viewModel.container.stateFlow.collectAsStateWithLifecycle().value as StartExamState.Input
+
+    val certifyingStatement: String = remember(state.certifyingStatement) {
+        state.certifyingStatement
+    }
+    val certifyingStatementText: String = remember(state.certifyingStatementInputText) {
+        state.certifyingStatementInputText
+    }
+
+    Column(modifier = modifier) {
+        // 상단 탭바
+        QuackTopAppBar(
+            leadingIcon = QuackIcon.ArrowBack,
+            onLeadingIconClick = viewModel::finishStartExam,
+        )
+
+        // 제목
+        QuackHeadLine1(
+            modifier = Modifier.padding(
+                top = 16.dp,
+                start = 16.dp,
+                end = 16.dp,
+            ),
+            text = stringResource(id = R.string.title),
+        )
+
+        // 필적 확인 문구 TextField
+        StartExamTextField(
+            modifier = Modifier.padding(
+                top = 28.dp,
+                start = 16.dp,
+                end = 16.dp,
+            ),
+            text = certifyingStatementText,
+            onTextChanged = viewModel::inputCertifyingStatement,
+            placeholderText = certifyingStatement,
+        )
+
+        // 여백
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 시험시작 버튼
+        QuackLargeButton(
+            modifier = Modifier.padding(
+                vertical = 12.dp,
+                horizontal = 16.dp,
+            ),
+            type = QuackLargeButtonType.Fill,
+            text = stringResource(id = R.string.start_button),
+            enabled = viewModel.startExamValidate(),
+            onClick = viewModel::startSolveProblem,
+        )
+
+        ImeSpacer()
+    }
+}
+
+/**
+ * [시험 시작 화면][StartExamScreen]에서 활용하는 TextField
+ * 기존 [QuackGrayscaleTextField] 와 차이가 있다면, placeholder 가 계속 유지된다.
+ *
+ * // TODO(riflockle7): 추후 QuackQuack 라이브러리에서 해당 기능 제공 시 아래 코드 제거 및 대체 필요
+ */
+@Composable
+internal fun StartExamTextField(
+    modifier: Modifier = Modifier,
+    text: String,
+    alwaysPlaceholderVisible: Boolean = true,
+    placeholderText: String,
+    onTextChanged: (text: String) -> Unit,
+    imeAction: ImeAction = ImeAction.Done,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+) {
+    BasicTextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = QuackColor.Gray4.composeColor)
+            .padding(
+                vertical = 17.dp,
+                horizontal = 20.dp,
+            ),
+        value = text,
+        onValueChange = onTextChanged,
+        textStyle = QuackTextStyle.Body1.asComposeStyle(),
+        keyboardOptions = KeyboardOptions(imeAction = imeAction),
+        keyboardActions = keyboardActions,
+        singleLine = true,
+        cursorBrush = QuackColor.Black.toBrush(),
+        decorationBox = { textField ->
+            Box(propagateMinConstraints = true) {
+                // TODO(riflockle7): 추후 QuackTextFieldCommonBody1Placeholder 내용에 반영 필요
+                if (alwaysPlaceholderVisible || text.isEmpty()) {
+                    QuackText(
+                        text = placeholderText,
+                        style = QuackTextStyle.Body1.change(color = QuackColor.Gray2),
+                    )
+                }
+            }
+
+            Box(propagateMinConstraints = true) {
+                textField()
+            }
+        },
+    )
+}

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -58,9 +59,14 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
             leadingIcon = QuackIcon.ArrowBack,
             onLeadingIconClick = viewModel::finishStartExam,
         )
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp)
+                .fillMaxWidth()
+        ) {
             InfoBox(
-                modifier = Modifier.padding(top = 12.dp),
+                modifier = Modifier
+                    .padding(top = 12.dp)
+                    .fillMaxWidth(),
                 limitTime = 10,
             )
             QuackTitle2(

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -60,8 +60,9 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
             onLeadingIconClick = viewModel::finishStartExam,
         )
         Column(
-            modifier = Modifier.padding(horizontal = 16.dp)
-                .fillMaxWidth()
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth(),
         ) {
             InfoBox(
                 modifier = Modifier

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -1,0 +1,133 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.ui.start.exam.screen.quiz
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.duckie.app.android.feature.ui.start.exam.R
+import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamState
+import team.duckie.app.android.feature.ui.start.exam.viewmodel.StartExamViewModel
+import team.duckie.app.android.shared.ui.compose.ImeSpacer
+import team.duckie.app.android.shared.ui.compose.Spacer
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackBody2
+import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
+import team.duckie.quackquack.ui.component.QuackHeadLine1
+import team.duckie.quackquack.ui.component.QuackLargeButton
+import team.duckie.quackquack.ui.component.QuackLargeButtonType
+import team.duckie.quackquack.ui.component.QuackTitle2
+import team.duckie.quackquack.ui.component.QuackTopAppBar
+import team.duckie.quackquack.ui.component.internal.QuackText
+import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.ui.textstyle.QuackTextStyle
+
+@Composable
+internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewModel) {
+    val state =
+        viewModel.container.stateFlow.collectAsStateWithLifecycle().value as StartExamState.Input
+
+    val certifyingStatement: String = remember(state.certifyingStatement) {
+        state.certifyingStatement
+    }
+    val certifyingStatementText: String = remember(state.certifyingStatementInputText) {
+        state.certifyingStatementInputText
+    }
+
+    Column(modifier = modifier) {
+        QuackTopAppBar(
+            leadingIcon = QuackIcon.ArrowBack,
+            onLeadingIconClick = viewModel::finishStartExam,
+        )
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            InfoBox(
+                modifier = Modifier.padding(top = 12.dp),
+                limitTime = 10,
+            )
+            QuackTitle2(
+                modifier = Modifier.padding(top = 34.dp),
+                text = stringResource(id = R.string.challenge_condition),
+            )
+            Spacer(space = 4.dp)
+            QuackHeadLine1(
+                modifier = Modifier.padding(top = 4.dp),
+                text = state.certifyingStatement, // TODO(EvergreenTree97) 추후 도전 조건 response 생기면 변경
+            )
+            QuackGrayscaleTextField(
+                modifier = Modifier.padding(top = 14.dp),
+                text = certifyingStatementText,
+                onTextChanged = viewModel::inputCertifyingStatement,
+                placeholderText = "ex) $certifyingStatement",
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        QuackLargeButton(
+            modifier = Modifier.padding(
+                vertical = 12.dp,
+                horizontal = 16.dp,
+            ),
+            type = QuackLargeButtonType.Fill,
+            text = stringResource(id = R.string.start_button),
+            enabled = viewModel.startExamValidate(),
+            onClick = viewModel::startSolveProblem,
+        )
+        ImeSpacer()
+    }
+}
+
+@Composable
+internal fun InfoBox(
+    modifier: Modifier = Modifier,
+    limitTime: Int,
+) {
+    Column(
+        modifier = modifier
+            .background(color = QuackColor.Gray4.composeColor)
+            .padding(all = 12.dp)
+            .clip(RoundedCornerShape(8.dp)),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        QuackTitle2(text = stringResource(id = R.string.information_before_quiz_title))
+        Spacer(space = 4.dp)
+        QuackBody2(text = stringResource(id = R.string.information_before_quiz_line1))
+        QuackText(
+            annotatedText = buildAnnotatedString {
+                append(stringResource(id = R.string.information_before_quiz_line2_prefix))
+                withStyle(
+                    SpanStyle(
+                        color = QuackColor.Black.composeColor,
+                        fontWeight = FontWeight.Bold,
+                    ),
+                ) {
+                    append(
+                        stringResource(
+                            id = R.string.information_before_quiz_line2_infix,
+                            limitTime.toString(),
+                        ),
+                    )
+                }
+                append(stringResource(id = R.string.information_before_quiz_line2_postfix))
+            },
+            style = QuackTextStyle.Body2,
+        )
+    }
+}

--- a/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamState.kt
+++ b/feature-ui-start-exam/src/main/java/team/duckie/app/android/feature/ui/start/exam/viewmodel/StartExamState.kt
@@ -18,6 +18,7 @@ sealed class StartExamState {
         val examId: Int,
         val certifyingStatement: String,
         val certifyingStatementInputText: String = "",
+        val isQuiz: Boolean = true,
     ) : StartExamState() {
         val isCertified: Boolean
             get() = certifyingStatement == certifyingStatementInputText

--- a/feature-ui-start-exam/src/main/res/values/strings.xml
+++ b/feature-ui-start-exam/src/main/res/values/strings.xml
@@ -5,8 +5,8 @@
     <string name="start_button">시험시작</string>
     <string name="information_before_quiz_title">[ 퀴즈 시작 전 안내사항 ]</string>
     <string name="information_before_quiz_line1">※ 문제를 틀릴 경우 바로 도전이 종료됩니다.</string>
-    <string name="information_before_quiz_line2_prefix">※ 문제당 </string>
-    <string name="information_before_quiz_line2_infix">약 %s초의 제한시간이 있습니다. </string>
-    <string name="information_before_quiz_line2_postfix">※ 문제당 </string>
-    <string name="challenge_condition">&lt;도전 조건&lt;</string>
+    <string name="information_before_quiz_line2_prefix">※ 문제당&#160;</string>
+    <string name="information_before_quiz_line2_infix">약 %s초의 제한시간이 있습니다.&#160;</string>
+    <string name="information_before_quiz_line2_postfix">문제를 잘 읽고 시간 내에 물음에 답해주세요.</string>
+    <string name="challenge_condition">&lt;도전 조건&gt;</string>
 </resources>

--- a/feature-ui-start-exam/src/main/res/values/strings.xml
+++ b/feature-ui-start-exam/src/main/res/values/strings.xml
@@ -3,4 +3,10 @@
     <string name="title">시험 시작 전, 필적 확인 문구를\n정확히 입력해주세요.</string>
     <string name="certifing_statement_placeholder">누칼협? 열심히 살지 말자</string>
     <string name="start_button">시험시작</string>
+    <string name="information_before_quiz_title">[ 퀴즈 시작 전 안내사항 ]</string>
+    <string name="information_before_quiz_line1">※ 문제를 틀릴 경우 바로 도전이 종료됩니다.</string>
+    <string name="information_before_quiz_line2_prefix">※ 문제당 </string>
+    <string name="information_before_quiz_line2_infix">약 %s초의 제한시간이 있습니다. </string>
+    <string name="information_before_quiz_line2_postfix">※ 문제당 </string>
+    <string name="challenge_condition">&lt;도전 조건&lt;</string>
 </resources>


### PR DESCRIPTION
## Overview (Required)
- `feature-ui-start-exam` 모듈에서, 시작 화면을 덕퀴즈와, 덕력고사로 분기하였습니다.
![image](https://github.com/duckie-team/duckie-android/assets/70064912/1b8982cf-bb19-4ed7-ac6f-1a3e69f77e65)
