### PR TITLE
덕퀴즈 결과 화면 피그마 스펙에 맞게 수정

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/mapper/mapper.kt
@@ -7,6 +7,7 @@
 
 package team.duckie.app.android.data.quiz.mapper
 
+import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
 import team.duckie.app.android.data.exam.mapper.toDomain
 import team.duckie.app.android.data.quiz.model.GetQuizResponse
 import team.duckie.app.android.data.quiz.model.PostQuizResponse
@@ -15,7 +16,6 @@ import team.duckie.app.android.data.user.mapper.toDomain
 import team.duckie.app.android.domain.quiz.model.Quiz
 import team.duckie.app.android.domain.quiz.model.QuizExam
 import team.duckie.app.android.domain.quiz.model.QuizResult
-import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
 
 internal fun PostQuizResponse.toDomain() = Quiz(
     id = id ?: duckieResponseFieldNpe("${this::class.java.simpleName}.id"),
@@ -36,6 +36,8 @@ internal fun GetQuizResponse.toDomain() = QuizResult(
     score = score ?: duckieResponseFieldNpe("${this::class.java.simpleName}.score"),
     user = user?.toDomain() ?: duckieResponseFieldNpe("${this::class.java.simpleName}.user"),
     wrongProblem = wrongProblem?.toDomain(),
+    ranking = ranking,
+    requirementAnswer = requirementAnswer,
 )
 
 internal fun QuizExamData.toDomain() = QuizExam(

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/GetQuizResponse.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/GetQuizResponse.kt
@@ -27,4 +27,8 @@ internal data class GetQuizResponse(
     val user: UserResponse? = null,
     @JsonProperty("wrongProblem")
     val wrongProblem: ProblemData? = null,
+    @JsonProperty("ranking")
+    val ranking: Int? = null,
+    @JsonProperty("requirementAnswer")
+    val requirementAnswer: String? = null,
 )

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/model/QuizResult.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/model/QuizResult.kt
@@ -21,4 +21,6 @@ data class QuizResult(
     val time: Int,
     val user: User,
     val wrongProblem: Problem?,
+    val ranking: Int?,
+    val requirementAnswer: String?,
 )

--- a/feature/exam-result/build.gradle.kts
+++ b/feature/exam-result/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
         libs.compose.lifecycle.runtime,
         libs.compose.ui.material, // needs for Scaffold
         libs.quack.ui.components,
+        libs.quack.v2.ui,
         libs.firebase.crashlytics,
     )
 }

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/common/ResultBottomBar.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/common/ResultBottomBar.kt
@@ -45,7 +45,7 @@ internal fun ResultBottomBar(
             modifier = Modifier
                 .heightIn(min = 44.dp)
                 .weight(1f),
-            text = stringResource(id = R.string.solve_retry),
+            text = stringResource(id = R.string.exam_result_solve_retry),
             onClick = onClickRetryButton,
         )
         QuackSmallButton(
@@ -53,7 +53,7 @@ internal fun ResultBottomBar(
                 .heightIn(44.dp)
                 .weight(1f),
             type = QuackSmallButtonType.Fill,
-            text = stringResource(id = R.string.exit_exam),
+            text = stringResource(id = R.string.exam_result_exit_exam),
             enabled = true,
             onClick = onClickExitButton,
         )

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.feature.exam.result.ExamResultActivity
@@ -85,8 +86,12 @@ internal fun ExamResultScreen(
                                 correctProblemCount = correctProblemCount,
                                 time = time,
                                 mainTag = mainTag,
-                                rank = rank,
-                                wrongAnswerMessage = wrongAnswerMessage,
+                                ranking = ranking,
+                                message = if (isPerfectScore) {
+                                    stringResource(id = R.string.exam_result_correct_problem_all, mainTag)
+                                } else {
+                                    wrongAnswerMessage
+                                },
                             )
                         } else {
                             ExamResultContent(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -86,6 +86,7 @@ internal fun ExamResultScreen(
                                 time = time,
                                 mainTag = mainTag,
                                 rank = rank,
+                                wrongAnswerMessage = wrongAnswerMessage,
                             )
                         } else {
                             ExamResultContent(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -60,7 +60,7 @@ internal fun ExamResultScreen(
         bottomBar = {
             ResultBottomBar(
                 onClickRetryButton = {
-                    viewModel.clickRetry(activity.getString(R.string.feature_prepare))
+                    viewModel.clickRetry(activity.getString(R.string.exam_result_feature_prepare))
                 },
                 onClickExitButton = viewModel::exitExam,
             )

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -33,10 +33,11 @@ import team.duckie.app.android.common.compose.GetHeightRatioW328H240
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.kotlin.toHourMinuteSecond
 import team.duckie.app.android.feature.exam.result.R
+import team.duckie.quackquack.ui.QuackImage
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody1
 import team.duckie.quackquack.ui.component.QuackDivider
-import team.duckie.quackquack.ui.component.QuackImage
+import team.duckie.quackquack.ui.component.QuackHeadLine1
 import team.duckie.quackquack.ui.component.internal.QuackText
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
@@ -46,6 +47,7 @@ internal fun QuizResultContent(
     time: Int,
     correctProblemCount: Int,
     mainTag: String,
+    wrongAnswerMessage: String,
     rank: Int,
 ) {
     Column(
@@ -62,11 +64,23 @@ internal fun QuizResultContent(
             contentAlignment = Alignment.Center,
         ) {
             QuackImage(
+                modifier = Modifier.fillMaxSize(),
                 src = resultImageUrl,
-                contentScale = ContentScale.Inside,
+                contentScale = ContentScale.Fit,
             )
         }
-        // TODO(EvergreenTree97) : 시험 결과지 스펙에 맞게 수정 및 문구 출력
+        Spacer(space = 16.dp)
+        // TODO(EvergreenTree97) : 에러 문구 폰트 변경 필요
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 30.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            QuackHeadLine1(text = "\"")
+            QuackHeadLine1(text = wrongAnswerMessage)
+            QuackHeadLine1(text = "\"")
+        }
         Spacer(space = 28.dp)
         QuackDivider()
         Spacer(space = 20.dp)

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -7,15 +7,21 @@
 
 package team.duckie.app.android.feature.exam.result.screen.quiz
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -23,6 +29,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import team.duckie.app.android.common.compose.GetHeightRatioW328H240
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.kotlin.toHourMinuteSecond
 import team.duckie.app.android.feature.exam.result.R
@@ -46,10 +53,19 @@ internal fun QuizResultContent(
             .fillMaxSize()
             .padding(all = 16.dp),
     ) {
-        QuackImage(
-            modifier = Modifier.fillMaxWidth(),
-            src = resultImageUrl,
-        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(GetHeightRatioW328H240)
+                .clip(RoundedCornerShape(8.dp))
+                .background(QuackColor.Black.composeColor),
+            contentAlignment = Alignment.Center,
+        ) {
+            QuackImage(
+                src = resultImageUrl,
+                contentScale = ContentScale.Inside,
+            )
+        }
         // TODO(EvergreenTree97) : 시험 결과지 스펙에 맞게 수정 및 문구 출력
         Spacer(space = 28.dp)
         QuackDivider()

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -47,8 +47,8 @@ internal fun QuizResultContent(
     time: Int,
     correctProblemCount: Int,
     mainTag: String,
-    wrongAnswerMessage: String,
-    rank: Int,
+    message: String,
+    ranking: Int,
 ) {
     Column(
         modifier = Modifier
@@ -78,7 +78,7 @@ internal fun QuizResultContent(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             QuackHeadLine1(text = "\"")
-            QuackHeadLine1(text = wrongAnswerMessage)
+            QuackHeadLine1(text = message)
             QuackHeadLine1(text = "\"")
         }
         Spacer(space = 28.dp)
@@ -114,7 +114,7 @@ internal fun QuizResultContent(
                 }
                 append(" 영역 ")
                 withDuckieOrangeBoldStyle {
-                    append("${rank}위")
+                    append("${ranking}위")
                 }
                 append(" 입니다.")
             },

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -7,21 +7,15 @@
 
 package team.duckie.app.android.feature.exam.result.screen.quiz
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -29,11 +23,10 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import team.duckie.app.android.common.compose.GetHeightRatioW328H240
+import team.duckie.app.android.common.compose.DuckieFitImage
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.kotlin.toHourMinuteSecond
 import team.duckie.app.android.feature.exam.result.R
-import team.duckie.quackquack.ui.QuackImage
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody1
 import team.duckie.quackquack.ui.component.QuackDivider
@@ -55,20 +48,7 @@ internal fun QuizResultContent(
             .fillMaxSize()
             .padding(all = 16.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(GetHeightRatioW328H240)
-                .clip(RoundedCornerShape(8.dp))
-                .background(QuackColor.Black.composeColor),
-            contentAlignment = Alignment.Center,
-        ) {
-            QuackImage(
-                modifier = Modifier.fillMaxSize(),
-                src = resultImageUrl,
-                contentScale = ContentScale.Fit,
-            )
-        }
+        DuckieFitImage(imageUrl = resultImageUrl)
         Spacer(space = 16.dp)
         // TODO(EvergreenTree97) : 에러 문구 폰트 변경 필요
         Row(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -23,9 +23,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import team.duckie.app.android.feature.exam.result.R
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.kotlin.toHourMinuteSecond
+import team.duckie.app.android.feature.exam.result.R
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody1
 import team.duckie.quackquack.ui.component.QuackDivider
@@ -58,7 +58,7 @@ internal fun QuizResultContent(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            QuackBody1(text = stringResource(id = R.string.total_time))
+            QuackBody1(text = stringResource(id = R.string.exam_result_total_time))
             QuackBody1(text = time.toHourMinuteSecond())
         }
         Spacer(space = 8.dp)
@@ -66,10 +66,10 @@ internal fun QuizResultContent(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            QuackBody1(text = stringResource(id = R.string.correct_problem))
+            QuackBody1(text = stringResource(id = R.string.exam_result_correct_problem))
             QuackBody1(
                 text = stringResource(
-                    id = R.string.correct_problem_unit,
+                    id = R.string.exam_result_correct_problem_unit,
                     correctProblemCount.toString(),
                 ),
             )

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultState.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultState.kt
@@ -17,6 +17,7 @@ sealed class ExamResultState {
         val time: Int = 0,
         val mainTag: String = "",
         val rank: Int = 0,
+        val wrongAnswerMessage: String = "",
     ) : ExamResultState()
 
     data class Error(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultState.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultState.kt
@@ -16,8 +16,9 @@ sealed class ExamResultState {
         val correctProblemCount: Int = 0,
         val time: Int = 0,
         val mainTag: String = "",
-        val rank: Int = 0,
+        val ranking: Int = 0,
         val wrongAnswerMessage: String = "",
+        val isPerfectScore: Boolean = false,
     ) : ExamResultState()
 
     data class Error(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
@@ -101,9 +101,10 @@ class ExamResultViewModel @Inject constructor(
             postSideEffect(ExamResultSideEffect.ReportError(it))
         }
         getQuizUseCase(examId).onSuccess { quizResult ->
+            val isPerfectScore = quizResult.wrongProblem == null
             reduce {
                 ExamResultState.Success(
-                    reportUrl = if (quizResult.wrongProblem == null) {
+                    reportUrl = if (isPerfectScore) {
                         quizResult.exam.perfectScoreImageUrl ?: ""
                     } else {
                         quizResult.wrongProblem?.solution?.solutionImageUrl ?: ""
@@ -112,7 +113,7 @@ class ExamResultViewModel @Inject constructor(
                     correctProblemCount = quizResult.correctProblemCount,
                     time = quizResult.time,
                     mainTag = quizResult.exam.mainTag?.name ?: "",
-                    rank = quizResult.score,
+                    ranking = quizResult.ranking ?: 0,
                     wrongAnswerMessage = quizResult.wrongProblem?.solution?.wrongAnswerMessage ?: "",
                 )
             }

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
@@ -54,7 +54,7 @@ class ExamResultViewModel @Inject constructor(
             getReport(
                 examId = examId,
                 submitted = ExamInstanceSubmitBody(
-                    submitted = submitted.toList().toImmutableList()
+                    submitted = submitted.toList().toImmutableList(),
                 ),
             )
         }

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
@@ -17,13 +17,13 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.common.android.savedstate.getOrThrow
+import team.duckie.app.android.common.android.ui.const.Extras
 import team.duckie.app.android.domain.exam.model.ExamInstanceSubmit
 import team.duckie.app.android.domain.exam.model.ExamInstanceSubmitBody
 import team.duckie.app.android.domain.examInstance.usecase.MakeExamInstanceSubmitUseCase
 import team.duckie.app.android.domain.quiz.usecase.GetQuizUseCase
 import team.duckie.app.android.domain.quiz.usecase.SubmitQuizUseCase
-import team.duckie.app.android.common.android.savedstate.getOrThrow
-import team.duckie.app.android.common.android.ui.const.Extras
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,7 +43,8 @@ class ExamResultViewModel @Inject constructor(
         val examId = savedStateHandle.getOrThrow<Int>(Extras.ExamId)
         val isQuiz = savedStateHandle.getOrThrow<Boolean>(Extras.IsQuiz)
         if (isQuiz) {
-            val updateQuizParam = savedStateHandle.getOrThrow<SubmitQuizUseCase.Param>(Extras.UpdateQuizParam)
+            val updateQuizParam =
+                savedStateHandle.getOrThrow<SubmitQuizUseCase.Param>(Extras.UpdateQuizParam)
             updateQuiz(
                 examId = examId,
                 updateQuizParam = updateQuizParam,
@@ -52,7 +53,9 @@ class ExamResultViewModel @Inject constructor(
             val submitted = savedStateHandle.getOrThrow<Array<String>>(Extras.Submitted)
             getReport(
                 examId = examId,
-                submitted = ExamInstanceSubmitBody(submitted = submitted.toList().toImmutableList()),
+                submitted = ExamInstanceSubmitBody(
+                    submitted = submitted.toList().toImmutableList()
+                ),
             )
         }
     }
@@ -110,6 +113,7 @@ class ExamResultViewModel @Inject constructor(
                     time = quizResult.time,
                     mainTag = quizResult.exam.mainTag?.name ?: "",
                     rank = quizResult.score,
+                    wrongAnswerMessage = quizResult.wrongProblem?.solution?.wrongAnswerMessage ?: "",
                 )
             }
         }.onFailure {

--- a/feature/exam-result/src/main/res/values/strings.xml
+++ b/feature/exam-result/src/main/res/values/strings.xml
@@ -6,10 +6,10 @@
   -->
 
 <resources>
-    <string name="solve_retry">다시 풀기</string>
-    <string name="exit_exam">시험 끝내기</string>
-    <string name="feature_prepare">준비 중인 기능입니다.</string>
-    <string name="total_time">총 응시시간</string>
-    <string name="correct_problem">맞은 문제</string>
-    <string name="correct_problem_unit">%s덕</string>
+    <string name="exam_result_solve_retry">다시 풀기</string>
+    <string name="exam_result_exit_exam">시험 끝내기</string>
+    <string name="exam_result_feature_prepare">준비 중인 기능입니다.</string>
+    <string name="exam_result_total_time">총 응시시간</string>
+    <string name="exam_result_correct_problem">맞은 문제</string>
+    <string name="exam_result_correct_problem_unit">%s덕</string>
 </resources>

--- a/feature/exam-result/src/main/res/values/strings.xml
+++ b/feature/exam-result/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="exam_result_total_time">총 응시시간</string>
     <string name="exam_result_correct_problem">맞은 문제</string>
     <string name="exam_result_correct_problem_unit">%s덕</string>
+    <string name="exam_result_correct_problem_all">모든 문제를 맞혔습니다. 당신은 %s 영역 씹덕입니다.</string>
 </resources>


### PR DESCRIPTION
## Issue
https://www.notion.so/duckie-team/c32f4855de244e3a853002f0f55911d5?pvs=4

## Overview (Required)
- 결과 사진의 여백에 검정색 배경을 주었습니다.
- 해설 문구를 포함하였습니다(추후 꽥꽥 글꼴 추가될 시 변경 예정)
- 순위를 추가하였습니다.

## Screenshot
![image](https://github.com/duckie-team/duckie-android/assets/70064912/f1eadad9-a959-4b47-9911-301d9493fbe9)
