### PR TITLE
feat: 문제 풀기 주관식 문제 keyboard show, focus 처리

### DIFF
--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/problem.kt
@@ -130,6 +130,8 @@ sealed class Answer(val type: Type) {
         return type.hashCode()
     }
 
+    fun isShortAnswer(): Boolean = this.type == Type.ShortAnswer
+
     fun validate(): Boolean = when (this) {
         is Short -> true
 

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/SolveProblemActivity.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/SolveProblemActivity.kt
@@ -8,7 +8,6 @@
 package team.duckie.app.android.feature.ui.solve.problem
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/SolveProblemActivity.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/SolveProblemActivity.kt
@@ -8,6 +8,7 @@
 package team.duckie.app.android.feature.ui.solve.problem
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -81,7 +82,12 @@ class SolveProblemActivity : BaseActivity() {
                         }
 
                         else -> {
-                            SolveProblemScreen()
+                            SolveProblemScreen(
+                                state = state,
+                                inputAnswer = viewModel::inputAnswer,
+                                stopExam = viewModel::stopExam,
+                                finishExam = viewModel::finishExam,
+                            )
                         }
                     }
                 }

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/answer/AnswerSection.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/answer/AnswerSection.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:OptIn(ExperimentalComposeUiApi::class)
+
 package team.duckie.app.android.feature.ui.solve.problem.answer
 
 import androidx.compose.foundation.layout.Arrangement
