### PR TITLE
덕퀴즈 수정 필요한 사항 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
         projects.feature.solveProblem,
         projects.feature.notification,
         projects.feature.createProblem,
+        projects.feature.startExam,
         projects.feature.detail,
         projects.feature.profile,
         projects.feature.setting,

--- a/common/android/src/main/kotlin/team/duckie/app/android/common/android/ui/const/Extras.kt
+++ b/common/android/src/main/kotlin/team/duckie/app/android/common/android/ui/const/Extras.kt
@@ -27,4 +27,5 @@ object Extras {
     const val RequirementQuestion = "ExtraRequirementQuestion"
     const val RequirementPlaceholder = "ExtraRequirementPlaceholder"
     const val Timer = "ExtraTimer"
+    const val RequirementAnswer = "ExtraRequirementAnswer"
 }

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/DuckieFitImage.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/DuckieFitImage.kt
@@ -43,11 +43,12 @@ private object DuckieFitImageStyle {
 fun DuckieFitImage(
     modifier: Modifier = Modifier,
     imageUrl: String,
+    horizontalPadding: PaddingValues = DuckieFitImageStyle.HorizontalPadding,
 ) = with(DuckieFitImageStyle) {
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .padding(HorizontalPadding)
+            .padding(horizontalPadding)
             .background(
                 color = BackgroundColor,
                 shape = BackgroundShape,

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/BackPressedHeadLineTopAppBar.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/BackPressedHeadLineTopAppBar.kt
@@ -44,7 +44,6 @@ fun BackPressedTopAppBar(
     }
 }
 
-
 @Composable
 fun BackPressedHeadLineTopAppBar(
     title: String,

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/BackPressedHeadLineTopAppBar.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/BackPressedHeadLineTopAppBar.kt
@@ -8,6 +8,7 @@ package team.duckie.app.android.common.compose.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -21,12 +22,9 @@ import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.icon.QuackIcon
 
 @Composable
-fun BackPressedHeadLineTopAppBar(
-    title: String,
-    isLoading: Boolean,
-    trailingIcon: QuackIcon? = null,
-    onTrailingIconClick: (() -> Unit)? = null,
+fun BackPressedTopAppBar(
     onBackPressed: () -> Unit,
+    trailingSlot: @Composable (RowScope.() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier
@@ -42,6 +40,20 @@ fun BackPressedHeadLineTopAppBar(
             src = QuackIcon.ArrowBack,
             onClick = onBackPressed,
         )
+        if (trailingSlot != null) trailingSlot()
+    }
+}
+
+
+@Composable
+fun BackPressedHeadLineTopAppBar(
+    title: String,
+    isLoading: Boolean,
+    trailingIcon: QuackIcon? = null,
+    onTrailingIconClick: (() -> Unit)? = null,
+    onBackPressed: () -> Unit,
+) {
+    BackPressedTopAppBar(onBackPressed = onBackPressed) {
         QuackHeadLine1(
             modifier = Modifier.skeleton(isLoading),
             text = title,
@@ -65,20 +77,7 @@ fun BackPressedHeadLine2TopAppBar(
     isLoading: Boolean = false,
     onBackPressed: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                horizontal = 16.dp,
-                vertical = 12.dp,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        QuackImage(
-            src = QuackIcon.ArrowBack,
-            onClick = onBackPressed,
-        )
+    BackPressedTopAppBar(onBackPressed = onBackPressed) {
         QuackHeadLine2(
             modifier = Modifier.skeleton(isLoading),
             text = title,

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/Dialog.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/Dialog.kt
@@ -9,6 +9,7 @@
 
 package team.duckie.app.android.common.compose.ui.dialog
 
+import android.view.Gravity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,10 +22,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
 import team.duckie.app.android.common.kotlin.runIf
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody2
@@ -37,30 +39,13 @@ enum class DuckieDialogPosition {
     BOTTOM, CENTER, TOP
 }
 
-fun Modifier.duckieDialogPosition(pos: DuckieDialogPosition) = layout { measurable, constraints ->
-
-    val placeable = measurable.measure(constraints)
-    layout(constraints.maxWidth, constraints.maxHeight) {
-        when (pos) {
-            DuckieDialogPosition.BOTTOM -> {
-                placeable.place(0, constraints.maxHeight - placeable.height)
-            }
-
-            DuckieDialogPosition.CENTER -> {
-                placeable.place(
-                    x = 0,
-                    y = Alignment.CenterVertically.align(
-                        size = placeable.height,
-                        space = constraints.maxHeight,
-                    ),
-                )
-            }
-
-            DuckieDialogPosition.TOP -> {
-                placeable.place(0, 0)
-            }
-        }
+private fun DialogWindowProvider.setGravity(position: DuckieDialogPosition) {
+    val gravity = when (position) {
+        DuckieDialogPosition.BOTTOM -> Gravity.BOTTOM
+        DuckieDialogPosition.CENTER -> Gravity.CENTER
+        DuckieDialogPosition.TOP -> Gravity.TOP
     }
+    window.setGravity(gravity)
 }
 
 @Composable
@@ -74,6 +59,7 @@ fun DuckieDialog(
     rightButtonOnClick: (() -> Unit)? = null,
     visible: Boolean,
     onDismissRequest: () -> Unit,
+    dialogPosition: DuckieDialogPosition = DuckieDialogPosition.CENTER,
     properties: DialogProperties = DialogProperties(
         usePlatformDefaultWidth = false,
     ),
@@ -83,6 +69,9 @@ fun DuckieDialog(
             properties = properties,
             onDismissRequest = onDismissRequest,
         ) {
+            val dialogWindowProvider = LocalView.current.parent as DialogWindowProvider
+            dialogWindowProvider.setGravity(position = dialogPosition)
+
             Box(
                 modifier = Modifier
                     .padding(horizontal = 30.dp)

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/Dialog.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/Dialog.kt
@@ -131,17 +131,12 @@ fun DuckieDialog(
                                 modifier = Modifier
                                     .weight(1f)
                                     .quackClickable(
-                                        rippleEnabled = false,
                                         onClick = leftButtonOnClick,
                                     ),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 QuackSubtitle(
                                     modifier = Modifier
-                                        .quackClickable(
-                                            rippleEnabled = false,
-                                            onClick = leftButtonOnClick,
-                                        )
                                         .padding(
                                             vertical = 12.dp,
                                             horizontal = 16.dp,
@@ -157,17 +152,12 @@ fun DuckieDialog(
                                     .weight(1f)
                                     .background(color = QuackColor.DuckieOrange.composeColor)
                                     .quackClickable(
-                                        rippleEnabled = false,
-                                        onClick = leftButtonOnClick,
+                                        onClick = rightButtonOnClick,
                                     ),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 QuackSubtitle(
                                     modifier = Modifier
-                                        .quackClickable(
-                                            rippleEnabled = false,
-                                            onClick = rightButtonOnClick,
-                                        )
                                         .padding(
                                             vertical = 12.dp,
                                             horizontal = 16.dp,

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/IgnoreCheckDialog.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/IgnoreCheckDialog.kt
@@ -21,7 +21,6 @@ fun IgnoreCheckDialog(
     onDismissRequest: () -> Unit,
 ) {
     DuckieDialog(
-        modifier = modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.ignore_check_title, targetName),
         message = stringResource(id = R.string.ignore_check_content, targetName),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/IgnoreCheckDialog.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/IgnoreCheckDialog.kt
@@ -21,6 +21,7 @@ fun IgnoreCheckDialog(
     onDismissRequest: () -> Unit,
 ) {
     DuckieDialog(
+        modifier = modifier,
         title = stringResource(id = R.string.ignore_check_title, targetName),
         message = stringResource(id = R.string.ignore_check_content, targetName),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/ReportDialog.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/ReportDialog.kt
@@ -20,6 +20,7 @@ fun ReportDialog(
     onDismissRequest: () -> Unit,
 ) {
     DuckieDialog(
+        modifier = modifier,
         title = stringResource(id = R.string.report_success),
         rightButtonText = stringResource(id = R.string.check),
         rightButtonOnClick = onClick,

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/ReportDialog.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/dialog/ReportDialog.kt
@@ -20,7 +20,6 @@ fun ReportDialog(
     onDismissRequest: () -> Unit,
 ) {
     DuckieDialog(
-        modifier = modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.report_success),
         rightButtonText = stringResource(id = R.string.check),
         rightButtonOnClick = onClick,

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/PatchQuizBody.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/model/PatchQuizBody.kt
@@ -16,4 +16,6 @@ data class PatchQuizBody(
     val correctProblemCount: Int? = null,
     @JsonProperty("time")
     val time: Int? = null,
+    @JsonProperty("requirementAnswer")
+    val requirementAnswer: String? = null,
 )

--- a/data/src/main/kotlin/team/duckie/app/android/data/quiz/repository/QuizRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/quiz/repository/QuizRepositoryImpl.kt
@@ -29,6 +29,7 @@ class QuizRepositoryImpl @Inject constructor(
         examId: Int,
         correctProblemCount: Int,
         time: Int?,
+        requirementAnswer: String?,
         problemId: Int?,
     ): Boolean {
         return quizDataSource.patchQuiz(
@@ -37,6 +38,7 @@ class QuizRepositoryImpl @Inject constructor(
                 correctProblemCount = correctProblemCount,
                 time = time,
                 problemId = problemId,
+                requirementAnswer = requirementAnswer,
             ),
         )
     }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/repository/QuizRepository.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/repository/QuizRepository.kt
@@ -21,6 +21,7 @@ interface QuizRepository {
         examId: Int,
         correctProblemCount: Int,
         time: Int?,
+        requirementAnswer: String?,
         problemId: Int?,
     ): Boolean
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/SubmitQuizUseCase.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/quiz/usecase/SubmitQuizUseCase.kt
@@ -26,6 +26,7 @@ class SubmitQuizUseCase @Inject constructor(
             correctProblemCount = param.correctProblemCount,
             time = param.time,
             problemId = param.problemId,
+            requirementAnswer = param.requirementAnswer,
         )
     }
 
@@ -34,5 +35,6 @@ class SubmitQuizUseCase @Inject constructor(
         val correctProblemCount: Int,
         val time: Int?,
         val problemId: Int?,
+        val requirementAnswer: String?,
     ) : Parcelable
 }

--- a/feature/create-problem/src/main/kotlin/team/duckie/app/android/feature/create/problem/screen/CreateProblemScreen.kt
+++ b/feature/create-problem/src/main/kotlin/team/duckie/app/android/feature/create/problem/screen/CreateProblemScreen.kt
@@ -66,9 +66,16 @@ import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.common.compose.activityViewModel
+import team.duckie.app.android.common.compose.rememberToast
+import team.duckie.app.android.common.compose.systemBarPaddings
+import team.duckie.app.android.common.compose.ui.PhotoPicker
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
+import team.duckie.app.android.common.kotlin.fastForEach
+import team.duckie.app.android.common.kotlin.fastForEachIndexed
+import team.duckie.app.android.common.kotlin.takeBy
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.Question
-import team.duckie.app.android.common.compose.ui.PhotoPicker
 import team.duckie.app.android.feature.create.problem.R
 import team.duckie.app.android.feature.create.problem.common.CreateProblemBottomLayout
 import team.duckie.app.android.feature.create.problem.common.NoLazyGridItems
@@ -77,15 +84,6 @@ import team.duckie.app.android.feature.create.problem.common.getCreateProblemMea
 import team.duckie.app.android.feature.create.problem.viewmodel.CreateProblemViewModel
 import team.duckie.app.android.feature.create.problem.viewmodel.state.CreateProblemPhotoState
 import team.duckie.app.android.feature.create.problem.viewmodel.state.CreateProblemStep
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
-import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
-import team.duckie.app.android.common.compose.activityViewModel
-import team.duckie.app.android.common.compose.rememberToast
-import team.duckie.app.android.common.compose.systemBarPaddings
-import team.duckie.app.android.common.kotlin.fastForEach
-import team.duckie.app.android.common.kotlin.fastForEachIndexed
-import team.duckie.app.android.common.kotlin.takeBy
 import team.duckie.quackquack.ui.border.QuackBorder
 import team.duckie.quackquack.ui.border.applyAnimatedQuackBorder
 import team.duckie.quackquack.ui.color.QuackColor
@@ -572,7 +570,6 @@ internal fun CreateProblemScreen(
     }
 
     DuckieDialog(
-        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(
             id = R.string.create_problem_delete_dialog_title,
             (deleteDialogNo?.first?.let { "${it + 1}번 문제" } ?: "") +

--- a/feature/create-problem/src/main/kotlin/team/duckie/app/android/feature/create/problem/screen/ExamInformationScreen.kt
+++ b/feature/create-problem/src/main/kotlin/team/duckie/app/android/feature/create/problem/screen/ExamInformationScreen.kt
@@ -41,6 +41,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.common.compose.activityViewModel
+import team.duckie.app.android.common.compose.ui.DuckieGridLayout
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
+import team.duckie.app.android.common.kotlin.takeBy
 import team.duckie.app.android.feature.create.problem.R
 import team.duckie.app.android.feature.create.problem.common.CreateProblemBottomLayout
 import team.duckie.app.android.feature.create.problem.common.ImeActionNext
@@ -49,12 +53,6 @@ import team.duckie.app.android.feature.create.problem.common.TitleAndComponent
 import team.duckie.app.android.feature.create.problem.common.getCreateProblemMeasurePolicy
 import team.duckie.app.android.feature.create.problem.common.moveDownFocus
 import team.duckie.app.android.feature.create.problem.viewmodel.CreateProblemViewModel
-import team.duckie.app.android.common.compose.ui.DuckieGridLayout
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
-import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
-import team.duckie.app.android.common.compose.activityViewModel
-import team.duckie.app.android.common.kotlin.takeBy
 import team.duckie.quackquack.ui.animation.QuackAnimatedVisibility
 import team.duckie.quackquack.ui.border.QuackBorder
 import team.duckie.quackquack.ui.color.QuackColor
@@ -264,7 +262,6 @@ internal fun ExamInformationScreen(
     )
 
     DuckieDialog(
-        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.create_problem_exit_dialog_title),
         message = stringResource(id = R.string.create_problem_exit_dialog_message),
         visible = createProblemExitDialogVisible,

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
         projects.common.android,
         projects.common.kotlin,
         projects.common.compose,
-        projects.feature.startExam,
         libs.orbit.viewmodel,
         libs.orbit.compose,
         libs.ktx.lifecycle.runtime,

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/DetailActivity.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/DetailActivity.kt
@@ -20,15 +20,14 @@ import team.duckie.app.android.common.android.exception.handling.reporter.report
 import team.duckie.app.android.common.android.exception.handling.reporter.reportToToast
 import team.duckie.app.android.common.android.ui.BaseActivity
 import team.duckie.app.android.common.android.ui.const.Extras
-import team.duckie.app.android.common.android.ui.startActivityWithAnimation
 import team.duckie.app.android.common.compose.ToastWrapper
 import team.duckie.app.android.common.kotlin.exception.DuckieResponseException
 import team.duckie.app.android.feature.detail.screen.DetailScreen
 import team.duckie.app.android.feature.detail.viewmodel.DetailViewModel
 import team.duckie.app.android.feature.detail.viewmodel.sideeffect.DetailSideEffect
-import team.duckie.app.android.feature.start.exam.screen.StartExamActivity
 import team.duckie.app.android.navigator.feature.profile.ProfileNavigator
 import team.duckie.app.android.navigator.feature.search.SearchNavigator
+import team.duckie.app.android.navigator.feature.startexam.StartExamNavigator
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
@@ -43,6 +42,9 @@ class DetailActivity : BaseActivity() {
 
     @Inject
     lateinit var profileNavigator: ProfileNavigator
+
+    @Inject
+    lateinit var startExamNavigator: StartExamNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -84,7 +86,8 @@ class DetailActivity : BaseActivity() {
                 )
             }
 
-            is DetailSideEffect.StartExam -> startActivityWithAnimation<StartExamActivity>(
+            is DetailSideEffect.StartExam -> startExamNavigator.navigateFrom(
+                activity = this,
                 intentBuilder = {
                     putExtra(Extras.ExamId, sideEffect.examId)
                     putExtra(Extras.CertifyingStatement, sideEffect.certifyingStatement)
@@ -102,7 +105,8 @@ class DetailActivity : BaseActivity() {
             }
 
             is DetailSideEffect.SendToast -> ToastWrapper(this).invoke(sideEffect.message)
-            is DetailSideEffect.StartQuiz -> startActivityWithAnimation<StartExamActivity>(
+            is DetailSideEffect.StartQuiz -> startExamNavigator.navigateFrom(
+                activity = this,
                 intentBuilder = {
                     putExtra(Extras.ExamId, sideEffect.examId)
                     putExtra(Extras.Timer, sideEffect.timer)

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
@@ -156,10 +156,8 @@ private fun RankingContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                user.duckPower?.tier?.let {
-                    QuackBody2(text = it)
-                    QuackBody2(text = "|")
-                }
+                QuackBody2(text = "${correctProblemCount}덕")
+                QuackBody2(text = "|")
                 QuackBody2(text = "${time}초")
             }
         }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/viewmodel/DetailViewModel.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/viewmodel/DetailViewModel.kt
@@ -17,6 +17,11 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.common.android.ui.const.Extras
+import team.duckie.app.android.common.compose.ui.dialog.ReportAlreadyExists
+import team.duckie.app.android.common.kotlin.exception.DuckieResponseFieldNPE
+import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
+import team.duckie.app.android.common.kotlin.exception.isReportAlreadyExists
 import team.duckie.app.android.domain.exam.model.ExamInstanceBody
 import team.duckie.app.android.domain.exam.repository.ExamRepository
 import team.duckie.app.android.domain.examInstance.usecase.MakeExamInstanceUseCase
@@ -29,11 +34,6 @@ import team.duckie.app.android.domain.report.usecase.ReportUseCase
 import team.duckie.app.android.domain.user.usecase.GetMeUseCase
 import team.duckie.app.android.feature.detail.viewmodel.sideeffect.DetailSideEffect
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.compose.ui.dialog.ReportAlreadyExists
-import team.duckie.app.android.common.kotlin.exception.DuckieResponseFieldNPE
-import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
-import team.duckie.app.android.common.kotlin.exception.isReportAlreadyExists
-import team.duckie.app.android.common.android.ui.const.Extras
 import javax.inject.Inject
 
 @HiltViewModel

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/common/ResultBottomBar.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/common/ResultBottomBar.kt
@@ -28,6 +28,7 @@ import team.duckie.quackquack.ui.component.QuackSurface
 
 @Composable
 internal fun ResultBottomBar(
+    isQuiz: Boolean,
     onClickRetryButton: () -> Unit,
     onClickExitButton: () -> Unit,
 ) {
@@ -41,13 +42,15 @@ internal fun ResultBottomBar(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
     ) {
-        GrayBorderSmallButton(
-            modifier = Modifier
-                .heightIn(min = 44.dp)
-                .weight(1f),
-            text = stringResource(id = R.string.exam_result_solve_retry),
-            onClick = onClickRetryButton,
-        )
+        if(isQuiz){
+            GrayBorderSmallButton(
+                modifier = Modifier
+                    .heightIn(min = 44.dp)
+                    .weight(1f),
+                text = stringResource(id = R.string.exam_result_solve_retry),
+                onClick = onClickRetryButton,
+            )
+        }
         QuackSmallButton(
             modifier = Modifier
                 .heightIn(44.dp)

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/common/ResultBottomBar.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/common/ResultBottomBar.kt
@@ -42,7 +42,7 @@ internal fun ResultBottomBar(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
     ) {
-        if(isQuiz){
+        if (isQuiz) {
             GrayBorderSmallButton(
                 modifier = Modifier
                     .heightIn(min = 44.dp)

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -54,7 +54,7 @@ internal fun ExamResultScreen(
                 modifier = Modifier
                     .padding(vertical = 12.dp)
                     .padding(horizontal = 16.dp),
-                leadingIcon = QuackIcon.Close,
+                leadingIcon = QuackIcon.ArrowBack,
                 onLeadingIconClick = viewModel::exitExam,
             )
         },

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -16,14 +16,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.common.compose.activityViewModel
 import team.duckie.app.android.common.compose.ui.ErrorScreen
 import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
-import team.duckie.app.android.feature.exam.result.ExamResultActivity
 import team.duckie.app.android.feature.exam.result.R
 import team.duckie.app.android.feature.exam.result.common.LoadingIndicator
 import team.duckie.app.android.feature.exam.result.common.ResultBottomBar
@@ -92,7 +90,7 @@ internal fun ExamResultScreen(
                                 message = if (isPerfectScore) {
                                     stringResource(
                                         id = R.string.exam_result_correct_problem_all,
-                                        mainTag
+                                        mainTag,
                                     )
                                 } else {
                                     wrongAnswerMessage

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -39,7 +39,6 @@ internal fun ExamResultScreen(
     viewModel: ExamResultViewModel = activityViewModel(),
 ) {
     val state by viewModel.container.stateFlow.collectAsStateWithLifecycle()
-    val activity = LocalContext.current as ExamResultActivity
 
     LaunchedEffect(Unit) {
         viewModel.initState()
@@ -59,7 +58,7 @@ internal fun ExamResultScreen(
             )
         },
         bottomBar = {
-            if((state is ExamResultState.Loading).not()){
+            if ((state is ExamResultState.Loading).not()) {
                 ResultBottomBar(
                     isQuiz = state.isQuiz(),
                     onClickRetryButton = {

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -52,7 +52,7 @@ internal fun ExamResultScreen(
         topBar = {
             QuackTopAppBar(
                 modifier = Modifier
-                    .padding(vertical = 12.dp)
+                    .padding(vertical = 8.dp)
                     .padding(horizontal = 16.dp),
                 leadingIcon = QuackIcon.ArrowBack,
                 onLeadingIconClick = viewModel::exitExam,

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/ExamResultScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.duckie.app.android.common.compose.activityViewModel
+import team.duckie.app.android.common.compose.ui.ErrorScreen
+import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
 import team.duckie.app.android.feature.exam.result.ExamResultActivity
 import team.duckie.app.android.feature.exam.result.R
 import team.duckie.app.android.feature.exam.result.common.LoadingIndicator
@@ -28,9 +31,6 @@ import team.duckie.app.android.feature.exam.result.screen.exam.ExamResultContent
 import team.duckie.app.android.feature.exam.result.screen.quiz.QuizResultContent
 import team.duckie.app.android.feature.exam.result.viewmodel.ExamResultState
 import team.duckie.app.android.feature.exam.result.viewmodel.ExamResultViewModel
-import team.duckie.app.android.common.compose.ui.ErrorScreen
-import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
-import team.duckie.app.android.common.compose.activityViewModel
 import team.duckie.quackquack.ui.component.QuackTopAppBar
 import team.duckie.quackquack.ui.icon.QuackIcon
 
@@ -59,12 +59,15 @@ internal fun ExamResultScreen(
             )
         },
         bottomBar = {
-            ResultBottomBar(
-                onClickRetryButton = {
-                    viewModel.clickRetry(activity.getString(R.string.exam_result_feature_prepare))
-                },
-                onClickExitButton = viewModel::exitExam,
-            )
+            if((state is ExamResultState.Loading).not()){
+                ResultBottomBar(
+                    isQuiz = state.isQuiz(),
+                    onClickRetryButton = {
+                        viewModel.clickRetry()
+                    },
+                    onClickExitButton = viewModel::exitExam,
+                )
+            }
         },
     ) { padding ->
         QuackCrossfade(
@@ -88,7 +91,10 @@ internal fun ExamResultScreen(
                                 mainTag = mainTag,
                                 ranking = ranking,
                                 message = if (isPerfectScore) {
-                                    stringResource(id = R.string.exam_result_correct_problem_all, mainTag)
+                                    stringResource(
+                                        id = R.string.exam_result_correct_problem_all,
+                                        mainTag
+                                    )
                                 } else {
                                     wrongAnswerMessage
                                 },
@@ -112,3 +118,5 @@ internal fun ExamResultScreen(
         }
     }
 }
+
+private fun ExamResultState.isQuiz() = this is ExamResultState.Success && this.isQuiz

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/exam/ExamResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/exam/ExamResultContent.kt
@@ -7,28 +7,19 @@
 
 package team.duckie.app.android.feature.exam.result.screen.exam
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import team.duckie.quackquack.ui.component.QuackImage
+import androidx.compose.ui.layout.ContentScale
+import team.duckie.quackquack.ui.QuackImage
 
 @Composable
 internal fun ExamResultContent(
     resultImageUrl: String,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(all = 16.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        QuackImage(
-            modifier = Modifier.fillMaxSize(),
-            src = resultImageUrl,
-        )
-    }
+    QuackImage(
+        modifier = Modifier.fillMaxSize(),
+        src = resultImageUrl,
+        contentScale = ContentScale.FillBounds,
+    )
 }

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -46,7 +46,8 @@ internal fun QuizResultContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(all = 16.dp),
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 16.dp),
     ) {
         DuckieFitImage(imageUrl = resultImageUrl)
         Spacer(space = 16.dp)

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -9,6 +9,7 @@ package team.duckie.app.android.feature.exam.result.screen.quiz
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -49,7 +50,10 @@ internal fun QuizResultContent(
             .padding(horizontal = 16.dp)
             .padding(bottom = 16.dp),
     ) {
-        DuckieFitImage(imageUrl = resultImageUrl)
+        DuckieFitImage(
+            imageUrl = resultImageUrl,
+            horizontalPadding = PaddingValues(horizontal = 0.dp),
+        )
         Spacer(space = 16.dp)
         // TODO(EvergreenTree97) : 에러 문구 폰트 변경 필요
         Row(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/screen/quiz/QuizResultContent.kt
@@ -8,6 +8,7 @@
 package team.duckie.app.android.feature.exam.result.screen.quiz
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -31,8 +32,8 @@ import team.duckie.app.android.feature.exam.result.R
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody1
 import team.duckie.quackquack.ui.component.QuackDivider
-import team.duckie.quackquack.ui.component.QuackHeadLine1
 import team.duckie.quackquack.ui.component.internal.QuackText
+import team.duckie.quackquack.ui.sugar.QuackHeadLine1
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 @Composable
@@ -60,10 +61,15 @@ internal fun QuizResultContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 30.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             QuackHeadLine1(text = "\"")
-            QuackHeadLine1(text = message)
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.Center,
+            ) {
+                QuackHeadLine1(text = message)
+            }
             QuackHeadLine1(text = "\"")
         }
         Spacer(space = 28.dp)

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultSideEffect.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultSideEffect.kt
@@ -9,6 +9,13 @@ package team.duckie.app.android.feature.exam.result.viewmodel
 
 sealed class ExamResultSideEffect {
     object FinishExamResult : ExamResultSideEffect()
-    data class SendToast(val message: String) : ExamResultSideEffect()
-    data class ReportError(val exception: Throwable) : ExamResultSideEffect()
+
+    class NavigateToStartExam(
+        val examId: Int,
+        val requirementQuestion: String,
+        val requirementPlaceholder: String,
+        val timer: Int,
+    ) : ExamResultSideEffect()
+
+    class ReportError(val exception: Throwable) : ExamResultSideEffect()
 }

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultState.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultState.kt
@@ -12,6 +12,7 @@ sealed class ExamResultState {
 
     data class Success(
         val reportUrl: String = "",
+        val examId: Int = 0,
         val isQuiz: Boolean = true,
         val correctProblemCount: Int = 0,
         val time: Int = 0,
@@ -19,6 +20,9 @@ sealed class ExamResultState {
         val ranking: Int = 0,
         val wrongAnswerMessage: String = "",
         val isPerfectScore: Boolean = false,
+        val requirementQuestion: String = "",
+        val requirementPlaceholder: String = "",
+        val timer: Int = 0,
     ) : ExamResultState()
 
     data class Error(

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
@@ -140,7 +140,7 @@ class ExamResultViewModel @Inject constructor(
                 requirementQuestion = state.requirementQuestion,
                 requirementPlaceholder = state.requirementPlaceholder,
                 timer = state.timer,
-            )
+            ),
         )
     }
 

--- a/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
+++ b/feature/exam-result/src/main/java/team/duckie/app/android/feature/exam/result/viewmodel/ExamResultViewModel.kt
@@ -103,19 +103,25 @@ class ExamResultViewModel @Inject constructor(
         getQuizUseCase(examId).onSuccess { quizResult ->
             val isPerfectScore = quizResult.wrongProblem == null
             reduce {
-                ExamResultState.Success(
-                    reportUrl = if (isPerfectScore) {
-                        quizResult.exam.perfectScoreImageUrl ?: ""
-                    } else {
-                        quizResult.wrongProblem?.solution?.solutionImageUrl ?: ""
-                    },
-                    isQuiz = true,
-                    correctProblemCount = quizResult.correctProblemCount,
-                    time = quizResult.time,
-                    mainTag = quizResult.exam.mainTag?.name ?: "",
-                    ranking = quizResult.ranking ?: 0,
-                    wrongAnswerMessage = quizResult.wrongProblem?.solution?.wrongAnswerMessage ?: "",
-                )
+                with(quizResult) {
+                    ExamResultState.Success(
+                        examId = id,
+                        reportUrl = if (isPerfectScore) {
+                            exam.perfectScoreImageUrl ?: ""
+                        } else {
+                            wrongProblem?.solution?.solutionImageUrl ?: ""
+                        },
+                        isQuiz = true,
+                        correctProblemCount = correctProblemCount,
+                        time = time,
+                        mainTag = exam.mainTag?.name ?: "",
+                        ranking = ranking ?: 0,
+                        wrongAnswerMessage = wrongProblem?.solution?.wrongAnswerMessage ?: "",
+                        requirementPlaceholder = exam.requirementPlaceholder ?: "",
+                        requirementQuestion = exam.requirementQuestion ?: "",
+                        timer = exam.timer ?: 0,
+                    )
+                }
             }
         }.onFailure {
             it.printStackTrace()
@@ -126,8 +132,16 @@ class ExamResultViewModel @Inject constructor(
         }
     }
 
-    fun clickRetry(message: String) = intent {
-        postSideEffect(ExamResultSideEffect.SendToast(message))
+    fun clickRetry() = intent {
+        val state = state as ExamResultState.Success
+        postSideEffect(
+            ExamResultSideEffect.NavigateToStartExam(
+                examId = state.examId,
+                requirementQuestion = state.requirementQuestion,
+                requirementPlaceholder = state.requirementPlaceholder,
+                timer = state.timer,
+            )
+        )
     }
 
     fun exitExam() = intent {

--- a/feature/exam-result/src/main/res/values/strings.xml
+++ b/feature/exam-result/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
 <resources>
     <string name="exam_result_solve_retry">다시 풀기</string>
     <string name="exam_result_exit_exam">시험 끝내기</string>
-    <string name="exam_result_feature_prepare">준비 중인 기능입니다.</string>
     <string name="exam_result_total_time">총 응시시간</string>
     <string name="exam_result_correct_problem">맞은 문제</string>
     <string name="exam_result_correct_problem_unit">%s덕</string>

--- a/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingActivity.kt
+++ b/feature/setting/src/main/kotlin/team/duckie/app/android/feature/setting/screen/SettingActivity.kt
@@ -31,20 +31,18 @@ import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.common.android.ui.BaseActivity
 import team.duckie.app.android.common.android.ui.finishWithAnimation
 import team.duckie.app.android.common.android.ui.startActivityWithAnimation
+import team.duckie.app.android.common.compose.ToastWrapper
 import team.duckie.app.android.common.compose.systemBarPaddings
 import team.duckie.app.android.common.compose.ui.DuckieTodoScreen
 import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
-import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
 import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
 import team.duckie.app.android.feature.setting.BuildConfig
 import team.duckie.app.android.feature.setting.R
 import team.duckie.app.android.feature.setting.constans.SettingType
 import team.duckie.app.android.feature.setting.viewmodel.SettingViewModel
 import team.duckie.app.android.feature.setting.viewmodel.sideeffect.SettingSideEffect
-import team.duckie.app.android.navigator.feature.intro.IntroNavigator
-import team.duckie.app.android.common.compose.ToastWrapper
 import team.duckie.app.android.feature.setting.viewmodel.state.SettingState
+import team.duckie.app.android.navigator.feature.intro.IntroNavigator
 import team.duckie.quackquack.material.QuackColor
 import team.duckie.quackquack.material.theme.QuackTheme
 import team.duckie.quackquack.ui.component.QuackTopAppBar
@@ -149,7 +147,6 @@ class SettingActivity : BaseActivity() {
     ) {
         // 로그아웃 확인 목적의 Dialog
         DuckieDialog(
-            modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
             title = stringResource(id = R.string.log_out_check_message),
             leftButtonText = stringResource(id = R.string.cancel),
             leftButtonOnClick = {
@@ -167,7 +164,6 @@ class SettingActivity : BaseActivity() {
 
         // 회원탈퇴 확인 목적의 Dialog
         DuckieDialog(
-            modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
             title = stringResource(id = R.string.withdraw_check_message),
             leftButtonText = stringResource(id = R.string.withdraw_cancel_msg),
             leftButtonOnClick = {

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/SolveProblemActivity.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/SolveProblemActivity.kt
@@ -29,6 +29,12 @@ import com.google.firebase.crashlytics.ktx.crashlytics
 import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.AndroidEntryPoint
 import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.common.android.ui.BaseActivity
+import team.duckie.app.android.common.android.ui.const.Extras
+import team.duckie.app.android.common.android.ui.finishWithAnimation
+import team.duckie.app.android.common.compose.moveNextPage
+import team.duckie.app.android.common.compose.ui.ErrorScreen
+import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
 import team.duckie.app.android.domain.quiz.usecase.SubmitQuizUseCase
 import team.duckie.app.android.feature.solve.problem.common.LoadingIndicator
 import team.duckie.app.android.feature.solve.problem.screen.QuizScreen
@@ -37,12 +43,6 @@ import team.duckie.app.android.feature.solve.problem.viewmodel.SolveProblemViewM
 import team.duckie.app.android.feature.solve.problem.viewmodel.SolveProblemViewModel.Companion.TimerCount
 import team.duckie.app.android.feature.solve.problem.viewmodel.sideeffect.SolveProblemSideEffect
 import team.duckie.app.android.navigator.feature.examresult.ExamResultNavigator
-import team.duckie.app.android.common.compose.ui.ErrorScreen
-import team.duckie.app.android.common.compose.ui.quack.QuackCrossfade
-import team.duckie.app.android.common.compose.moveNextPage
-import team.duckie.app.android.common.android.ui.BaseActivity
-import team.duckie.app.android.common.android.ui.const.Extras
-import team.duckie.app.android.common.android.ui.finishWithAnimation
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
@@ -158,6 +158,7 @@ class SolveProblemActivity : BaseActivity() {
                                 correctProblemCount = sideEffect.correctProblemCount,
                                 time = sideEffect.time,
                                 problemId = sideEffect.problemId,
+                                requirementAnswer = sideEffect.requirementAnswer,
                             ),
                         )
                         putExtra(Extras.IsQuiz, true)

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
@@ -43,8 +43,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import team.duckie.app.android.common.compose.isCurrentPage
 import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
-import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
 import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.Problem.Companion.isSubjective
@@ -99,7 +97,6 @@ internal fun QuizScreen(
     }
 
     DuckieDialog(
-        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.quit_exam),
         message = stringResource(id = R.string.not_saved),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
@@ -41,20 +41,21 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
+import team.duckie.app.android.common.compose.isCurrentPage
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
+import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
+import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.Problem.Companion.isSubjective
 import team.duckie.app.android.feature.solve.problem.R
 import team.duckie.app.android.feature.solve.problem.answer.answerSection
 import team.duckie.app.android.feature.solve.problem.common.ButtonBottomBar
+import team.duckie.app.android.feature.solve.problem.common.FlexibleSubjectiveQuestionSection
 import team.duckie.app.android.feature.solve.problem.common.TimerTopBar
 import team.duckie.app.android.feature.solve.problem.question.questionSection
 import team.duckie.app.android.feature.solve.problem.viewmodel.state.InputAnswer
 import team.duckie.app.android.feature.solve.problem.viewmodel.state.SolveProblemState
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.isCurrentPage
-import team.duckie.app.android.common.compose.ui.Spacer
-import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
-import team.duckie.app.android.feature.solve.problem.common.FlexibleSubjectiveQuestionSection
 
 private const val QuizTopAppBarLayoutId = "QuizTopAppBar"
 private const val QuizContentLayoutId = "QuizContent"
@@ -98,6 +99,7 @@ internal fun QuizScreen(
     }
 
     DuckieDialog(
+        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.quit_exam),
         message = stringResource(id = R.string.not_saved),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -111,6 +111,7 @@ internal fun SolveProblemScreen(
                 modifier = Modifier
                     .layoutId(SolveProblemTopAppBarLayoutId)
                     .padding(vertical = 12.dp)
+                    .padding(start = 12.dp)
                     .padding(end = 16.dp),
                 onCloseClick = {
                     examExitDialogVisible = true

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -36,21 +36,23 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import team.duckie.app.android.common.compose.isCurrentPage
+import team.duckie.app.android.common.compose.moveNextPage
+import team.duckie.app.android.common.compose.movePrevPage
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
+import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
+import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
+import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.Problem.Companion.isSubjective
 import team.duckie.app.android.feature.solve.problem.R
 import team.duckie.app.android.feature.solve.problem.answer.answerSection
 import team.duckie.app.android.feature.solve.problem.common.CloseAndPageTopBar
 import team.duckie.app.android.feature.solve.problem.common.DoubleButtonBottomBar
+import team.duckie.app.android.feature.solve.problem.common.FlexibleSubjectiveQuestionSection
 import team.duckie.app.android.feature.solve.problem.question.questionSection
 import team.duckie.app.android.feature.solve.problem.viewmodel.state.InputAnswer
 import team.duckie.app.android.feature.solve.problem.viewmodel.state.SolveProblemState
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.isCurrentPage
-import team.duckie.app.android.common.compose.moveNextPage
-import team.duckie.app.android.common.compose.movePrevPage
-import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
-import team.duckie.app.android.feature.solve.problem.common.FlexibleSubjectiveQuestionSection
 
 private const val SolveProblemTopAppBarLayoutId = "SolveProblemTopAppBar"
 private const val SolveProblemContentLayoutId = "SolveProblemContent"
@@ -81,6 +83,7 @@ internal fun SolveProblemScreen(
 
     // 시험 종료 다이얼로그
     DuckieDialog(
+        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.quit_exam),
         message = stringResource(id = R.string.not_saved),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -96,6 +96,7 @@ internal fun SolveProblemScreen(
 
     // 답안 제출 다이얼로그
     DuckieDialog(
+        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.submit_answer),
         message = stringResource(id = R.string.submit_answer_warning),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -40,8 +40,6 @@ import team.duckie.app.android.common.compose.isCurrentPage
 import team.duckie.app.android.common.compose.moveNextPage
 import team.duckie.app.android.common.compose.movePrevPage
 import team.duckie.app.android.common.compose.ui.dialog.DuckieDialog
-import team.duckie.app.android.common.compose.ui.dialog.DuckieDialogPosition
-import team.duckie.app.android.common.compose.ui.dialog.duckieDialogPosition
 import team.duckie.app.android.common.kotlin.exception.duckieResponseFieldNpe
 import team.duckie.app.android.domain.exam.model.Answer
 import team.duckie.app.android.domain.exam.model.Problem.Companion.isSubjective
@@ -83,7 +81,6 @@ internal fun SolveProblemScreen(
 
     // 시험 종료 다이얼로그
     DuckieDialog(
-        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.quit_exam),
         message = stringResource(id = R.string.not_saved),
         leftButtonText = stringResource(id = R.string.cancel),
@@ -96,7 +93,6 @@ internal fun SolveProblemScreen(
 
     // 답안 제출 다이얼로그
     DuckieDialog(
-        modifier = Modifier.duckieDialogPosition(DuckieDialogPosition.CENTER),
         title = stringResource(id = R.string.submit_answer),
         message = stringResource(id = R.string.submit_answer_warning),
         leftButtonText = stringResource(id = R.string.cancel),

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/SolveProblemViewModel.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.Container
@@ -20,17 +19,17 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.common.android.savedstate.getOrThrow
+import team.duckie.app.android.common.android.timer.ProblemTimer
+import team.duckie.app.android.common.android.ui.const.Extras
+import team.duckie.app.android.common.kotlin.ImmutableList
+import team.duckie.app.android.common.kotlin.exception.DuckieClientLogicProblemException
+import team.duckie.app.android.common.kotlin.seconds
 import team.duckie.app.android.domain.examInstance.usecase.GetExamInstanceUseCase
 import team.duckie.app.android.domain.quiz.usecase.GetQuizUseCase
 import team.duckie.app.android.feature.solve.problem.viewmodel.sideeffect.SolveProblemSideEffect
 import team.duckie.app.android.feature.solve.problem.viewmodel.state.InputAnswer
 import team.duckie.app.android.feature.solve.problem.viewmodel.state.SolveProblemState
-import team.duckie.app.android.common.android.savedstate.getOrThrow
-import team.duckie.app.android.common.android.timer.ProblemTimer
-import team.duckie.app.android.common.kotlin.ImmutableList
-import team.duckie.app.android.common.kotlin.exception.DuckieClientLogicProblemException
-import team.duckie.app.android.common.kotlin.seconds
-import team.duckie.app.android.common.android.ui.const.Extras
 import javax.inject.Inject
 
 @HiltViewModel
@@ -80,6 +79,10 @@ internal class SolveProblemViewModel @Inject constructor(
             )
         }
         if (isQuiz) {
+            val requirementAnswer = savedStateHandle.getOrThrow<String>(Extras.RequirementAnswer)
+            reduce {
+                state.copy(requirementAnswer = requirementAnswer)
+            }
             getQuizs(examId)
         } else {
             getExams(examId)
@@ -183,6 +186,7 @@ internal class SolveProblemViewModel @Inject constructor(
                 } else {
                     state.quizProblems[index].id
                 },
+                requirementAnswer = state.requirementAnswer,
             ),
         )
     }

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/sideeffect/SolveProblemSideEffect.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/sideeffect/SolveProblemSideEffect.kt
@@ -18,6 +18,7 @@ internal sealed class SolveProblemSideEffect {
         val correctProblemCount: Int,
         val time: Int,
         val problemId: Int?,
+        val requirementAnswer: String,
     ) : SolveProblemSideEffect()
 
     class ReportError(val exception: Throwable) : SolveProblemSideEffect()

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/state/SolveProblemState.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/viewmodel/state/SolveProblemState.kt
@@ -21,6 +21,7 @@ data class SolveProblemState(
     val problems: ImmutableList<ProblemInstance> = persistentListOf(),
     val quizProblems: ImmutableList<Problem> = persistentListOf(),
     val inputAnswers: ImmutableList<InputAnswer> = persistentListOf(),
+    val requirementAnswer: String = "",
     val totalPage: Int = 0,
 )
 

--- a/feature/start-exam/src/main/AndroidManifest.xml
+++ b/feature/start-exam/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Designed and developed by Duckie Team, 2022
   ~
   ~ Licensed under the MIT.
@@ -11,7 +10,8 @@
     <application>
         <activity
             android:name=".screen.StartExamActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
     </application>
 
 </manifest>

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/navigator/impl/StartExamNavigatorImpl.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/navigator/impl/StartExamNavigatorImpl.kt
@@ -1,0 +1,28 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.start.exam.navigator.impl
+
+import android.app.Activity
+import android.content.Intent
+import team.duckie.app.android.common.android.ui.startActivityWithAnimation
+import team.duckie.app.android.feature.start.exam.screen.StartExamActivity
+import team.duckie.app.android.navigator.feature.startexam.StartExamNavigator
+import javax.inject.Inject
+
+internal class StartExamNavigatorImpl @Inject constructor() : StartExamNavigator {
+    override fun navigateFrom(
+        activity: Activity,
+        intentBuilder: Intent.() -> Intent,
+        withFinish: Boolean,
+    ) {
+        activity.startActivityWithAnimation<StartExamActivity>(
+            intentBuilder = intentBuilder,
+            withFinish = withFinish,
+        )
+    }
+}

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/navigator/module/StartExamNavigatorModule.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/navigator/module/StartExamNavigatorModule.kt
@@ -15,7 +15,6 @@ import team.duckie.app.android.feature.start.exam.navigator.impl.StartExamNaviga
 import team.duckie.app.android.navigator.feature.startexam.StartExamNavigator
 import javax.inject.Singleton
 
-
 @Module
 @InstallIn(SingletonComponent::class)
 internal abstract class StartExamNavigatorModule {

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/navigator/module/StartExamNavigatorModule.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/navigator/module/StartExamNavigatorModule.kt
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.feature.start.exam.navigator.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import team.duckie.app.android.feature.start.exam.navigator.impl.StartExamNavigatorImpl
+import team.duckie.app.android.navigator.feature.startexam.StartExamNavigator
+import javax.inject.Singleton
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class StartExamNavigatorModule {
+
+    @Singleton
+    @Binds
+    abstract fun bindStartExamNavigator(navigator: StartExamNavigatorImpl): StartExamNavigator
+}

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/StartExamActivity.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/StartExamActivity.kt
@@ -18,12 +18,12 @@ import com.google.firebase.crashlytics.ktx.crashlytics
 import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.AndroidEntryPoint
 import org.orbitmvi.orbit.viewmodel.observe
-import team.duckie.app.android.feature.start.exam.viewmodel.StartExamSideEffect
-import team.duckie.app.android.feature.start.exam.viewmodel.StartExamViewModel
-import team.duckie.app.android.navigator.feature.solveproblem.SolveProblemNavigator
 import team.duckie.app.android.common.android.ui.BaseActivity
 import team.duckie.app.android.common.android.ui.const.Extras
 import team.duckie.app.android.common.android.ui.finishWithAnimation
+import team.duckie.app.android.feature.start.exam.viewmodel.StartExamSideEffect
+import team.duckie.app.android.feature.start.exam.viewmodel.StartExamViewModel
+import team.duckie.app.android.navigator.feature.solveproblem.SolveProblemNavigator
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.theme.QuackTheme
 import javax.inject.Inject
@@ -64,6 +64,7 @@ class StartExamActivity : BaseActivity() {
                         intentBuilder = {
                             putExtra(Extras.ExamId, sideEffect.examId)
                             putExtra(Extras.IsQuiz, sideEffect.isQuiz)
+                            putExtra(Extras.RequirementAnswer, sideEffect.requirementAnswer)
                         },
                         withFinish = true,
                     )

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
@@ -24,19 +24,17 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.duckie.app.android.common.compose.ui.BackPressedTopAppBar
+import team.duckie.app.android.common.compose.ui.ImeSpacer
 import team.duckie.app.android.feature.start.exam.R
 import team.duckie.app.android.feature.start.exam.screen.StartExamScreen
 import team.duckie.app.android.feature.start.exam.viewmodel.StartExamState
 import team.duckie.app.android.feature.start.exam.viewmodel.StartExamViewModel
-import team.duckie.app.android.common.compose.ui.ImeSpacer
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackGrayscaleTextField
 import team.duckie.quackquack.ui.component.QuackHeadLine1
 import team.duckie.quackquack.ui.component.QuackLargeButton
 import team.duckie.quackquack.ui.component.QuackLargeButtonType
-import team.duckie.quackquack.ui.component.QuackTopAppBar
 import team.duckie.quackquack.ui.component.internal.QuackText
-import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 /**

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/exam/StartExamInputScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.duckie.app.android.common.compose.ui.BackPressedTopAppBar
 import team.duckie.app.android.feature.start.exam.R
 import team.duckie.app.android.feature.start.exam.screen.StartExamScreen
 import team.duckie.app.android.feature.start.exam.viewmodel.StartExamState
@@ -56,10 +57,7 @@ internal fun StartExamInputScreen(modifier: Modifier, viewModel: StartExamViewMo
 
     Column(modifier = modifier) {
         // 상단 탭바
-        QuackTopAppBar(
-            leadingIcon = QuackIcon.ArrowBack,
-            onLeadingIconClick = viewModel::finishStartExam,
-        )
+        BackPressedTopAppBar(onBackPressed = viewModel::finishStartExam)
 
         // 제목
         QuackHeadLine1(

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -93,7 +93,7 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
                 horizontal = 16.dp,
             ),
             type = QuackLargeButtonType.Fill,
-            text = stringResource(id = R.string.start_exam_start_button),
+            text = stringResource(id = R.string.start_exam_quiz_start_button),
             enabled = certifyingStatementText.isNotEmpty(),
             onClick = viewModel::startSolveProblem,
         )

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -61,10 +61,13 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),
         ) {
+            Spacer(space = 12.dp)
             InfoBox(
                 modifier = Modifier
-                    .padding(top = 12.dp)
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(color = QuackColor.Gray4.composeColor)
+                    .padding(all = 12.dp),
                 limitTime = state.timer,
             )
             QuackTitle2(
@@ -99,15 +102,12 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
 }
 
 @Composable
-internal fun InfoBox(
+private fun InfoBox(
     modifier: Modifier = Modifier,
     limitTime: Int,
 ) {
     Column(
-        modifier = modifier
-            .background(color = QuackColor.Gray4.composeColor)
-            .padding(all = 12.dp)
-            .clip(RoundedCornerShape(8.dp)),
+        modifier = modifier,
         verticalArrangement = Arrangement.Center,
     ) {
         QuackTitle2(text = stringResource(id = R.string.start_exam_information_before_quiz_title))

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/screen/quiz/StartQuizInputScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.duckie.app.android.common.compose.ui.BackPressedTopAppBar
 import team.duckie.app.android.common.compose.ui.ImeSpacer
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.feature.start.exam.R
@@ -37,9 +38,7 @@ import team.duckie.quackquack.ui.component.QuackHeadLine1
 import team.duckie.quackquack.ui.component.QuackLargeButton
 import team.duckie.quackquack.ui.component.QuackLargeButtonType
 import team.duckie.quackquack.ui.component.QuackTitle2
-import team.duckie.quackquack.ui.component.QuackTopAppBar
 import team.duckie.quackquack.ui.component.internal.QuackText
-import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 @Composable
@@ -52,10 +51,7 @@ internal fun StartQuizInputScreen(modifier: Modifier, viewModel: StartExamViewMo
     }
 
     Column(modifier = modifier) {
-        QuackTopAppBar(
-            leadingIcon = QuackIcon.ArrowBack,
-            onLeadingIconClick = viewModel::finishStartExam,
-        )
+        BackPressedTopAppBar(onBackPressed = viewModel::finishStartExam)
         Column(
             modifier = Modifier
                 .padding(horizontal = 16.dp)

--- a/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/viewmodel/StartExamSideEffect.kt
+++ b/feature/start-exam/src/main/java/team/duckie/app/android/feature/start/exam/viewmodel/StartExamSideEffect.kt
@@ -14,6 +14,7 @@ internal sealed class StartExamSideEffect {
         val certified: Boolean,
         val examId: Int,
         val isQuiz: Boolean,
+        val requirementAnswer: String,
     ) : StartExamSideEffect()
 
     data class ReportError(val exception: Throwable) : StartExamSideEffect()

--- a/feature/start-exam/src/main/res/values/strings.xml
+++ b/feature/start-exam/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="start_exam_information_before_quiz_line2_infix">약 %s초의 제한시간이 있습니다.&#160;</string>
     <string name="start_exam_information_before_quiz_line2_postfix">문제를 잘 읽고 시간 내에 물음에 답해주세요.</string>
     <string name="start_exam_challenge_condition">&lt;도전 조건&gt;</string>
+    <string name="start_exam_quiz_start_button">덕퀴즈 도전</string>
 </resources>


### PR DESCRIPTION
## Issue

https://www.notion.so/duckie-team/1-0-10-ab0f4ef8943a4102ba9f42207e76867e?pvs=4

## Overview (Required)

미리 말씀드렸다시피 PR이 무거운 점 죄송합니다.🙏
큰 작업은 티켓으로 분리해 두고 더 진행할 예정입니다.

- [x]  덕퀴즈 랭킹에 맞은 갯수 안써있음
- [x]  `퀴즈 시작 전 안내사항` 배경에 rounded 안되있음
- [x]  시험시작이 아니라 덕퀴즈 도전임
- [x]  도전조건 적으려고 하면 버튼 키보드에 가려짐 (덕력고사 필적확인도 마찬가지)
- [x]  시험시작 BackArrow 패딩값 안맞음
- [x]  시험결과 상단탭 X가 아니라 BackArrow임
- [x]  덕력고사 X 버튼 패딩값 안맞음
- [x]  종료 다이얼로그 계속 하단에 나옴
- [x]  상단탭이랑 결과 이미지 사이 간격도 좀 안맞는것같기도..
- [x]  덕력고사 성적표 꽉차도록 수정
- [x]  `로제, 제니 등등의 대부분` 케이스에서 시험결과에서 ” ” 오른쪽꺼 안보임
- [x]  덕퀴즈 재 응시시 requirementAnswer 반영 안됨
- [x]  시험끝냈을경우 상세화면도 같이 종료됨(덕력고사는 안그럼)
- [x]  다시 풀기 기능 추가
- [x]  덕력고사는 다시 풀기 제거
