### PR TITLE
refactor: feature-setting migrate quack-v2

### DIFF
--- a/common/compose/build.gradle.kts
+++ b/common/compose/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
         projects.common.kotlin,
         libs.compose.lifecycle.viewmodel,
         libs.quack.ui.components,
+        libs.quack.v2.ui,
         libs.compose.ui.activity,
         libs.compose.ui.material,
         libs.compose.ui.camposer,

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/typography.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/typography.kt
@@ -1,0 +1,14 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.common.compose
+
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackTypography
+
+fun QuackTypography.toGray1Color() =
+    this.change(color = QuackColor.Gray1)

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/QuackMaxWidthDivider.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/QuackMaxWidthDivider.kt
@@ -21,7 +21,7 @@ import team.duckie.quackquack.ui.component.QuackDivider
  */
 @Composable
 fun QuackMaxWidthDivider(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/QuackMaxWidthDivider.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/QuackMaxWidthDivider.kt
@@ -20,14 +20,16 @@ import team.duckie.quackquack.ui.component.QuackDivider
  * 스크린의 크기만큼 QuackDivider를 그립니다.
  */
 @Composable
-fun QuackMaxWidthDivider() {
+fun QuackMaxWidthDivider(
+    modifier: Modifier = Modifier
+) {
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
 
     val screenWidthPx = remember { configuration.screenWidthDp * density.density }
 
     QuackDivider(
-        modifier = Modifier
+        modifier = modifier
             .layout { measurable, constraints ->
                 val placeable = measurable.measure(
                     constraints.copy(

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
         libs.orbit.viewmodel,
         libs.orbit.compose,
         libs.quack.ui.components,
+        libs.quack.v2.ui,
         libs.compose.lifecycle.runtime,
         libs.compose.ui.accompanist.webview,
         libs.firebase.crashlytics,

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/component/SettingContentLayout.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/component/SettingContentLayout.kt
@@ -16,9 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackBody1
-import team.duckie.quackquack.ui.component.QuackTitle2
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackTypography
+import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.modifier.quackClickable
 
 @Composable
@@ -44,27 +44,31 @@ internal fun SettingContentLayout(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         if (isBold) {
-            QuackTitle2(
+            QuackText(
                 text = title,
-                color = QuackColor.Black,
+                typography = QuackTypography.Title2,
             )
         } else {
-            QuackBody1(
+            QuackText(
                 text = title,
-                color = QuackColor.Black,
+                typography = QuackTypography.Body1,
             )
         }
         if (content != null) {
-            QuackBody1(
+            QuackText(
                 modifier = Modifier.padding(start = 12.dp),
                 text = content,
-                color = QuackColor.Gray1,
+                typography = QuackTypography.Body1.change(
+                    color = QuackColor.Gray1,
+                ),
             )
         }
         if (trailingText != null) {
-            QuackBody1(
+            QuackText(
                 text = trailingText,
-                color = QuackColor.Gray1,
+                typography = QuackTypography.Body1.change(
+                    color = QuackColor.Gray1,
+                ),
             )
         }
     }

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/component/SettingContentLayout.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/component/SettingContentLayout.kt
@@ -16,10 +16,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import team.duckie.quackquack.material.QuackColor
-import team.duckie.quackquack.material.QuackTypography
+import team.duckie.app.android.feature.setting.constans.SettingDesignToken
 import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.modifier.quackClickable
+import team.duckie.quackquack.ui.sugar.QuackBody1
+import team.duckie.quackquack.ui.sugar.QuackTitle2
 
 @Composable
 internal fun SettingContentLayout(
@@ -28,7 +29,7 @@ internal fun SettingContentLayout(
     trailingText: String? = null,
     isBold: Boolean,
     onClick: (() -> Unit)? = null,
-) {
+) = with(SettingDesignToken) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -44,31 +45,25 @@ internal fun SettingContentLayout(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         if (isBold) {
-            QuackText(
+            QuackTitle2(
                 text = title,
-                typography = QuackTypography.Title2,
             )
         } else {
-            QuackText(
+            QuackBody1(
                 text = title,
-                typography = QuackTypography.Body1,
             )
         }
         if (content != null) {
             QuackText(
                 modifier = Modifier.padding(start = 12.dp),
                 text = content,
-                typography = QuackTypography.Body1.change(
-                    color = QuackColor.Gray1,
-                ),
+                typography = SettingHorizontalResultTypography,
             )
         }
         if (trailingText != null) {
             QuackText(
                 text = trailingText,
-                typography = QuackTypography.Body1.change(
-                    color = QuackColor.Gray1,
-                ),
+                typography = SettingHorizontalResultTypography,
             )
         }
     }

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/constans/SettingDesignToken.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/constans/SettingDesignToken.kt
@@ -1,0 +1,19 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.setting.constans
+
+import team.duckie.app.android.common.compose.toGray1Color
+import team.duckie.quackquack.material.QuackTypography
+
+/**
+ * 설정에서 쓰이는 공통적으로 쓰이는 일정한 형식의 디자인 토큰 집합
+ */
+internal object SettingDesignToken {
+    val SettingHorizontalResultTypography = QuackTypography.Body1.toGray1Color()
+    val SettingVerticalResultTypography = QuackTypography.Body2.toGray1Color()
+}

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
@@ -29,14 +29,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.component.SettingContentLayout
-import team.duckie.app.android.common.compose.ui.Spacer
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackBody1
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackTypography
+import team.duckie.quackquack.ui.QuackImage
+import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.component.QuackDivider
-import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.component.QuackSubtitle2
 
 private val KakaoColor: Color = Color(0xFFFEE500)
 
@@ -56,9 +56,10 @@ fun SettingAccountInfoScreen(
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
-        QuackSubtitle2(
+        QuackText(
             modifier = Modifier.padding(vertical = 12.dp),
             text = stringResource(id = R.string.sign_in_account),
+            typography = QuackTypography.Subtitle2,
         )
         Row(
             modifier = Modifier
@@ -66,7 +67,10 @@ fun SettingAccountInfoScreen(
                 .height(44.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            QuackBody1(text = stringResource(id = R.string.email))
+            QuackText(
+                text = stringResource(id = R.string.email),
+                typography = QuackTypography.Body1,
+            )
             Spacer(space = 12.dp)
             Box(
                 modifier = Modifier
@@ -83,11 +87,14 @@ fun SettingAccountInfoScreen(
                 )
             }
             Spacer(space = 4.dp)
-            QuackBody1(
+            QuackText(
                 text = email,
-                color = QuackColor.Gray1,
+                    typography = QuackTypography.Body1.change(
+                    color = QuackColor.Gray1,
+                ),
             )
         }
+
         QuackDivider(modifier = Modifier.padding(vertical = 16.dp))
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import team.duckie.app.android.common.compose.ui.QuackMaxWidthDivider
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.component.SettingContentLayout
@@ -91,8 +92,7 @@ fun SettingAccountInfoScreen(
                 typography = SettingHorizontalResultTypography,
             )
         }
-
-        QuackDivider(modifier = Modifier.padding(vertical = 16.dp))
+        QuackMaxWidthDivider(modifier = Modifier.padding(vertical = 16.dp))
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
@@ -32,11 +32,12 @@ import kotlinx.collections.immutable.persistentListOf
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.component.SettingContentLayout
-import team.duckie.quackquack.material.QuackColor
-import team.duckie.quackquack.material.QuackTypography
+import team.duckie.app.android.feature.setting.constans.SettingDesignToken
 import team.duckie.quackquack.ui.QuackImage
 import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.component.QuackDivider
+import team.duckie.quackquack.ui.sugar.QuackBody1
+import team.duckie.quackquack.ui.sugar.QuackSubtitle2
 
 private val KakaoColor: Color = Color(0xFFFEE500)
 
@@ -45,7 +46,7 @@ fun SettingAccountInfoScreen(
     email: String,
     onClickLogOut: () -> Unit,
     onClickWithdraw: () -> Unit,
-) {
+) = with(SettingDesignToken) {
     val rememberAccountInfoItems: ImmutableList<Pair<Int, () -> Unit>> = remember {
         persistentListOf(
             R.string.log_out to onClickLogOut,
@@ -56,10 +57,9 @@ fun SettingAccountInfoScreen(
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
-        QuackText(
+        QuackSubtitle2(
             modifier = Modifier.padding(vertical = 12.dp),
             text = stringResource(id = R.string.sign_in_account),
-            typography = QuackTypography.Subtitle2,
         )
         Row(
             modifier = Modifier
@@ -67,9 +67,8 @@ fun SettingAccountInfoScreen(
                 .height(44.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            QuackText(
+            QuackBody1(
                 text = stringResource(id = R.string.email),
-                typography = QuackTypography.Body1,
             )
             Spacer(space = 12.dp)
             Box(
@@ -89,9 +88,7 @@ fun SettingAccountInfoScreen(
             Spacer(space = 4.dp)
             QuackText(
                 text = email,
-                    typography = QuackTypography.Body1.change(
-                    color = QuackColor.Gray1,
-                ),
+                typography = SettingHorizontalResultTypography,
             )
         }
 

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingAccountInfoScreen.kt
@@ -36,7 +36,6 @@ import team.duckie.app.android.feature.setting.component.SettingContentLayout
 import team.duckie.app.android.feature.setting.constans.SettingDesignToken
 import team.duckie.quackquack.ui.QuackImage
 import team.duckie.quackquack.ui.QuackText
-import team.duckie.quackquack.ui.component.QuackDivider
 import team.duckie.quackquack.ui.sugar.QuackBody1
 import team.duckie.quackquack.ui.sugar.QuackSubtitle2
 

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingActivity.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingActivity.kt
@@ -27,28 +27,29 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.common.android.ui.BaseActivity
+import team.duckie.app.android.common.android.ui.finishWithAnimation
+import team.duckie.app.android.common.android.ui.startActivityWithAnimation
+import team.duckie.app.android.common.compose.systemBarPaddings
+import team.duckie.app.android.common.compose.ui.DuckieTodoScreen
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
+import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
+import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
 import team.duckie.app.android.feature.setting.BuildConfig
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.constans.SettingType
 import team.duckie.app.android.feature.setting.viewmodel.SettingViewModel
 import team.duckie.app.android.feature.setting.viewmodel.sideeffect.SettingSideEffect
 import team.duckie.app.android.navigator.feature.intro.IntroNavigator
-import team.duckie.app.android.common.compose.ui.DuckieTodoScreen
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
-import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
-import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
-import team.duckie.app.android.common.compose.systemBarPaddings
-import team.duckie.app.android.common.android.ui.finishWithAnimation
-import team.duckie.app.android.common.android.ui.startActivityWithAnimation
-import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.theme.QuackTheme
 import team.duckie.quackquack.ui.component.QuackTopAppBar
 import team.duckie.quackquack.ui.icon.QuackIcon
-import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SettingActivity : team.duckie.app.android.common.android.ui.BaseActivity() {
+class SettingActivity : BaseActivity() {
 
     @Inject
     lateinit var introNavigator: IntroNavigator
@@ -92,7 +93,7 @@ class SettingActivity : team.duckie.app.android.common.android.ui.BaseActivity()
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(QuackColor.White.composeColor)
+                        .background(QuackColor.White.value)
                         .padding(systemBarPaddings),
                 ) {
                     QuackTopAppBar(

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingInquiryScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingInquiryScreen.kt
@@ -22,7 +22,8 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.component.SettingContentLayout
-import team.duckie.quackquack.ui.component.QuackSubtitle2
+import team.duckie.quackquack.material.QuackTypography
+import team.duckie.quackquack.ui.QuackText
 
 /**
  * 덕키 공식 이메일
@@ -46,9 +47,10 @@ fun SettingInquiryScreen() {
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
-        QuackSubtitle2(
+        QuackText(
             modifier = Modifier.padding(vertical = 12.dp),
             text = stringResource(id = R.string.contact_inquiry),
+            typography = QuackTypography.Subtitle2,
         )
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingInquiryScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingInquiryScreen.kt
@@ -22,8 +22,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.component.SettingContentLayout
-import team.duckie.quackquack.material.QuackTypography
-import team.duckie.quackquack.ui.QuackText
+import team.duckie.quackquack.ui.sugar.QuackSubtitle2
 
 /**
  * 덕키 공식 이메일
@@ -47,10 +46,9 @@ fun SettingInquiryScreen() {
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
-        QuackText(
+        QuackSubtitle2(
             modifier = Modifier.padding(vertical = 12.dp),
             text = stringResource(id = R.string.contact_inquiry),
-            typography = QuackTypography.Subtitle2,
         )
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingMainPolicyScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingMainPolicyScreen.kt
@@ -16,10 +16,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.component.SettingContentLayout
 import team.duckie.app.android.feature.setting.constans.SettingType
-import team.duckie.app.android.common.compose.ui.Spacer
 
 @Composable
 fun SettingMainPolicyScreen(

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingNotificationScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingNotificationScreen.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import team.duckie.app.android.feature.setting.constans.SettingNotificationType
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackBody1
-import team.duckie.quackquack.ui.component.QuackBody2
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackTypography
+import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.component.QuackSwitch
 
 /**
@@ -65,11 +65,16 @@ private fun SettingNotificationLayout(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column {
-            QuackBody1(text = title)
-            QuackBody2(
+            QuackText(
+                text = title,
+                typography = QuackTypography.Body1,
+            )
+            QuackText(
                 modifier = Modifier.padding(top = 4.dp),
                 text = description,
-                color = QuackColor.Gray1,
+                typography = QuackTypography.Body2.change(
+                    color = QuackColor.Gray1,
+                ),
             )
         }
         Spacer(modifier = Modifier.weight(1f))

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingNotificationScreen.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingNotificationScreen.kt
@@ -22,10 +22,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import team.duckie.app.android.feature.setting.constans.SettingNotificationType
-import team.duckie.quackquack.material.QuackColor
-import team.duckie.quackquack.material.QuackTypography
+import team.duckie.app.android.feature.setting.constans.SettingDesignToken
 import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.component.QuackSwitch
+import team.duckie.quackquack.ui.sugar.QuackBody1
 
 /**
  * 알림 설정 화면
@@ -57,7 +57,7 @@ private fun SettingNotificationLayout(
     description: String,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
-) {
+) = with(SettingDesignToken) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -65,16 +65,13 @@ private fun SettingNotificationLayout(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column {
-            QuackText(
+            QuackBody1(
                 text = title,
-                typography = QuackTypography.Body1,
             )
             QuackText(
                 modifier = Modifier.padding(top = 4.dp),
                 text = description,
-                typography = QuackTypography.Body2.change(
-                    color = QuackColor.Gray1,
-                ),
+                typography = SettingVerticalResultTypography,
             )
         }
         Spacer(modifier = Modifier.weight(1f))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,9 @@ quack-lint-quack = "1.0.1"
 quack-lint-compose = "1.0.2"
 # TODO(sungbin): quack-lint-writing
 
+# quack v2
+quack-v2-ui = "2.0.0-alpha04"
+
 # test
 test-strikt = "0.34.1"
 test-junit-core = "4.13.2"
@@ -250,6 +253,8 @@ quack-ui-components = { module = "team.duckie.quack:quack-ui-components", versio
 quack-lint-core = { module = "team.duckie.quack:quack-lint-core", version.ref = "quack-lint-core" }
 quack-lint-quack = { module = "team.duckie.quack:quack-lint-quack", version.ref = "quack-lint-quack" }
 quack-lint-compose = { module = "team.duckie.quack:quack-lint-compose", version.ref = "quack-lint-compose" }
+
+quack-v2-ui = { module = "team.duckie.quackquack.ui:ui", version.ref = "quack-v2-ui" }
 
 test-strikt = { module = "io.strikt:strikt-core", version.ref = "test-strikt" }
 test-junit-core = { module = "junit:junit", version.ref = "test-junit-core" }


### PR DESCRIPTION
### Issue
* close [feature-setting QuackQuackV2 로 바꾸기](https://www.notion.so/duckie-team/feature-setting-QuackQuackV2-728e9d07de214743956669de6219b259?pvs=4)

### Overview (Required)
* 설정에서 마이그레이션 할 수 있는 부분을 마이그레이션 했습니다.
* 설정에서 일괄적인 규칙을 가진 디자인 토큰들을 SettingDesignToken으로 분리하여 관리했습니다.
* QuackQuack V1 to V2