### PR TITLE
fix: 홈 디테일 프로필 클릭 범위 수정

### DIFF
--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
@@ -151,10 +151,15 @@ private fun DetailProfileLayout(
     val isFollowed = remember(state.isFollowing) { state.isFollowing }
 
     Row(
-        modifier = Modifier.padding(
-            horizontal = 16.dp,
-            vertical = 12.dp,
-        ),
+        modifier = Modifier
+            .quackClickable(
+                onClick = { profileClick(state.exam.user?.id ?: 0) },
+                rippleEnabled = false,
+            )
+            .padding(
+                horizontal = 16.dp,
+                vertical = 12.dp,
+            ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // 작성자 프로필 이미지
@@ -177,12 +182,7 @@ private fun DetailProfileLayout(
         // 공백
         Spacer(modifier = Modifier.width(8.dp))
         // 닉네임, 응시자, 일자 Layout
-        Column(
-            modifier = Modifier.quackClickable(
-                onClick = { profileClick(state.exam.user?.id ?: 0) },
-                rippleEnabled = false,
-            ),
-        ) {
+        Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 // 댓글 작성자 닉네임
                 QuackBody3(


### PR DESCRIPTION
## Issue

- close [상세 화면에서 유저 프로필 사진 클릭시 프로필로 이동 안됨](https://www.notion.so/duckie-team/33c5fed09ed64263ad5280625b02669f?pvs=4)

## Overview (Required)

- 홈 디테일에서 유저 프로필 클릭 범위는 프로필 사진을 포함하도록 변경했습니다.
