### PR TITLE
fix: 덕력고사 시작 전 타이틀 텍스트 변경

### DIFF
--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
@@ -68,7 +68,7 @@ internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewMo
                 start = 16.dp,
                 end = 16.dp,
             ),
-            text = stringResource(id = R.string.title),
+            text = stringResource(id = R.string.information_before_title),
         )
 
         // 필적 확인 문구 TextField

--- a/feature/start-exam/src/main/res/values/strings.xml
+++ b/feature/start-exam/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="title">시험 시작 전, 필적 확인 문구를\n정확히 입력해주세요.</string>
+    <string name="information_before_title">시험 시작 전, 필적 확인 문구를\n정확히 입력해주세요.</string>
     <string name="certifing_statement_placeholder">누칼협? 열심히 살지 말자</string>
     <string name="start_button">시험시작</string>
     <string name="information_before_quiz_title">[ 퀴즈 시작 전 안내사항 ]</string>


### PR DESCRIPTION
## Issue

- close [시험 시작을 했더니 태그편집이 나오네…](https://www.notion.so/duckie-team/f44c7a1448bf44fca428bac561d4ba1f?pvs=4)

## Overview (Required)

- 시험 시작 전 타이틀 텍스트 알맞게 변경