@@ -12,7 +14,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import team.duckie.app.android.domain.exam.model.Answer
@@ -29,6 +34,8 @@ internal fun LazyListScope.answerSection(
     answer: Answer,
     inputAnswers: ImmutableList<InputAnswer>,
     onClickAnswer: (page: Int, inputAnswer: InputAnswer) -> Unit,
+    focusRequester: FocusRequester,
+    keyboardController: SoftwareKeyboardController?,
 ) {
     when (answer) {
         is Answer.Choice -> {
@@ -97,6 +104,8 @@ internal fun LazyListScope.answerSection(
                             ),
                         )
                     },
+                    focusRequester = focusRequester,
+                    keyboardController = keyboardController,
                 )
             }
         }

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/answer/shortanswer/ShortAnswerForm.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/answer/shortanswer/ShortAnswerForm.kt
@@ -16,7 +16,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import team.duckie.app.android.feature.ui.solve.problem.R
@@ -27,12 +29,14 @@ internal fun ShortAnswerForm(
     modifier: Modifier = Modifier,
     answer: String,
     onDone: (String) -> Unit,
+    keyboardController: SoftwareKeyboardController?,
+    focusRequester: FocusRequester,
 ) {
     var value by remember { mutableStateOf("") }
-    val keyboardController = LocalSoftwareKeyboardController.current
 
     QuackGrayscaleTextField(
-        modifier = modifier,
+        modifier = modifier
+            .focusRequester(focusRequester),
         text = value,
         onTextChanged = {
             if (it.length <= answer.length) {

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
@@ -64,7 +64,12 @@ internal fun QuizScreen(
 ) {
     val state by viewModel.container.stateFlow.collectAsStateWithLifecycle()
     val totalPage = remember { state.totalPage }
+
     val pagerState = rememberPagerState()
+    val isCurrentPageOffsetFractionZero = remember {
+        derivedStateOf { pagerState.currentPageOffsetFraction == 0f }
+    }
+
     val coroutineScope = rememberCoroutineScope()
     var examExitDialogVisible by remember { mutableStateOf(false) }
     var examSubmitDialogVisible by remember { mutableStateOf(false) }
@@ -111,6 +116,7 @@ internal fun QuizScreen(
                 viewModel = viewModel,
                 pagerState = pagerState,
                 state = state,
+                isCurrentPageOffsetFractionZero = isCurrentPageOffsetFractionZero.value,
             )
             DoubleButtonBottomBar(
                 modifier = Modifier.layoutId(QuizBottomBarLayoutId),
@@ -147,13 +153,14 @@ private fun ContentSection(
     viewModel: SolveProblemViewModel,
     pagerState: PagerState,
     state: SolveProblemState,
+    isCurrentPageOffsetFractionZero: Boolean,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     val currentProblem = state.problems[pagerState.currentPage].problem
 
-    LaunchedEffect(pagerState.currentPageOffsetFraction) {
-        if (currentProblem.answer?.isShortAnswer() == true && pagerState.currentPageOffsetFraction == 0f) {
+    LaunchedEffect(isCurrentPageOffsetFractionZero) {
+        if (currentProblem.answer?.isShortAnswer() == true) {
             keyboardController?.show()
             focusRequester.requestFocus()
         } else {

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
@@ -171,7 +171,7 @@ private fun ContentSection(
             // TODO(EvergreenTree97) 추후 덕퀴즈 종료로 이동 viewModel.finishExam()
         }
     }
-    DisposableEffect(Unit) {
+    DisposableEffect(pagerState.currentPage) {
         viewModel.startTimer()
         onDispose {
             viewModel.stopTimer()

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
@@ -5,7 +5,7 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 
 package team.duckie.app.android.feature.ui.solve.problem.screen
 
@@ -28,9 +28,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -145,6 +148,19 @@ private fun ContentSection(
     pagerState: PagerState,
     state: SolveProblemState,
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusRequester = remember { FocusRequester() }
+    val currentProblem = state.problems[pagerState.currentPage].problem
+
+    LaunchedEffect(pagerState.currentPageOffsetFraction) {
+        if (currentProblem.answer?.isShortAnswer() == true && pagerState.currentPageOffsetFraction == 0f) {
+            keyboardController?.show()
+            focusRequester.requestFocus()
+        } else {
+            keyboardController?.hide()
+        }
+    }
+
     val progress by viewModel.timerCount.collectAsStateWithLifecycle()
     val timeOver by remember {
         derivedStateOf { progress == 0 }
@@ -191,6 +207,8 @@ private fun ContentSection(
                 },
                 inputAnswers = state.inputAnswers,
                 onClickAnswer = viewModel::inputAnswer,
+                focusRequester = focusRequester,
+                keyboardController = keyboardController,
             )
         }
     }

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/QuizScreen.kt
@@ -48,7 +48,7 @@ import team.duckie.app.android.shared.ui.compose.LinearProgressBar
 import team.duckie.app.android.shared.ui.compose.dialog.DuckieDialog
 import team.duckie.app.android.util.compose.activityViewModel
 import team.duckie.app.android.util.compose.moveNextPage
-import team.duckie.app.android.util.compose.movePreviousPage
+import team.duckie.app.android.util.compose.movePrevPage
 import team.duckie.app.android.util.kotlin.exception.duckieResponseFieldNpe
 
 private const val QuizTopAppBarLayoutId = "QuizTopAppBar"
@@ -65,10 +65,6 @@ internal fun QuizScreen(
     val coroutineScope = rememberCoroutineScope()
     var examExitDialogVisible by remember { mutableStateOf(false) }
     var examSubmitDialogVisible by remember { mutableStateOf(false) }
-
-    LaunchedEffect(key1 = pagerState.currentPage) {
-        viewModel.setPage(pagerState.currentPage)
-    }
 
     // 시험 종료 다이얼로그
     DuckieDialog(
@@ -119,15 +115,16 @@ internal fun QuizScreen(
                 isLastPage = pagerState.currentPage == totalPage - 1,
                 onLeftButtonClick = {
                     coroutineScope.launch {
-                        pagerState.movePreviousPage(viewModel::onMovePreviousPage)
+                        pagerState.movePrevPage()
                     }
                 },
                 onRightButtonClick = {
                     coroutineScope.launch {
-                        if (pagerState.currentPage == totalPage - 1) {
+                        val maximumPage = totalPage - 1
+                        if (pagerState.currentPage == maximumPage) {
                             examSubmitDialogVisible = true
                         } else {
-                            pagerState.moveNextPage(viewModel::onMoveNextPage)
+                            pagerState.moveNextPage(maximumPage)
                         }
                     }
                 },
@@ -158,7 +155,7 @@ private fun ContentSection(
             // TODO(EvergreenTree97) 추후 덕퀴즈 종료로 이동 viewModel.finishExam()
         }
     }
-    DisposableEffect(state.currentPageIndex) {
+    DisposableEffect(Unit) {
         viewModel.startTimer()
         onDispose {
             viewModel.stopTimer()

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/screen/SolveProblemScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,7 +59,11 @@ internal fun SolveProblemScreen(
     finishExam: () -> Unit,
 ) {
     val totalPage = remember { state.totalPage }
+
     val pagerState = rememberPagerState()
+    val isCurrentPageOffsetFractionZero = remember {
+        derivedStateOf { pagerState.currentPageOffsetFraction == 0f }
+    }
 
     val coroutineScope = rememberCoroutineScope()
     var examExitDialogVisible by remember { mutableStateOf(false) }
@@ -106,6 +111,7 @@ internal fun SolveProblemScreen(
                 pagerState = pagerState,
                 state = state,
                 inputAnswer = inputAnswer,
+                isCurrentPageOffsetFractionZero = isCurrentPageOffsetFractionZero.value,
             )
             DoubleButtonBottomBar(
                 modifier = Modifier.layoutId(SolveProblemBottomBarLayoutId),
@@ -143,13 +149,14 @@ private fun ContentSection(
     inputAnswer: (Int, InputAnswer) -> Unit,
     pagerState: PagerState,
     state: SolveProblemState,
+    isCurrentPageOffsetFractionZero: Boolean,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     val currentProblem = state.problems[pagerState.currentPage].problem
 
-    LaunchedEffect(pagerState.currentPageOffsetFraction) {
-        if (currentProblem.answer?.isShortAnswer() == true && pagerState.currentPageOffsetFraction == 0f) {
+    LaunchedEffect(key1 = isCurrentPageOffsetFractionZero) {
+        if (currentProblem.answer?.isShortAnswer() == true) {
             keyboardController?.show()
             focusRequester.requestFocus()
         } else {

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/SolveProblemViewModel.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/SolveProblemViewModel.kt
@@ -98,26 +98,6 @@ internal class SolveProblemViewModel @Inject constructor(
         }
     }
 
-    fun setPage(page: Int) = intent {
-        reduce {
-            state.copy(
-                currentPageIndex = page,
-            )
-        }
-    }
-
-    fun onMoveNextPage(page: Int) = intent {
-        if (state.currentPageIndex < state.totalPage - 1) {
-            setPage(page = page)
-        }
-    }
-
-    fun onMovePreviousPage(page: Int) = intent {
-        if (state.currentPageIndex > 0) {
-            setPage(page = page)
-        }
-    }
-
     fun inputAnswer(
         pageIndex: Int,
         inputAnswer: InputAnswer,

--- a/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/state/SolveProblemState.kt
+++ b/feature-ui-solve-problem/src/main/kotlin/team/duckie/app/android/feature/ui/solve/problem/viewmodel/state/SolveProblemState.kt
@@ -15,7 +15,6 @@ internal data class SolveProblemState(
     val examId: Int = -1,
     val isProblemsLoading: Boolean = true,
     val isError: Boolean = false,
-    val currentPageIndex: Int = 0,
     val problems: ImmutableList<ProblemInstance> = persistentListOf(),
     val inputAnswers: ImmutableList<InputAnswer> = persistentListOf(),
 ) {

--- a/util-compose/src/main/kotlin/team/duckie/app/android/util/compose/PagerState.kt
+++ b/util-compose/src/main/kotlin/team/duckie/app/android/util/compose/PagerState.kt
@@ -12,24 +12,18 @@ package team.duckie.app.android.util.compose
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.pager.PagerState
 
-suspend inline fun PagerState.moveNextPage(
-    onMovePage: (Int) -> Unit,
-) {
-    if (canScrollForward) {
-        currentPage.plus(1).also {
+suspend inline fun PagerState.movePrevPage() {
+    if (currentPage > 0 && canScrollBackward) {
+        currentPage.minus(1).also {
             animateScrollToPage(it)
-            onMovePage(it)
         }
     }
 }
 
-suspend inline fun PagerState.movePreviousPage(
-    onMovePage: (Int) -> Unit,
-) {
-    if (canScrollBackward) {
-        currentPage.minus(1).also {
+suspend inline fun PagerState.moveNextPage(maxPage: Int) {
+    if (currentPage < maxPage && canScrollForward) {
+        currentPage.plus(1).also {
             animateScrollToPage(it)
-            onMovePage(it)
         }
     }
 }


### PR DESCRIPTION
## Issue

- close [#문제 풀기 중 주관식 답안이 나오면 텍스트필드를 올리고, focus해줘야 함](https://www.notion.so/duckie-team/focus-82a89406e9a24e658028f497d870107e?pvs=4)

## Overview (Required)

- 주관식 문제가 나올 경우 keyboard를 올려주었습니다.
- 주관식 문제가 나올 경우 정답 입력란에 focus를 request 해주었습니다.

### 참고
* recomposition을 최적화 하던 도중 QuizScreen의 pageIndexed를 제거하였습니다. 추후 작업 시 참고부탁드립니다.
* QuizScreen 로직을 본의아니게 조금 건드리게 되었는데, 확인 한 번 부탁드립니다.

### 리뷰 포인트
* HorizontalPager에서 페이지를 다 넘긴 후에 키보드를 올리기 위해서 key로 pagerState.currentPageOffsetFraction를 주었습니다. 때문에    recomposition이 많이 일어날 것 같은데 이렇게 처리를 해도 되는지 고민됩니다.
```kotlin
LaunchedEffect(pagerState.currentPageOffsetFraction) {
      if (currentProblem.answer?.isShortAnswer() == true && pagerState.currentPageOffsetFraction == 0f) {
          keyboardController?.show()
          focusRequester.requestFocus()
      } else {
          keyboardController?.hide()
      }
}
```
