### PR TITLE
태그 추가 바텀 시트 공통 Composable 추가 및 각 화면에 적용 (태그 편집, 온보딩)

### DIFF
--- a/common/compose/build.gradle.kts
+++ b/common/compose/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 
 dependencies {
     implementations(
+        projects.domain,
         projects.common.kotlin,
         libs.compose.lifecycle.viewmodel,
         libs.quack.ui.components,
@@ -28,5 +29,6 @@ dependencies {
         libs.compose.ui.coil,
         libs.compose.ui.accompanist.placeholder,
         libs.paging.compose,
+        libs.compose.ui.accompanist.flowlayout,
     )
 }

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/domain/DuckieTagAddBottomSheet.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/domain/DuckieTagAddBottomSheet.kt
@@ -1,0 +1,208 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+@file:OptIn(
+    ExperimentalMaterialApi::class,
+    ExperimentalMaterialApi::class,
+    ExperimentalComposeUiApi::class,
+)
+
+package team.duckie.app.android.common.compose.ui.domain
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.google.accompanist.flowlayout.FlowRow
+import kotlinx.coroutines.launch
+import team.duckie.app.android.common.compose.R
+import team.duckie.app.android.common.compose.invisible
+import team.duckie.app.android.common.compose.rememberToast
+import team.duckie.app.android.common.compose.systemBarPaddings
+import team.duckie.app.android.common.compose.ui.ImeSpacer
+import team.duckie.app.android.common.kotlin.fastForEachIndexed
+import team.duckie.app.android.domain.tag.model.Tag
+import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.ui.component.QuackBasic2TextField
+import team.duckie.quackquack.ui.component.QuackCircleTag
+import team.duckie.quackquack.ui.component.QuackSubtitle
+import team.duckie.quackquack.ui.component.QuackTitle2
+import team.duckie.quackquack.ui.icon.QuackIcon
+
+/**
+ * 태그를 추가할 수 있는 [ModalBottomSheetLayout]
+ * primitive type 인 [String] 대신 [Tag] 를 직접 사용한다
+ *
+ * 사유: API 연동을 위해
+ */
+@Composable
+fun DuckieTagAddBottomSheet(
+    prevTags: List<Tag> = listOf(),
+    sheetState: ModalBottomSheetState,
+    onDismissRequest: (addedTags: List<Tag>, clearAction: () -> Unit) -> Unit,
+    requestAddTag: suspend (String) -> Tag?,
+    content: @Composable () -> Unit,
+) {
+    ModalBottomSheetLayout(
+        modifier = Modifier.fillMaxSize(),
+        sheetState = sheetState,
+        sheetBackgroundColor = QuackColor.White.composeColor,
+        scrimColor = QuackColor.Dimmed.composeColor,
+        sheetShape = RoundedCornerShape(
+            topStart = 16.dp,
+            topEnd = 16.dp,
+        ),
+        sheetContent = {
+            DuckieTagAddBottomSheetContent(
+                prevTags = prevTags,
+                onDismissRequest = onDismissRequest,
+                requestAddTag = requestAddTag,
+            )
+        },
+    ) {
+        content()
+    }
+}
+
+/**
+ * 태그를 추가할 수 있는 바텀 시트 content
+ *
+ * @param prevTags 해당 바텀 시트를 호출한 화면에서 가지고 있는 태그 목록
+ * @param onDismissRequest 해당 바텀 시트 content 종료 시 실행되는 함수
+ * @param requestAddTag 태그 추가 요청하는 로직. 대체로 API 로직이다.
+ */
+@Composable
+private fun DuckieTagAddBottomSheetContent(
+    prevTags: List<Tag>,
+    onDismissRequest: (addedTags: List<Tag>, clearAction: () -> Unit) -> Unit,
+    requestAddTag: suspend (String) -> Tag?,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val toast = rememberToast()
+    val context = LocalContext.current
+
+    val inputtedTags = remember { mutableStateListOf<Tag>() }
+    var tagInput by remember { mutableStateOf("") }
+
+    val keyboard = LocalSoftwareKeyboardController.current
+
+    fun updateTagInput() {
+        if (tagInput.isNotBlank()) {
+            if ((prevTags.map { it.name } + inputtedTags).contains(tagInput)) {
+                toast(context.getString(R.string.tag_toast_already_added))
+                return
+            }
+
+            coroutineScope.launch {
+                val newTag = requestAddTag(tagInput)
+
+                newTag?.let {
+                    inputtedTags.add(newTag)
+                    tagInput = ""
+                } ?: toast(context.getString(R.string.tag_toast_network_error))
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = systemBarPaddings.calculateBottomPadding()),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = 16.dp,
+                    horizontal = 16.dp,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            QuackTitle2(text = stringResource(R.string.tag_added_tag))
+            QuackSubtitle(
+                text = stringResource(R.string.tag_edit_button_done),
+                color = QuackColor.DuckieOrange,
+                padding = PaddingValues(vertical = 4.dp),
+                onClick = {
+                    onDismissRequest(inputtedTags) {
+                        inputtedTags.clear()
+                        keyboard?.hide()
+                    }
+                },
+            )
+        }
+        if (inputtedTags.isNotEmpty()) {
+            Box(modifier = Modifier.padding()) {
+                QuackCircleTag(
+                    modifier = Modifier
+                        .zIndex(0f)
+                        .invisible(),
+                    text = "",
+                    isSelected = false,
+                )
+
+                // TODO(sungbin): 애니메이션 출처 밝히기
+                FlowRow(
+                    modifier = Modifier
+                        .zIndex(1f)
+                        .padding(
+                            vertical = 12.dp,
+                            horizontal = 16.dp,
+                        ),
+                    mainAxisSpacing = 8.dp,
+                    crossAxisSpacing = 8.dp,
+                ) {
+                    inputtedTags.fastForEachIndexed { index, tag ->
+                        QuackCircleTag(
+                            text = tag.name,
+                            isSelected = false,
+                            trailingIcon = QuackIcon.Close,
+                        ) {
+                            inputtedTags.remove(inputtedTags[index])
+                        }
+                    }
+                }
+            }
+        }
+        QuackBasic2TextField(
+            text = tagInput,
+            onTextChanged = { tagInput = it },
+            placeholderText = stringResource(R.string.tag_add_manual_placeholder),
+            leadingStartPadding = 16.dp,
+            trailingEndPadding = 10.dp,
+            trailingIcon = QuackIcon.ArrowSend,
+            trailingIconOnClick = ::updateTagInput,
+            keyboardActions = KeyboardActions { updateTagInput() },
+        )
+        ImeSpacer()
+    }
+}

--- a/common/compose/src/main/res/values/strings.xml
+++ b/common/compose/src/main/res/values/strings.xml
@@ -36,4 +36,10 @@
 
     <string name="topappbar_filter_full">전체보기</string>
     <string name="topappbar_add">추가</string>
+
+    <string name="tag_toast_already_added">이미 추가한 태그예요.</string>
+    <string name="tag_toast_network_error">네트워크 연결이 불안정해요\n잠시 후 다시 시도해 주세요.</string>
+    <string name="tag_added_tag">추가한 태그</string>
+    <string name="tag_edit_button_done">완료</string>
+    <string name="tag_add_manual_placeholder">태그 입력하기</string>
 </resources>

--- a/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
@@ -65,7 +65,7 @@ object ExamDummyResponse {
             "timer": 0,
             "requirementQuestion": "",
             "requirementPlaceholder": "",
-            "problemCount": null,
+            "problemCount": null
         }
     """
 

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/ranking/ExamineeSection.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/ranking/ExamineeSection.kt
@@ -26,12 +26,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemsIndexed
+import team.duckie.app.android.common.compose.itemsIndexedPagingKey
+import team.duckie.app.android.common.compose.ui.Spacer
+import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
+import team.duckie.app.android.common.compose.ui.skeleton
 import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.feature.home.viewmodel.ranking.RankingViewModel
-import team.duckie.app.android.common.compose.ui.Spacer
-import team.duckie.app.android.common.compose.ui.skeleton
-import team.duckie.app.android.common.compose.itemsIndexedPagingKey
-import team.duckie.app.android.common.compose.ui.DefaultProfile
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody2
 import team.duckie.quackquack.ui.component.QuackImage

--- a/feature/onboard/src/main/kotlin/team/duckie/app/android/feature/onboard/screen/3_TagScreen.kt
+++ b/feature/onboard/src/main/kotlin/team/duckie/app/android/feature/onboard/screen/3_TagScreen.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import team.duckie.app.android.common.compose.activityViewModel
 import team.duckie.app.android.common.compose.asLoose
-import team.duckie.app.android.common.compose.rememberToast
 import team.duckie.app.android.common.compose.systemBarPaddings
 import team.duckie.app.android.common.compose.ui.domain.DuckieTagAddBottomSheet
 import team.duckie.app.android.common.kotlin.AllowMagicNumber
@@ -127,7 +126,6 @@ private val TagScreenMeasurePolicy = MeasurePolicy { measurables, constraints ->
 internal fun TagScreen(vm: OnboardViewModel = activityViewModel()) {
     val keyboard = LocalSoftwareKeyboardController.current
     val coroutineScope = rememberCoroutineScope()
-    val toast = rememberToast()
 
     var isLoadingToFinish by remember { mutableStateOf(false) }
     val addedTags = remember { mutableStateListOf<Tag>() }

--- a/feature/onboard/src/main/kotlin/team/duckie/app/android/feature/onboard/viewmodel/OnboardViewModel.kt
+++ b/feature/onboard/src/main/kotlin/team/duckie/app/android/feature/onboard/viewmodel/OnboardViewModel.kt
@@ -13,7 +13,6 @@ import android.app.Application
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
@@ -316,7 +315,6 @@ internal class OnboardViewModel @AssistedInject constructor(
             viewModelScope.launch {
                 fileUploadUseCase(file, FileType.Profile)
                     .onSuccess { url ->
-                        Log.i("riflockle7", url);
                         continuation.resume(url)
                     }
                     .onFailure { exception ->

--- a/feature/onboard/src/main/res/values/strings.xml
+++ b/feature/onboard/src/main/res/values/strings.xml
@@ -35,10 +35,10 @@
 
     <string name="tag_title">좋아요!\n더 자세한 관심 태그를 추가해보세요.</string>
     <string name="tag_description">태그 할수록 더키의 추천이 정확해져요!</string>
-    <string name="tag_added_tag">추가한 태그</string>
+    <string name="tag_added_tag">추가한 태그</string> <!--추후 삭제-->
     <string name="tag_add_manual">+ 직접 태그 추가하기</string>
-    <string name="tag_add_manual_placeholder">태그 입력하기</string>
+    <string name="tag_add_manual_placeholder">태그 입력하기</string> <!--추후 삭제-->
     <string name="tag_hottest_tag">%s 분야 인기 태그</string>
-    <string name="tag_toast_already_added">이미 추가한 태그예요.</string>
+    <string name="tag_toast_already_added">이미 추가한 태그예요.</string> <!--추후 삭제-->
     <string name="tag_toast_create_failed">태그 생성에 실패했어요. 실패한 태그: %s</string>
 </resources>

--- a/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/viewmodel/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/viewmodel/SearchViewModel.kt
@@ -30,6 +30,7 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import team.duckie.app.android.common.android.ui.const.Debounce
 import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.follow.model.FollowBody
 import team.duckie.app.android.domain.follow.usecase.FollowUseCase
@@ -46,7 +47,6 @@ import team.duckie.app.android.feature.search.constants.SearchStep
 import team.duckie.app.android.feature.search.viewmodel.sideeffect.SearchSideEffect
 import team.duckie.app.android.feature.search.viewmodel.state.SearchState
 import team.duckie.app.android.feature.search.viewmodel.state.toUiModel
-import team.duckie.app.android.common.android.ui.const.Debounce
 import javax.inject.Inject
 
 @HiltViewModel
@@ -93,7 +93,7 @@ internal class SearchViewModel @Inject constructor(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     ).apply {
         intent {
-            this@apply.debounce(team.duckie.app.android.common.android.ui.const.Debounce.SearchSecond).collectLatest { query ->
+            this@apply.debounce(Debounce.SearchSecond).collectLatest { query ->
                 refreshSearchStep(keyword = state.searchKeyword)
                 // TODO(limsaehyun): 추후 추천 검색어 비즈니스 로직을 이곳에서 작업해야 함
             }

--- a/feature/tag-edit/src/main/AndroidManifest.xml
+++ b/feature/tag-edit/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <application>
         <activity
             android:name="TagEditActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
     </application>
 </manifest>

--- a/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/screen/TagEditScreen.kt
+++ b/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/screen/TagEditScreen.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:OptIn(ExperimentalMaterialApi::class)
+
 package team.duckie.app.android.feature.tag.edit.screen
 
 import android.app.Activity
@@ -12,22 +14,27 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
-import team.duckie.app.android.feature.tag.edit.R
-import team.duckie.app.android.feature.tag.edit.viewmodel.TagEditState
-import team.duckie.app.android.feature.tag.edit.viewmodel.TagEditViewModel
+import team.duckie.app.android.common.compose.activityViewModel
 import team.duckie.app.android.common.compose.ui.ErrorScreen
 import team.duckie.app.android.common.compose.ui.FavoriteTagSection
 import team.duckie.app.android.common.compose.ui.LoadingScreen
-import team.duckie.app.android.common.compose.ui.screen.SearchTagScreen
-import team.duckie.app.android.common.compose.activityViewModel
+import team.duckie.app.android.common.compose.ui.domain.DuckieTagAddBottomSheet
+import team.duckie.app.android.domain.tag.model.Tag
+import team.duckie.app.android.feature.tag.edit.R
+import team.duckie.app.android.feature.tag.edit.viewmodel.TagEditState
+import team.duckie.app.android.feature.tag.edit.viewmodel.TagEditViewModel
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackSubtitle
 import team.duckie.quackquack.ui.component.QuackTopAppBar
@@ -50,22 +57,9 @@ internal fun TagEditScreen(
             state = state,
             onEditFinishClick = vm::onEditFinishClick,
             onTrailingClick = vm::onTrailingClick,
-            onAddTagClick = vm::onAddTagClick,
-            onTagClick = vm::onTagClick,
-        )
-
-        is TagEditState.AddTag -> SearchTagScreen(
-            modifier = modifier,
-            title = stringResource(id = R.string.add_tag_title),
-            placeholderText = stringResource(id = R.string.add_tag_placeholder),
-            multiSelectMode = false,
-            onCloseClick = vm::onAddFinishClick,
-            onBackPressed = vm::onAddFinishClick,
-            onClickSearchListHeader = vm::onSearchTagHeaderClick,
-            onClickSearchList = { index -> vm.onSearchTagClick(index) },
-            onTextChanged = { newSearchTextValue -> vm.onSearchTextChanged(newSearchTextValue) },
-            onSearchTextValidate = { searchTextValue -> vm.onSearchTextValidate(searchTextValue) },
-            searchResults = state.searchResults.map { it.name }.toImmutableList(),
+            addNewTags = vm::addNewTags,
+            requestAddTag = vm::requestNewTag,
+            onTagClick = vm::onTrailingClick,
         )
 
         is TagEditState.Error -> ErrorScreen(
@@ -81,50 +75,71 @@ fun TagEditSuccessScreen(
     state: TagEditState.Success,
     onEditFinishClick: () -> Unit,
     onTrailingClick: (Int) -> Unit,
-    onAddTagClick: () -> Unit,
+    addNewTags: (List<Tag>) -> Unit,
+    requestAddTag: suspend (String) -> Tag?,
     onTagClick: (Int) -> Unit,
 ) {
     val activity = LocalContext.current as Activity
+    val coroutineScope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(
+        ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true,
+    )
 
-    Column(modifier = modifier) {
-        // 상단 탭바
-        QuackTopAppBar(
-            leadingIcon = QuackIcon.ArrowBack,
-            leadingText = stringResource(R.string.title),
-            onLeadingIconClick = activity::finish,
-            trailingContent = {
-                QuackSubtitle(
-                    modifier = Modifier
-                        .then(Modifier) // prevent Modifier.Companion
-                        .quackClickable(
-                            rippleEnabled = false,
-                            onClick = onEditFinishClick,
+    DuckieTagAddBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = { newAddedTags, clearAction ->
+            coroutineScope.launch {
+                addNewTags(newAddedTags)
+                clearAction()
+                sheetState.hide()
+            }
+        },
+        requestAddTag = requestAddTag,
+        content = {
+            Column(modifier = modifier) {
+                // 상단 탭바
+                QuackTopAppBar(
+                    leadingIcon = QuackIcon.ArrowBack,
+                    leadingText = stringResource(R.string.title),
+                    onLeadingIconClick = activity::finish,
+                    trailingContent = {
+                        QuackSubtitle(
+                            modifier = Modifier
+                                .then(Modifier) // prevent Modifier.Companion
+                                .quackClickable(
+                                    rippleEnabled = false,
+                                    onClick = onEditFinishClick,
+                                )
+                                .padding(
+                                    vertical = 4.dp,
+                                    horizontal = 16.dp,
+                                ),
+                            text = stringResource(R.string.edit_finish),
+                            color = QuackColor.DuckieOrange,
+                            singleLine = true,
                         )
-                        .padding(
-                            vertical = 4.dp,
-                            horizontal = 16.dp,
-                        ),
-                    text = stringResource(R.string.edit_finish),
-                    color = QuackColor.DuckieOrange,
-                    singleLine = true,
+                    },
                 )
-            },
-        )
 
-        // 내 관심 태그 영역
-        FavoriteTagSection(
-            modifier = Modifier.padding(vertical = 20.dp),
-            title = stringResource(id = R.string.my_favorite_tag),
-            horizontalPadding = PaddingValues(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            trailingIcon = QuackIcon.Close,
-            onTrailingClick = onTrailingClick,
-            tags = state.myTags.map { it.name }.toPersistentList(),
-            emptySection = {},
-            singleLine = false,
-            onTagClick = onTagClick,
-            addButtonTitle = stringResource(id = R.string.tag_edit_add_favorite_tag),
-            onAddTagClick = onAddTagClick,
-        )
-    }
+                // 내 관심 태그 영역
+                FavoriteTagSection(
+                    modifier = Modifier.padding(vertical = 20.dp),
+                    title = stringResource(id = R.string.my_favorite_tag),
+                    horizontalPadding = PaddingValues(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    trailingIcon = QuackIcon.Close,
+                    onTrailingClick = onTrailingClick,
+                    tags = state.myTags.map { it.name }.toPersistentList(),
+                    emptySection = {},
+                    singleLine = false,
+                    onTagClick = onTagClick,
+                    addButtonTitle = stringResource(id = R.string.tag_edit_add_favorite_tag),
+                    onAddTagClick = {
+                        coroutineScope.launch { sheetState.show() }
+                    },
+                )
+            }
+        },
+    )
 }

--- a/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/viewmodel/TagEditState.kt
+++ b/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/viewmodel/TagEditState.kt
@@ -19,9 +19,5 @@ sealed class TagEditState {
         val categoryTagList: ImmutableList<ImmutableList<Tag>> = persistentListOf(),
     ) : TagEditState()
 
-    class AddTag(
-        val searchResults: ImmutableList<Tag> = persistentListOf(),
-    ) : TagEditState()
-
     data class Error(val exception: Throwable) : TagEditState()
 }

--- a/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/viewmodel/TagEditViewModel.kt
+++ b/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/viewmodel/TagEditViewModel.kt
@@ -8,26 +8,16 @@
 package team.duckie.app.android.feature.tag.edit.viewmodel
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import team.duckie.app.android.domain.recommendation.model.SearchType
-import team.duckie.app.android.domain.search.model.Search
 import team.duckie.app.android.domain.search.usecase.GetSearchUseCase
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.tag.usecase.TagCreateUseCase
@@ -35,8 +25,6 @@ import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.domain.user.usecase.GetMeUseCase
 import team.duckie.app.android.domain.user.usecase.SetMeUseCase
 import team.duckie.app.android.domain.user.usecase.UserUpdateUseCase
-import team.duckie.app.android.common.kotlin.fastMap
-import team.duckie.app.android.common.android.ui.const.Debounce
 import javax.inject.Inject
 
 private const val TagsMaximumCount = 10
@@ -56,34 +44,6 @@ internal class TagEditViewModel @Inject constructor(
     private val myTags: ImmutableList<Tag>
         get() = me.favoriteTags?.toImmutableList() ?: persistentListOf()
 
-    /** tags 검색 flow. 실질 동작 로직은 apply 내에 명세되어 있다. */
-    @OptIn(FlowPreview::class)
-    private val _getSearchTagsFlow: MutableSharedFlow<String> = MutableSharedFlow<String>(
-        replay = 0,
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    ).apply {
-        viewModelScope.launch {
-            this@apply.debounce(team.duckie.app.android.common.android.ui.const.Debounce.SearchSecond).collectLatest { query ->
-                intent {
-                    getSearchUseCase(query = query, page = 1, type = SearchType.Tags)
-                        .onSuccess {
-                            val searchResults = (it as Search.TagSearch).tags
-                                .take(TagsMaximumCount)
-                                .toImmutableList()
-
-                            reduce {
-                                TagEditState.AddTag(searchResults = searchResults)
-                            }
-                        }
-                        .onFailure {
-                            postSideEffect(TagEditSideEffect.ReportError(it))
-                        }
-                }
-            }
-        }
-    }
-
     fun initState() = intent {
         getMeUseCase()
             .onSuccess { meResponse ->
@@ -96,88 +56,43 @@ internal class TagEditViewModel @Inject constructor(
     }
 
     /** 수정완료 버튼 누를 시 동작 */
-    fun onEditFinishClick() {
-        intent { postSideEffect(TagEditSideEffect.FinishTagEdit(true)) }
-    }
-
-    /** + 직접 태그 추가하기 버튼 클릭 시 동작 */
-    fun onAddTagClick() {
-        intent {
-            reduce { TagEditState.AddTag() }
-        }
-    }
+    fun onEditFinishClick() = intent { updateMe() }
 
     /** 각 태그 항목의 x 버튼 클릭 시 동작 */
-    fun onTrailingClick(index: Int) = viewModelScope.launch {
+    fun onTrailingClick(index: Int) = intent {
         val newTags = myTags.toMutableList().apply { removeAt(index) }.toPersistentList()
-        updateMe(newTags)
+        reduce { TagEditState.Success(myTags = newTags) }
     }
 
-    /**
-     * 태그 편집 화면에서, 각 태그 항목 클릭 시 동작
-     * // TODO(riflockle7): 본래는 [onTrailingClick] 에 들어갈 내용이며 추후 개선 필요
-     */
-    fun onTagClick(index: Int) = viewModelScope.launch {
-        val newTags = myTags.toMutableList().apply { removeAt(index) }.toPersistentList()
-        updateMe(newTags)
+    /** 바텀 시트에서 오른쪽 방향 화살표를 눌러 태그 추가를 완료한다. */
+    fun addNewTags(newTag: List<Tag>) {
+        val newTags = myTags.toMutableList().apply { addAll(newTag) }.toPersistentList()
+        intent { reduce { TagEditState.Success(myTags = newTags) } }
     }
 
-    /** 태그 추가 화면 종료 시 동작 */
-    fun onAddFinishClick() {
-        intent { reduce { TagEditState.Success(myTags) } }
-    }
-
-    /** 태그 추가 화면에서, 검색된 항목 클릭 시 동작 */
-    fun onSearchTagHeaderClick(tag: String) = viewModelScope.launch {
-        require(container.stateFlow.value is TagEditState.AddTag)
-        tagCreateUseCase(tag)
-            .onSuccess { tag -> addMyTag(tag) }
-            .onFailure {
-                intent { postSideEffect(TagEditSideEffect.ReportError(it)) }
-            }
-    }
-
-    /** 태그 추가 화면에서, 검색된 항목 클릭 시 동작 */
-    fun onSearchTagClick(index: Int) = viewModelScope.launch {
-        require(container.stateFlow.value is TagEditState.AddTag)
-        val searchResults = (container.stateFlow.value as TagEditState.AddTag).searchResults
-        addMyTag(searchResults[index])
-    }
-
-    /** 태그 추가 화면에서, 텍스트 내용 변경 시 동작 */
-    fun onSearchTextChanged(newSearchTextValue: String) = viewModelScope.launch {
-        _getSearchTagsFlow.emit(newSearchTextValue)
-    }
-
-    /** 태그 추가 화면에서, 텍스트 유효성 체크 */
-    fun onSearchTextValidate(searchTextValue: String): Boolean {
-        val state = container.stateFlow.value
-        require(state is TagEditState.AddTag)
-
-        return searchTextValue.isNotEmpty() &&
-                !state.searchResults.fastMap { it.name }.contains(searchTextValue)
-    }
-
-    /** 태그 추가 화면에서, 태그 추가한 뒤 화면을 종료한다. */
-    private suspend fun addMyTag(newTag: Tag) {
-        val newTags = myTags.toMutableList().apply { add(newTag) }.toPersistentList()
-        updateMe(newTags)
+    /** 새로운 태그를 요청한다. */
+    suspend fun requestNewTag(tag: String): Tag? {
+        require(container.stateFlow.value is TagEditState.Success)
+        return tagCreateUseCase(tag).getOrNull()
     }
 
     /** 태그 추가 화면에서, 태그 추가한 새로운 me 정보를 갱신하고 [TagEditViewModel] 내 정보 또한 갱신한다. */
-    private suspend fun updateMe(newTags: PersistentList<Tag>) {
+    private suspend fun updateMe() {
+        val tagSuccessState = container.stateFlow.value;
+        require(tagSuccessState is TagEditState.Success)
+
         userUpdateUseCase(
             id = me.id,
             profileImageUrl = null,
             categories = null,
-            tags = newTags,
+            tags = tagSuccessState.myTags,
             status = null,
             nickname = null,
             introduction = null,
         ).onSuccess { newMe ->
             setMeUseCase(newMe)
             me = newMe
-            intent { reduce { TagEditState.Success(myTags) } }
+            intent { postSideEffect(TagEditSideEffect.FinishTagEdit(true)) }
         }.onFailure {
             intent { postSideEffect(TagEditSideEffect.ReportError(it)) }
         }

--- a/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/viewmodel/TagEditViewModel.kt
+++ b/feature/tag-edit/src/main/kotlin/team/duckie/app/android/feature/tag/edit/viewmodel/TagEditViewModel.kt
@@ -18,7 +18,6 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import team.duckie.app.android.domain.search.usecase.GetSearchUseCase
 import team.duckie.app.android.domain.tag.model.Tag
 import team.duckie.app.android.domain.tag.usecase.TagCreateUseCase
 import team.duckie.app.android.domain.user.model.User
@@ -27,13 +26,10 @@ import team.duckie.app.android.domain.user.usecase.SetMeUseCase
 import team.duckie.app.android.domain.user.usecase.UserUpdateUseCase
 import javax.inject.Inject
 
-private const val TagsMaximumCount = 10
-
 @HiltViewModel
 internal class TagEditViewModel @Inject constructor(
     private val getMeUseCase: GetMeUseCase,
     private val setMeUseCase: SetMeUseCase,
-    private val getSearchUseCase: GetSearchUseCase,
     private val tagCreateUseCase: TagCreateUseCase,
     private val userUpdateUseCase: UserUpdateUseCase,
 ) : ContainerHost<TagEditState, TagEditSideEffect>, ViewModel() {
@@ -78,7 +74,7 @@ internal class TagEditViewModel @Inject constructor(
 
     /** 태그 추가 화면에서, 태그 추가한 새로운 me 정보를 갱신하고 [TagEditViewModel] 내 정보 또한 갱신한다. */
     private suspend fun updateMe() {
-        val tagSuccessState = container.stateFlow.value;
+        val tagSuccessState = container.stateFlow.value
         require(tagSuccessState is TagEditState.Success)
 
         userUpdateUseCase(


### PR DESCRIPTION
## Issue

- close [태그 편집 > 직접 태그 추가 flow 개선](https://www.notion.so/duckie-team/flow-69419222e4c747709f401b28d871ed1a?pvs=4)

작업내용
- 태그 추가 바텀 시트 공통 Composable 를 만들었습니다.
- 태그 편집, 온보딩 화면에 적용하면서 태그 편집 화면에 직접 태그 추가 flow 개선도 같이 작업했습니다.