### PR TITLE
fix: 덕력고사에서 focusRequster가 초기화 되지 않는 오류

### DIFF
--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/SolveProblemActivity.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/SolveProblemActivity.kt
@@ -111,7 +111,6 @@ class SolveProblemActivity : BaseActivity() {
                                 false -> SolveProblemScreen(
                                     state = state,
                                     pagerState = pagerState,
-                                    inputAnswer = viewModel::inputAnswer,
                                     stopExam = viewModel::stopExam,
                                     finishExam = viewModel::finishExam,
                                 )

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/AnswerSection.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/AnswerSection.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
@@ -34,7 +33,7 @@ internal fun LazyListScope.answerSection(
     answer: Answer,
     inputAnswers: ImmutableList<InputAnswer>,
     updateInputAnswers: (page: Int, inputAnswer: InputAnswer) -> Unit,
-    focusRequester: FocusRequester,
+    requestFocus: Boolean,
     keyboardController: SoftwareKeyboardController?,
 ) {
     when (answer) {
@@ -102,7 +101,7 @@ internal fun LazyListScope.answerSection(
                     onDone = { inputText ->
                         updateInputAnswers(pageIndex, InputAnswer(0, inputText))
                     },
-                    focusRequester = focusRequester,
+                    requestFocus = requestFocus,
                     keyboardController = keyboardController,
                 )
             }

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/shortanswer/ShortAnswerForm.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/shortanswer/ShortAnswerForm.kt
@@ -10,6 +10,8 @@ package team.duckie.app.android.feature.solve.problem.answer.shortanswer
 
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -28,8 +30,17 @@ internal fun ShortAnswerForm(
     answer: String,
     onDone: (String) -> Unit,
     keyboardController: SoftwareKeyboardController?,
-    focusRequester: FocusRequester,
+    requestFocus: Boolean,
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(key1 = requestFocus) {
+        if (requestFocus) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
     QuackGrayscaleTextField(
         modifier = modifier.focusRequester(focusRequester),
         text = text,

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -53,6 +52,7 @@ import team.duckie.app.android.feature.solve.problem.viewmodel.state.SolveProble
 import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
 import team.duckie.app.android.common.compose.isCurrentPage
 import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
+import team.duckie.quackquack.ui.component.QuackHeadLine1
 
 private const val QuizTopAppBarLayoutId = "QuizTopAppBar"
 private const val QuizContentLayoutId = "QuizContent"
@@ -171,17 +171,13 @@ private fun ContentSection(
     ) { pageIndex ->
         val problem = state.quizProblems[pageIndex]
 
-        val focusRequester = remember { FocusRequester() }
-        val requestFocus by remember { derivedStateOf { pagerState.isCurrentPage(pageIndex) } }
+        val requestFocus by remember(key1 = pagerState.currentPage) {
+            derivedStateOf { pagerState.isCurrentPage(pageIndex) }
+        }
 
         LaunchedEffect(key1 = requestFocus) {
-            if (requestFocus) {
-                if (problem.isSubjective()) {
-                    focusRequester.requestFocus()
-                    keyboardController?.show()
-                } else {
-                    keyboardController?.hide()
-                }
+            if (!problem.isSubjective()) {
+                keyboardController?.hide()
             }
         }
 
@@ -210,7 +206,7 @@ private fun ContentSection(
                 },
                 inputAnswers = inputAnswers,
                 updateInputAnswers = updateInputAnswers,
-                focusRequester = focusRequester,
+                requestFocus = requestFocus,
                 keyboardController = keyboardController,
             )
         }

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
@@ -52,7 +52,6 @@ import team.duckie.app.android.feature.solve.problem.viewmodel.state.SolveProble
 import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
 import team.duckie.app.android.common.compose.isCurrentPage
 import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
-import team.duckie.quackquack.ui.component.QuackHeadLine1
 
 private const val QuizTopAppBarLayoutId = "QuizTopAppBar"
 private const val QuizContentLayoutId = "QuizContent"

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -20,18 +20,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.Problem.Companion.isSubjective
@@ -52,19 +54,29 @@ private const val SolveProblemTopAppBarLayoutId = "SolveProblemTopAppBar"
 private const val SolveProblemContentLayoutId = "SolveProblemContent"
 private const val SolveProblemBottomBarLayoutId = "SolveProblemBottomBar"
 
+// 6번호
 @Composable
 internal fun SolveProblemScreen(
     state: SolveProblemState,
-    pagerState: PagerState,
-    inputAnswer: (Int, InputAnswer) -> Unit,
     stopExam: () -> Unit,
     finishExam: () -> Unit,
+    pagerState: PagerState,
 ) {
     val totalPage = remember { state.totalPage }
 
     val coroutineScope = rememberCoroutineScope()
     var examExitDialogVisible by remember { mutableStateOf(false) }
     var examSubmitDialogVisible by remember { mutableStateOf(false) }
+
+    // TODO(limsaehyun): inputAnswers를 제출할 때 Intent 해주는 로직 추가 작업 필요
+    val inputAnswers = remember {
+        mutableStateListOf(
+            elements = Array(
+                size = state.problems.size,
+                init = { InputAnswer() },
+            ),
+        )
+    }
 
     // 시험 종료 다이얼로그
     DuckieDialog(
@@ -107,7 +119,10 @@ internal fun SolveProblemScreen(
                 modifier = Modifier.layoutId(SolveProblemContentLayoutId),
                 pagerState = pagerState,
                 state = state,
-                updateInputAnswers = inputAnswer,
+                updateInputAnswers = { page, answer ->
+                    inputAnswers[page] = answer
+                },
+                inputAnswers = inputAnswers.toPersistentList(),
             )
             DoubleButtonBottomBar(
                 modifier = Modifier.layoutId(SolveProblemBottomBarLayoutId),
@@ -143,6 +158,7 @@ private fun ContentSection(
     modifier: Modifier = Modifier,
     pagerState: PagerState,
     state: SolveProblemState,
+    inputAnswers: ImmutableList<InputAnswer>,
     updateInputAnswers: (Int, InputAnswer) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -154,17 +170,15 @@ private fun ContentSection(
     ) { pageIndex ->
         val problem = state.problems[pageIndex].problem
 
-        val focusRequester = remember { FocusRequester() }
-        val requestFocus by remember { derivedStateOf { pagerState.isCurrentPage(pageIndex) } }
+        val requestFocus by remember(key1 = pagerState.currentPage) {
+            derivedStateOf {
+                pagerState.isCurrentPage(pageIndex)
+            }
+        }
 
         LaunchedEffect(key1 = requestFocus) {
-            if (requestFocus) {
-                if (problem.isSubjective()) {
-                    focusRequester.requestFocus()
-                    keyboardController?.show()
-                } else {
-                    keyboardController?.hide()
-                }
+            if (!problem.isSubjective()) {
+                keyboardController?.hide()
             }
         }
 
@@ -188,9 +202,9 @@ private fun ContentSection(
                     is Answer.Choice, is Answer.ImageChoice -> answer
                     else -> duckieResponseFieldNpe("해당 분기로 빠질 수 없는 AnswerType 입니다.")
                 },
-                inputAnswers = state.inputAnswers,
+                inputAnswers = inputAnswers,
                 updateInputAnswers = updateInputAnswers,
-                focusRequester = focusRequester,
+                requestFocus = requestFocus,
                 keyboardController = keyboardController,
             )
         }

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -50,7 +50,6 @@ import team.duckie.app.android.common.compose.isCurrentPage
 import team.duckie.app.android.common.compose.moveNextPage
 import team.duckie.app.android.common.compose.movePrevPage
 import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
-import team.duckie.quackquack.ui.component.QuackHeadLine1
 
 private const val SolveProblemTopAppBarLayoutId = "SolveProblemTopAppBar"
 private const val SolveProblemContentLayoutId = "SolveProblemContent"

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import team.duckie.app.android.domain.exam.model.Answer
@@ -49,6 +50,7 @@ import team.duckie.app.android.common.compose.isCurrentPage
 import team.duckie.app.android.common.compose.moveNextPage
 import team.duckie.app.android.common.compose.movePrevPage
 import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
+import team.duckie.quackquack.ui.component.QuackHeadLine1
 
 private const val SolveProblemTopAppBarLayoutId = "SolveProblemTopAppBar"
 private const val SolveProblemContentLayoutId = "SolveProblemContent"
@@ -59,7 +61,7 @@ private const val SolveProblemBottomBarLayoutId = "SolveProblemBottomBar"
 internal fun SolveProblemScreen(
     state: SolveProblemState,
     stopExam: () -> Unit,
-    finishExam: () -> Unit,
+    finishExam: (List<String>) -> Unit,
     pagerState: PagerState,
 ) {
     val totalPage = remember { state.totalPage }
@@ -68,7 +70,6 @@ internal fun SolveProblemScreen(
     var examExitDialogVisible by remember { mutableStateOf(false) }
     var examSubmitDialogVisible by remember { mutableStateOf(false) }
 
-    // TODO(limsaehyun): inputAnswers를 제출할 때 Intent 해주는 로직 추가 작업 필요
     val inputAnswers = remember {
         mutableStateListOf(
             elements = Array(
@@ -97,7 +98,9 @@ internal fun SolveProblemScreen(
         leftButtonText = stringResource(id = R.string.cancel),
         leftButtonOnClick = { examSubmitDialogVisible = false },
         rightButtonText = stringResource(id = R.string.submit),
-        rightButtonOnClick = finishExam,
+        rightButtonOnClick = {
+            finishExam(inputAnswers.map { it.answer }.toImmutableList())
+        },
         visible = examSubmitDialogVisible,
         onDismissRequest = { examSubmitDialogVisible = false },
     )

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
@@ -138,14 +138,6 @@ internal class SolveProblemViewModel @Inject constructor(
         }
     }
 
-    fun updateInputAnswer(
-        inputAnswer: ImmutableList<InputAnswer>,
-    ) = intent {
-        reduce {
-            state.copy(inputAnswers = inputAnswer)
-        }
-    }
-
     fun moveNextPage(
         pageIndex: Int,
         inputAnswer: InputAnswer,

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
@@ -139,7 +139,7 @@ internal class SolveProblemViewModel @Inject constructor(
     }
 
     fun updateInputAnswer(
-        inputAnswer: ImmutableList<InputAnswer>
+        inputAnswer: ImmutableList<InputAnswer>,
     ) = intent {
         reduce {
             state.copy(inputAnswers = inputAnswer)

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.Container
@@ -27,9 +28,7 @@ import team.duckie.app.android.feature.solve.problem.viewmodel.state.SolveProble
 import team.duckie.app.android.common.android.savedstate.getOrThrow
 import team.duckie.app.android.common.android.timer.ProblemTimer
 import team.duckie.app.android.common.kotlin.ImmutableList
-import team.duckie.app.android.common.kotlin.copy
 import team.duckie.app.android.common.kotlin.exception.DuckieClientLogicProblemException
-import team.duckie.app.android.common.kotlin.fastMap
 import team.duckie.app.android.common.kotlin.seconds
 import team.duckie.app.android.common.android.ui.const.Extras
 import javax.inject.Inject
@@ -139,16 +138,11 @@ internal class SolveProblemViewModel @Inject constructor(
         }
     }
 
-    fun inputAnswer(
-        pageIndex: Int,
-        inputAnswer: InputAnswer,
+    fun updateInputAnswer(
+        inputAnswer: ImmutableList<InputAnswer>
     ) = intent {
         reduce {
-            state.copy(
-                inputAnswers = state.inputAnswers.copy {
-                    this[pageIndex] = inputAnswer
-                },
-            )
+            state.copy(inputAnswers = inputAnswer)
         }
     }
 
@@ -167,12 +161,14 @@ internal class SolveProblemViewModel @Inject constructor(
         }
     }
 
-    fun finishExam() = intent {
+    fun finishExam(
+        userInputAnswers: List<String>,
+    ) = intent {
         stopTimer()
         postSideEffect(
             SolveProblemSideEffect.FinishSolveProblem(
                 examId = state.examId,
-                answers = state.inputAnswers.fastMap { it.answer },
+                answers = userInputAnswers,
             ),
         )
     }


### PR DESCRIPTION
## Issue

- close [덕력고사 간혈적인 Crash 발생](https://www.notion.so/duckie-team/Crash-131a6423771f422fb0e585c877ba4d19?pvs=4)

## Overview (Required)

- 잦은 리컴포지션으로 인해 focusRequster가 초기화 되지 않아 crash가 발생했습니다.
- 필요한 경우에만 리컴포지션이 되도록 최적화를 진행했습니다.
- focusRequster에 대한 로직을 책임에 맞게 ShortAnswerForm으로 이동시켜 필요한 경우에만 요청할 수 있도록 로직을 재점검했습니다.
