### PR TITLE
fix: 태그 추가 화면 상단탭 페딩값 수정

### DIFF
--- a/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
+++ b/shared-ui-compose/src/main/kotlin/team/duckie/app/android/shared/ui/compose/screen/SearchTagScreen.kt
@@ -76,7 +76,11 @@ fun SearchTagScreen(
         focusRequester.requestFocus()
     }
 
-    Column(modifier = modifier.navigationBarsPadding()) {
+    Column(
+        modifier = modifier
+            .navigationBarsPadding()
+            .padding(horizontal = 16.dp),
+    ) {
         QuackTopAppBar(
             leadingText = title,
             trailingIcon = QuackIcon.Close,
@@ -101,11 +105,7 @@ fun SearchTagScreen(
 
         QuackBasicTextField(
             modifier = Modifier
-                .padding(
-                    top = 16.dp,
-                    start = 16.dp,
-                    end = 16.dp,
-                )
+                .padding(top = 16.dp)
                 .focusRequester(focusRequester),
             leadingIcon = QuackIcon.Search,
             text = searchTextFieldValue.value,
@@ -128,8 +128,6 @@ fun SearchTagScreen(
         QuackAnimatedVisibility(
             modifier = Modifier.padding(
                 top = 8.dp,
-                start = 16.dp,
-                end = 16.dp,
             ),
             visible = searchTextFieldValue.value.isNotEmpty(),
         ) {


### PR DESCRIPTION
## Issue

- close [태그 편집 → 태그 추가 화면 상단탭 디자인 안맞음](https://www.notion.so/duckie-team/6df798a8a2c54779a09fc21115cdaf88?pvs=4)

## Overview (Required)

- 태그 추가 페이지의 상단탭 디자인을 수정했습니다.

- 태그 추가 페이지의 로직이나, 디자인이 전체적으로 다른 것 같습니다. 따로 [이슈화](https://www.notion.so/duckie-team/ad134c21e3e94ef493e8c3ad39012bb8?pvs=4) 해두었습니다.

## Screenshot

![image](https://github.com/duckie-team/duckie-android/assets/80076029/0f710735-d310-419d-9230-ae0c4d609cdb)

