### PR TITLE
갤러리에서 전체보기 말고 다른 정렬 기준이 있는 것으로 착각하게 되는 현상 해결

### DIFF
--- a/feature-photopicker/src/main/kotlin/team/duckie/app/android/feature/photopicker/PhotoPicker.kt
+++ b/feature-photopicker/src/main/kotlin/team/duckie/app/android/feature/photopicker/PhotoPicker.kt
@@ -115,7 +115,6 @@ fun PhotoPicker(
             leadingIcon = QuackIcon.Close,
             onLeadingIconClick = onCloseClick,
             centerText = stringResource(R.string.topappbar_filter_full),
-            centerTextTrailingIcon = QuackIcon.ArrowDown,
             trailingContent = {
                 QuackSubtitle(
                     modifier = Modifier


### PR DESCRIPTION
## Issue

https://www.notion.so/duckie-team/94f3288942ff4816954fd489dd802277?pvs=4

## Overview (Required)
- PhotoPicker에서 trailingicon 아래 화살표를 제거하였습니다.

## Screenshot
![image](https://github.com/duckie-team/duckie-android/assets/70064912/94cca4f0-d57b-4df0-8369-e7df55e1efd8)
