### PR TITLE
스플래쉬에서 진입 안 될 시 에러 핸들링 처리

### DIFF
--- a/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
@@ -59,7 +59,9 @@ object ExamDummyResponse {
             },
             "status": "PENDING",
             "heart": null,
-            "heartCount": 3
+            "heartCount": 3,
+            "challenges": [],
+            "perfectScoreImageUrl": null
         }
     """
 
@@ -101,5 +103,7 @@ object ExamDummyResponse {
         status = "PENDING",
         heart = null,
         heartCount = 3,
+        quizs = persistentListOf(),
+        perfectScoreImageUrl = null,
     )
 }

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/IntroActivity.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/IntroActivity.kt
@@ -99,8 +99,6 @@ class IntroActivity : BaseActivity() {
                 launchOnboardActivity()
             }
 
-            is IntroSideEffect.UpdateRequireError -> {}
-
             is IntroSideEffect.ReportError -> {
                 sideEffect.exception.printStackTrace()
                 sideEffect.exception.reportToCrashlyticsIfNeeded()

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/screen/IntroScreen.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/screen/IntroScreen.kt
@@ -41,8 +41,7 @@ internal fun IntroScreen(
 ) {
     val activity = LocalContext.current as Activity
     val appPackageName = getAppPackageName()
-    val updateRequireTitle = stringResource(id = R.string.update_require_dialog_title)
-    val updateRequireDescription = stringResource(id = R.string.update_require_dialog_description)
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -82,19 +81,44 @@ internal fun IntroScreen(
     }
 
     // 덕키 업데이트 팝업
-    DuckieDialog(
-        title = updateRequireTitle,
-        message = updateRequireDescription,
-        visible = viewModel.collectAsState().value.isUpdateRequire,
-        leftButtonText = "앱 종료",
-        leftButtonOnClick = {
-            activity.finish()
-        },
-        rightButtonText = "지금 업데이트",
-        rightButtonOnClick = {
-            activity.goToMarket(appPackageName)
-            activity.finish()
-        },
-        onDismissRequest = {},
-    )
+    viewModel.collectAsState().value.introDialogType?.let { introDialogType ->
+        DuckieDialog(
+            title = activity.getString(introDialogType.titleRes),
+            message = activity.getString(introDialogType.messageRes),
+            visible = true,
+            leftButtonText = activity.getString(introDialogType.leftBtnTitleRes),
+            leftButtonOnClick = { activity.finish() },
+            rightButtonText = activity.getString(introDialogType.rightBtnTitleRes),
+            rightButtonOnClick = {
+                if (introDialogType != IntroDialogType.Error) {
+                    activity.goToMarket(appPackageName)
+                    activity.finish()
+                } else {
+                    viewModel.checkUpdateRequire()
+                }
+            },
+            onDismissRequest = {},
+        )
+    }
+}
+
+/** IntroActivity 에서 띄워지는 Dialog 타입 */
+enum class IntroDialogType(
+    val titleRes: Int,
+    val messageRes: Int,
+    val leftBtnTitleRes: Int,
+    val rightBtnTitleRes: Int,
+) {
+    UpdateRequire(
+        R.string.update_require_dialog_title,
+        R.string.update_require_dialog_description,
+        R.string.update_require_dialog_left_button_title,
+        R.string.update_require_dialog_right_button_title,
+    ),
+    Error(
+        R.string.error_dialog_title,
+        R.string.error_dialog_description,
+        R.string.error_dialog_left_button_title,
+        R.string.error_dialog_right_button_title,
+    ),
 }

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/viewmodel/IntroViewModel.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/viewmodel/IntroViewModel.kt
@@ -16,6 +16,7 @@ import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 import team.duckie.app.android.domain.user.usecase.GetMeUseCase
+import team.duckie.app.android.presentation.screen.IntroDialogType
 import team.duckie.app.android.presentation.viewmodel.sideeffect.IntroSideEffect
 import team.duckie.app.android.presentation.viewmodel.state.IntroState
 import team.duckie.app.android.util.kotlin.exception.isAppUpgradeRequire
@@ -36,7 +37,9 @@ internal class IntroViewModel @Inject constructor(
     )
 
     /** 앱 업데이트 여부를 체크한다. */
-    suspend fun checkUpdateRequire() = intent {
+    fun checkUpdateRequire() = intent {
+        reduce { state.copy(introDialogType = null) }
+
         getMeUseCase()
             .onSuccess { user ->
                 postSideEffect(
@@ -50,7 +53,7 @@ internal class IntroViewModel @Inject constructor(
         onFailure { exception ->
             when {
                 exception.isAppUpgradeRequire -> {
-                    reduce { state.copy(isUpdateRequire = true) }
+                    reduce { state.copy(introDialogType = IntroDialogType.UpdateRequire) }
                 }
 
                 exception.isLoginRequireCode || exception.isUserNotFound -> {
@@ -63,6 +66,7 @@ internal class IntroViewModel @Inject constructor(
 
                 else -> {
                     postSideEffect(IntroSideEffect.ReportError(exception))
+                    reduce { state.copy(introDialogType = IntroDialogType.Error) }
                 }
             }
         }

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/viewmodel/sideeffect/IntroSideEffect.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/viewmodel/sideeffect/IntroSideEffect.kt
@@ -19,9 +19,6 @@ internal sealed class IntroSideEffect {
     /** 유저 정보를 가져오는 도중 에러 발생 시 방출하는 SideEffect */
     class GetMeError(val exception: Throwable) : IntroSideEffect()
 
-    /** 앱 업데이트가 필요할 시 방출하는 SideEffect */
-    class UpdateRequireError(val exception: Throwable) : IntroSideEffect()
-
     /** 에러 Report 하는 SideEffect */
     class ReportError(val exception: Throwable) : IntroSideEffect()
 }

--- a/presentation/src/main/kotlin/team/duckie/app/android/presentation/viewmodel/state/IntroState.kt
+++ b/presentation/src/main/kotlin/team/duckie/app/android/presentation/viewmodel/state/IntroState.kt
@@ -9,8 +9,9 @@ package team.duckie.app.android.presentation.viewmodel.state
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import team.duckie.app.android.presentation.screen.IntroDialogType
 
 @Parcelize
 internal data class IntroState(
-    val isUpdateRequire: Boolean = false,
+    val introDialogType: IntroDialogType? = null,
 ) : Parcelable

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -14,4 +14,11 @@
 
     <string name="update_require_dialog_title">덕키 업데이트 알림</string>
     <string name="update_require_dialog_description">덕키에 새로운 기능이 업데이트 되었어요!\n스토어에서 업데이트 후 사용해 주세요.</string>
+    <string name="update_require_dialog_left_button_title">앱 종료</string>
+    <string name="update_require_dialog_right_button_title">지금 업데이트</string>
+
+    <string name="error_dialog_title">네트워크가 불안정합니다.</string>
+    <string name="error_dialog_description">앱 종료 후 앱에 다시 접속해 주세요.</string>
+    <string name="error_dialog_left_button_title">앱 종료</string>
+    <string name="error_dialog_right_button_title">재 시도</string>
 </resources>


### PR DESCRIPTION
notion ticket link: https://www.notion.so/duckie-team/7613e1c9e98a4291abb57e821f0a0279?pvs=4

팝업을 띄워주도록 했습니다.
기존에 띄워주는 팝업이 있어 enum 을 활용하여 처리했습니다.