### PR TITLE
최근검색어 리플 범위 변경

### DIFF
--- a/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/screen/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/screen/SearchScreen.kt
@@ -58,7 +58,6 @@ internal fun SearchScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(SearchHorizontalPadding)
             .imePadding(),
     ) {
         Spacer(modifier = Modifier.height(16.dp))
@@ -148,6 +147,7 @@ private fun LazyListScope.recentKeywordSection(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(SearchHorizontalPadding)
                 .padding(bottom = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -185,6 +185,7 @@ private fun RecentSearchLayout(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick(keyword) }
+            .padding(SearchHorizontalPadding)
             .padding(vertical = 12.dp),
     ) {
         QuackImage(


### PR DESCRIPTION
## Issue

- https://www.notion.so/duckie-team/17ddc93fda384036945ba5dce8210253?pvs=4

## Overview (Required)

최근검색어 리플 범위 좌우 꽉차도록 변경