### PR TITLE
fix: 마이페이지 TopBar 디테일 잡기

### DIFF
--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/BackPressedHeadLineTopAppBar.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/BackPressedHeadLineTopAppBar.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import team.duckie.quackquack.ui.component.QuackHeadLine1
 import team.duckie.quackquack.ui.component.QuackHeadLine2
@@ -47,9 +46,8 @@ fun BackPressedTopAppBar(
 @Composable
 fun BackPressedHeadLineTopAppBar(
     title: String,
-    isLoading: Boolean,
-    trailingIcon: QuackIcon? = null,
-    onTrailingIconClick: (() -> Unit)? = null,
+    isLoading: Boolean = false,
+    trailingContent: (@Composable () -> Unit)? = null,
     onBackPressed: () -> Unit,
 ) {
     BackPressedTopAppBar(onBackPressed = onBackPressed) {
@@ -58,14 +56,8 @@ fun BackPressedHeadLineTopAppBar(
             text = title,
         )
         Spacer(weight = 1f)
-        if (trailingIcon != null) {
-            QuackImage(
-                size = DpSize(24.dp, 24.dp),
-                src = trailingIcon,
-                onClick = {
-                    if (onTrailingIconClick != null) onTrailingIconClick()
-                },
-            )
+        if (trailingContent != null) {
+            trailingContent()
         }
     }
 }

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/ProfileActivity.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/ProfileActivity.kt
@@ -113,6 +113,8 @@ class ProfileActivity : BaseActivity() {
                                     onClickMakeExam = viewModel::clickMakeExam,
                                     onClickTag = viewModel::onClickTag,
                                     onClickFriend = viewModel::navigateFriends,
+                                    isAccessedProfile = true,
+                                    navigateBack = viewModel::clickBackPress,
                                 )
                             }
 

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/MyProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/MyProfileScreen.kt
@@ -73,18 +73,18 @@ fun MyProfileScreen(
         },
         topBar = {
             HeadLineTopAppBar(
-                title = stringResource(id = R.string.mypage),
+                title = userProfile.user?.nickname ?: "",
                 rightIcons = {
                     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        QuackImage(
-                            src = QuackIcon.Setting,
-                            size = DpSize(all = 24.dp),
-                            onClick = onClickSetting,
-                        )
                         QuackImage(
                             src = QuackIcon.Notice,
                             size = DpSize(all = 24.dp),
                             onClick = onClickNotification,
+                        )
+                        QuackImage(
+                            src = QuackIcon.Setting,
+                            size = DpSize(all = 24.dp),
+                            onClick = onClickSetting,
                         )
                     }
                 },

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/MyProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/MyProfileScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import team.duckie.app.android.common.compose.ui.BackPressedHeadLineTopAppBar
 import team.duckie.app.android.domain.exam.model.ProfileExam
 import team.duckie.app.android.domain.user.model.UserProfile
 import team.duckie.app.android.feature.profile.R
@@ -42,6 +43,8 @@ import team.duckie.quackquack.ui.util.DpSize
 @Composable
 fun MyProfileScreen(
     modifier: Modifier = Modifier,
+    isAccessedProfile: Boolean = false,
+    navigateBack: (() -> Unit)? = null,
     userProfile: UserProfile,
     isLoading: Boolean,
     onClickSetting: () -> Unit,
@@ -53,6 +56,22 @@ fun MyProfileScreen(
     onClickTag: (String) -> Unit,
     onClickFriend: (FriendsType, Int, String) -> Unit,
 ) {
+    @Composable
+    fun BackPressedHeadLineTopBarInternal() {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            QuackImage(
+                src = QuackIcon.Notice,
+                size = DpSize(all = 24.dp),
+                onClick = onClickNotification,
+            )
+            QuackImage(
+                src = QuackIcon.Setting,
+                size = DpSize(all = 24.dp),
+                onClick = onClickSetting,
+            )
+        }
+    }
+
     val tags = remember(userProfile.user?.favoriteTags) {
         userProfile.user?.favoriteTags?.toImmutableList() ?: persistentListOf()
     }
@@ -72,23 +91,23 @@ fun MyProfileScreen(
             )
         },
         topBar = {
-            HeadLineTopAppBar(
-                title = userProfile.user?.nickname ?: "",
-                rightIcons = {
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        QuackImage(
-                            src = QuackIcon.Notice,
-                            size = DpSize(all = 24.dp),
-                            onClick = onClickNotification,
-                        )
-                        QuackImage(
-                            src = QuackIcon.Setting,
-                            size = DpSize(all = 24.dp),
-                            onClick = onClickSetting,
-                        )
-                    }
-                },
-            )
+            if (isAccessedProfile) {
+                BackPressedHeadLineTopAppBar(
+                    isLoading = isLoading,
+                    title = userProfile.user?.nickname ?: "",
+                    trailingContent = {
+                        BackPressedHeadLineTopBarInternal()
+                    },
+                    onBackPressed = { navigateBack?.invoke() },
+                )
+            } else {
+                HeadLineTopAppBar(
+                    title = userProfile.user?.nickname ?: "",
+                    rightIcons = {
+                        BackPressedHeadLineTopBarInternal()
+                    },
+                )
+            }
         },
         tagSection = {
             FavoriteTagSection(

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/OtherProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/OtherProfileScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -40,6 +42,7 @@ import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableType
 import team.duckie.app.android.common.compose.ui.dialog.IgnoreCheckDialog
 import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableBottomSheetDialog
 import team.duckie.app.android.common.compose.ui.dialog.ReportDialog
+import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.icon.QuackIcon
 
 @Composable
@@ -103,12 +106,17 @@ internal fun OtherProfileScreen(
                     title = state.userProfile.username(),
                     isLoading = state.isLoading,
                     onBackPressed = viewModel::clickBackPress,
-                    trailingIcon = QuackIcon.More,
-                    onTrailingIconClick = {
-                        viewModel.updateBottomSheetDialogType(DuckieSelectableType.Ignore)
-                        coroutineScope.launch {
-                            bottomSheetState.show()
-                        }
+                    trailingContent = {
+                        QuackImage(
+                            size = DpSize(24.dp, 24.dp),
+                            src = QuackIcon.More,
+                            onClick = {
+                                viewModel.updateBottomSheetDialogType(DuckieSelectableType.Ignore)
+                                coroutineScope.launch {
+                                    bottomSheetState.show()
+                                }
+                            },
+                        )
                     },
                 )
             },


### PR DESCRIPTION
## Issue

- close [마이페이지에 닉네임이 출력되지 않음](https://www.notion.so/duckie-team/45e15305d27b41c0a7ec30177ace3d8f?pvs=4)

## Overview (Required)

- 마이페이지 닉네임이 출력되지 않는 오류를 개선했습니다.
- TopBar의 아이콘이 올바르게 배치되도록 수정했습니다. (다른 경로로 마이페이지에 진입 한 경우 ArrowBar 처리, 아이콘 위치 변경)
- BackPressedTopBar의 TrailingContent를 재사용 할 수 있도록 수정했습니다.

