### PR TITLE
문제 시작 화면에 태그 편집 제목이 나옴

### DIFF
--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
@@ -68,7 +68,7 @@ internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewMo
                 start = 16.dp,
                 end = 16.dp,
             ),
-            text = stringResource(id = R.string.information_before_title),
+            text = stringResource(id = R.string.start_exam_title),
         )
 
         // 필적 확인 문구 TextField
@@ -93,7 +93,7 @@ internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewMo
                 horizontal = 16.dp,
             ),
             type = QuackLargeButtonType.Fill,
-            text = stringResource(id = R.string.start_button),
+            text = stringResource(id = R.string.start_exam_start_button),
             enabled = viewModel.startExamValidate(),
             onClick = viewModel::startSolveProblem,
         )

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -72,7 +72,7 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
             )
             QuackTitle2(
                 modifier = Modifier.padding(top = 34.dp),
-                text = stringResource(id = R.string.challenge_condition),
+                text = stringResource(id = R.string.start_exam_challenge_condition),
             )
             Spacer(space = 4.dp)
             QuackHeadLine1(
@@ -93,7 +93,7 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
                 horizontal = 16.dp,
             ),
             type = QuackLargeButtonType.Fill,
-            text = stringResource(id = R.string.start_button),
+            text = stringResource(id = R.string.start_exam_start_button),
             enabled = viewModel.startExamValidate(),
             onClick = viewModel::startSolveProblem,
         )
@@ -113,12 +113,12 @@ internal fun InfoBox(
             .clip(RoundedCornerShape(8.dp)),
         verticalArrangement = Arrangement.Center,
     ) {
-        QuackTitle2(text = stringResource(id = R.string.information_before_quiz_title))
+        QuackTitle2(text = stringResource(id = R.string.start_exam_information_before_quiz_title))
         Spacer(space = 4.dp)
-        QuackBody2(text = stringResource(id = R.string.information_before_quiz_line1))
+        QuackBody2(text = stringResource(id = R.string.start_exam_information_before_quiz_line1))
         QuackText(
             annotatedText = buildAnnotatedString {
-                append(stringResource(id = R.string.information_before_quiz_line2_prefix))
+                append(stringResource(id = R.string.start_exam_information_before_quiz_line2_prefix))
                 withStyle(
                     SpanStyle(
                         color = QuackColor.Black.composeColor,
@@ -127,12 +127,14 @@ internal fun InfoBox(
                 ) {
                     append(
                         stringResource(
-                            id = R.string.information_before_quiz_line2_infix,
+                            id = R.string.start_exam_information_before_quiz_line2_infix,
                             limitTime.toString(),
                         ),
                     )
                 }
-                append(stringResource(id = R.string.information_before_quiz_line2_postfix))
+                append(
+                    stringResource(id = R.string.start_exam_information_before_quiz_line2_postfix),
+                )
             },
             style = QuackTextStyle.Body2,
         )

--- a/feature/start-exam/src/main/res/values/strings.xml
+++ b/feature/start-exam/src/main/res/values/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="information_before_title">시험 시작 전, 필적 확인 문구를\n정확히 입력해주세요.</string>
-    <string name="certifing_statement_placeholder">누칼협? 열심히 살지 말자</string>
-    <string name="start_button">시험시작</string>
-    <string name="information_before_quiz_title">[ 퀴즈 시작 전 안내사항 ]</string>
-    <string name="information_before_quiz_line1">※ 문제를 틀릴 경우 바로 도전이 종료됩니다.</string>
-    <string name="information_before_quiz_line2_prefix">※ 문제당&#160;</string>
-    <string name="information_before_quiz_line2_infix">약 %s초의 제한시간이 있습니다.&#160;</string>
-    <string name="information_before_quiz_line2_postfix">문제를 잘 읽고 시간 내에 물음에 답해주세요.</string>
-    <string name="challenge_condition">&lt;도전 조건&gt;</string>
+    <string name="start_exam_title">시험 시작 전, 필적 확인 문구를\n정확히 입력해주세요.</string>
+    <string name="start_exam_certifing_statement_placeholder">누칼협? 열심히 살지 말자</string>
+    <string name="start_exam_start_button">시험시작</string>
+    <string name="start_exam_information_before_quiz_title">[ 퀴즈 시작 전 안내사항 ]</string>
+    <string name="start_exam_information_before_quiz_line1">※ 문제를 틀릴 경우 바로 도전이 종료됩니다.</string>
+    <string name="start_exam_information_before_quiz_line2_prefix">※ 문제당&#160;</string>
+    <string name="start_exam_information_before_quiz_line2_infix">약 %s초의 제한시간이 있습니다.&#160;</string>
+    <string name="start_exam_information_before_quiz_line2_postfix">문제를 잘 읽고 시간 내에 물음에 답해주세요.</string>
+    <string name="start_exam_challenge_condition">&lt;도전 조건&gt;</string>
 </resources>


### PR DESCRIPTION
resolve [문제 시작 화면에 태그 편집 제목이 나옴](https://www.notion.so/duckie-team/4c760a52b98b4068976456a9c5f39a6c?pvs=4)

resource 중복으로 인한 오류를 수정하였습니다. (domain 이름을 prefix 로 추가)

---

당분간은 resource 네이밍 처리할 때, `key 이름에 prefix 를 필수`로 넣어야 될 것 같습니다.
(아래 사진 같이 모듈 별로 동일한 key 를 사용하면, 저 3개 중에 하나만 사용됩니다)

![image](https://github.com/duckie-team/duckie-android/assets/13694046/41fc84ea-a783-4f24-94b7-499beb7d83ed)

다른 해결책이 있는지는 좀 더 찾아봐야 되겠는데
nowinandroid 레포에서도 동일 현상이 발생해서요 ㅠ
일단은 저희 내부에서 주의가 필요해 보입니다.

---

참고) 아래 내용으로 try 해봤는데 전부 안되었습니다.
- 각 모듈 AndroidManifest.xml 에 package 속성값 추가하기
- R 을 풀 네이밍으로 사용하거나 as 를 활용해 사용하기
  ```kotlin
  // 아래 케이스 모두 안됨
  // 1
  com.google.samples.apps.nowinandroid.feature.foryou.R.string.for_you
  
  // 2
  import com.google.samples.apps.nowinandroid.feature.foryou.R as forYouR
  ...
  
  forYouR.string.for_you
  ```