### PR TITLE
시험 상세 서브태그 end쪽에 패딩 없애주기 및 상세화면에 quack v2 적용

### DIFF
--- a/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
@@ -65,7 +65,7 @@ object ExamDummyResponse {
             "timer": 0,
             "requirementQuestion": "",
             "requirementPlaceholder": "",
-            "problemCount": null,
+            "problemCount": null
         }
     """
 

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -27,12 +27,12 @@ dependencies {
         projects.common.android,
         projects.common.kotlin,
         projects.common.compose,
+        libs.kotlin.collections.immutable,
         libs.orbit.viewmodel,
         libs.orbit.compose,
         libs.ktx.lifecycle.runtime,
         libs.compose.ui.material, // needs for Scaffold
         libs.compose.lifecycle.runtime,
-        libs.quack.ui.components,
         libs.quack.v2.ui,
         libs.compose.ui.coil,
     )

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/DetailActivity.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/DetailActivity.kt
@@ -28,8 +28,8 @@ import team.duckie.app.android.feature.detail.viewmodel.sideeffect.DetailSideEff
 import team.duckie.app.android.navigator.feature.profile.ProfileNavigator
 import team.duckie.app.android.navigator.feature.search.SearchNavigator
 import team.duckie.app.android.navigator.feature.startexam.StartExamNavigator
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.theme.QuackTheme
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.theme.QuackTheme
 import javax.inject.Inject
 
 /** 상세 화면 */
@@ -53,7 +53,7 @@ class DetailActivity : BaseActivity() {
                 DetailScreen(
                     Modifier
                         .fillMaxSize()
-                        .background(color = QuackColor.White.composeColor)
+                        .background(color = QuackColor.White.value)
                         .systemBarsPadding(),
                 )
             }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/BottomContent.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/BottomContent.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:OptIn(ExperimentalQuackQuackApi::class)
+
 package team.duckie.app.android.feature.detail.common
 
 import androidx.compose.foundation.layout.Arrangement
@@ -12,17 +14,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import team.duckie.app.android.common.compose.ui.QuackMaxWidthDivider
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.quackquack.ui.R
-import team.duckie.quackquack.ui.component.QuackDivider
-import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.component.QuackSmallButton
-import team.duckie.quackquack.ui.component.QuackSmallButtonType
+import team.duckie.quackquack.material.QuackIcon
+import team.duckie.quackquack.material.quackClickable
+import team.duckie.quackquack.ui.QuackButton
+import team.duckie.quackquack.ui.QuackButtonStyle
+import team.duckie.quackquack.ui.QuackImage
+import team.duckie.quackquack.ui.util.ExperimentalQuackQuackApi
 
 /** 상세 화면 최하단 Layout */
 @Composable
@@ -34,7 +39,8 @@ internal fun DetailBottomLayout(
 ) {
     Column(modifier = modifier) {
         // 구분선
-        QuackDivider()
+        QuackMaxWidthDivider()
+
         // 버튼 모음 Layout
         // TODO(riflockle7): 추후 Layout 을 활용해 처리하기
         Row(
@@ -46,20 +52,20 @@ internal fun DetailBottomLayout(
         ) {
             // 좋아요 버튼
             QuackImage(
+                modifier = Modifier
+                    .size(DpSize(24.dp, 24.dp))
+                    .quackClickable(onClick = onHeartClick),
                 src = if (state.isHeart) {
-                    R.drawable.quack_ic_heart_filled_24
+                    QuackIcon.FilledHeart.drawableId
                 } else {
-                    R.drawable.quack_ic_heart_24
+                    QuackIcon.Heart.drawableId
                 },
-                size = DpSize(24.dp, 24.dp),
-                onClick = onHeartClick,
             )
 
             // 버튼
-            QuackSmallButton(
+            QuackButton(
+                style = QuackButtonStyle.PrimaryFilledSmall,
                 text = state.buttonTitle,
-                type = QuackSmallButtonType.Fill,
-                enabled = true,
                 onClick = onChallengeClick,
             )
         }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
@@ -9,7 +9,6 @@
 
 package team.duckie.app.android.feature.detail.common
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -32,26 +31,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import team.duckie.app.android.common.compose.GetHeightRatioW328H240
-import team.duckie.app.android.common.compose.ui.DefaultProfile
+import team.duckie.app.android.common.compose.ui.QuackMaxWidthDivider
 import team.duckie.app.android.feature.detail.R
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
-import team.duckie.app.android.common.compose.GetHeightRatioW328H240
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackBody2
-import team.duckie.quackquack.ui.component.QuackBody3
-import team.duckie.quackquack.ui.component.QuackDivider
-import team.duckie.quackquack.ui.component.QuackHeadLine2
-import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.icon.QuackIcon
-import team.duckie.quackquack.ui.modifier.quackClickable
-import team.duckie.quackquack.ui.shape.SquircleShape
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackIcon
+import team.duckie.quackquack.material.QuackTypography
+import team.duckie.quackquack.material.quackClickable
+import team.duckie.quackquack.material.shape.SquircleShape
+import team.duckie.quackquack.ui.QuackImage
+import team.duckie.quackquack.ui.QuackTag
+import team.duckie.quackquack.ui.QuackTagStyle
+import team.duckie.quackquack.ui.QuackText
 import team.duckie.quackquack.ui.util.ExperimentalQuackQuackApi
 
 /** 상세 화면 컨텐츠 Layout */
@@ -96,12 +92,20 @@ internal fun DetailContentLayout(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             // 제목
-            QuackHeadLine2(text = state.exam.title)
+            QuackText(
+                text = state.exam.title,
+                typography = QuackTypography.HeadLine2,
+            )
+
             // 더보기 아이콘
             QuackImage(
-                src = QuackIcon.More,
-                size = DpSize(width = 24.dp, height = 24.dp),
-                onClick = moreButtonClick,
+                src = QuackIcon.More.drawableId,
+                modifier = Modifier
+                    .width(24.dp)
+                    .height(24.dp)
+                    .quackClickable {
+                        moreButtonClick()
+                    },
             )
         }
 
@@ -109,9 +113,10 @@ internal fun DetailContentLayout(
         Spacer(modifier = Modifier.height(8.dp))
         // 내용
         state.exam.description?.run {
-            QuackBody2(
+            QuackText(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 text = this,
+                typography = QuackTypography.Body2,
             )
         }
         // 공백
@@ -129,23 +134,27 @@ internal fun DetailContentLayout(
                 QuackTag(
                     text = tagName,
                     style = QuackTagStyle.GrayscaleFlat,
-                    onClick = { tagItemClick(tagName) }
+                    onClick = { tagItemClick(tagName) },
                 )
             }
         }
 
         // 공백
         Spacer(modifier = Modifier.height(24.dp))
+
         // 구분선
-        QuackDivider()
+        QuackMaxWidthDivider()
+
         // 프로필 Layout
         DetailProfileLayout(
             state = state,
             followButtonClick = followButtonClick,
             profileClick = profileClick,
         )
+
         // 구분선
-        QuackDivider()
+        QuackMaxWidthDivider()
+
         additionalInfo()
     }
 }
@@ -177,17 +186,17 @@ private fun DetailProfileLayout(
         // 작성자 프로필 이미지
         if (state.profileImageUrl.isNotEmpty()) {
             QuackImage(
-                src = state.profileImageUrl,
-                shape = SquircleShape,
-                size = DpSize(32.dp, 32.dp),
-            )
-        } else {
-            Image(
                 modifier = Modifier
                     .size(DpSize(32.dp, 32.dp))
                     .clip(SquircleShape),
-                painter = painterResource(id = QuackIcon.DefaultProfile),
-                contentDescription = null,
+                src = state.profileImageUrl,
+            )
+        } else {
+            QuackImage(
+                modifier = Modifier
+                    .size(DpSize(32.dp, 32.dp))
+                    .clip(SquircleShape),
+                src = QuackIcon.Profile.drawableId,
             )
         }
 
@@ -197,9 +206,9 @@ private fun DetailProfileLayout(
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 // 댓글 작성자 닉네임
-                QuackBody3(
+                QuackText(
                     text = state.nickname,
-                    color = QuackColor.Black,
+                    typography = QuackTypography.Body3,
                 )
 
                 // 공백
@@ -210,24 +219,30 @@ private fun DetailProfileLayout(
             Spacer(modifier = Modifier.height(2.dp))
 
             // 덕티어 + 퍼센트, 태그
-            QuackBody3(
+            QuackText(
                 text = stringResource(
                     R.string.detail_tier_tag,
                     state.exam.user?.duckPower?.tier ?: "",
                     state.exam.user?.duckPower?.tag?.name ?: "",
                 ),
-                color = QuackColor.Gray2,
+                typography = QuackTypography.Body3.change(color = QuackColor.Gray2),
             )
         }
         // 공백
         Spacer(modifier = Modifier.weight(1f))
 
         // 팔로우 버튼
-        QuackBody2(
-            padding = PaddingValues(
-                top = 8.dp,
-                bottom = 8.dp,
-            ),
+        QuackText(
+            modifier = Modifier
+                .padding(
+                    PaddingValues(
+                        top = 8.dp,
+                        bottom = 8.dp,
+                    ),
+                )
+                .quackClickable(
+                    onClick = followButtonClick,
+                ),
             text = stringResource(
                 if (isFollowed) {
                     R.string.detail_following
@@ -235,8 +250,13 @@ private fun DetailProfileLayout(
                     R.string.detail_follow
                 },
             ),
-            color = if (isFollowed) QuackColor.Gray2 else QuackColor.DuckieOrange,
-            onClick = followButtonClick,
+            typography = QuackTypography.Body2.change(
+                color = if (isFollowed) {
+                    QuackColor.Gray2
+                } else {
+                    QuackColor.DuckieOrange
+                },
+            ),
         )
     }
 }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
@@ -5,6 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:OptIn(ExperimentalQuackQuackApi::class)
+
 package team.duckie.app.android.feature.detail.common
 
 import androidx.compose.foundation.Image
@@ -19,6 +21,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -33,6 +37,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import team.duckie.app.android.common.compose.GetHeightRatioW328H240
+import team.duckie.app.android.common.compose.ui.DefaultProfile
 import team.duckie.app.android.feature.detail.R
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
 import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
@@ -43,11 +49,10 @@ import team.duckie.quackquack.ui.component.QuackBody3
 import team.duckie.quackquack.ui.component.QuackDivider
 import team.duckie.quackquack.ui.component.QuackHeadLine2
 import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.component.QuackSingeLazyRowTag
-import team.duckie.quackquack.ui.component.QuackTagType
 import team.duckie.quackquack.ui.icon.QuackIcon
 import team.duckie.quackquack.ui.modifier.quackClickable
 import team.duckie.quackquack.ui.shape.SquircleShape
+import team.duckie.quackquack.ui.util.ExperimentalQuackQuackApi
 
 /** 상세 화면 컨텐츠 Layout */
 @Suppress("MagicNumber")
@@ -111,14 +116,24 @@ internal fun DetailContentLayout(
         }
         // 공백
         Spacer(modifier = Modifier.height(12.dp))
+
         // 태그 목록
-        QuackSingeLazyRowTag(
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
-            horizontalSpace = 4.dp,
-            items = state.tagNames,
-            tagType = QuackTagType.Grayscale(""),
-            onClick = { index -> tagItemClick(state.tagNames[index]) },
-        )
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            contentPadding = PaddingValues(
+                horizontal = 16.dp,
+                vertical = 4.dp,
+            ),
+        ) {
+            items(items = state.tagNames) { tagName ->
+                QuackTag(
+                    text = tagName,
+                    style = QuackTagStyle.GrayscaleFlat,
+                    onClick = { tagItemClick(tagName) }
+                )
+            }
+        }
+
         // 공백
         Spacer(modifier = Modifier.height(24.dp))
         // 구분선

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/TopCustomBar.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/TopCustomBar.kt
@@ -5,15 +5,17 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
+@file:OptIn(ExperimentalQuackQuackApi::class)
+
 package team.duckie.app.android.feature.detail.common
 
 import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,10 +23,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackCircleTag
-import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.icon.QuackIcon
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackIcon
+import team.duckie.quackquack.material.quackClickable
+import team.duckie.quackquack.ui.QuackImage
+import team.duckie.quackquack.ui.QuackTag
+import team.duckie.quackquack.ui.QuackTagStyle
+import team.duckie.quackquack.ui.trailingIcon
+import team.duckie.quackquack.ui.util.ExperimentalQuackQuackApi
 
 /** 상세 화면에서 사용하는 TopAppBar */
 @Composable
@@ -37,7 +43,7 @@ internal fun TopAppCustomBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(QuackColor.White.composeColor)
+            .background(QuackColor.White.value)
             .padding(
                 vertical = 6.dp,
                 horizontal = 10.dp,
@@ -46,17 +52,23 @@ internal fun TopAppCustomBar(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         QuackImage(
-            padding = PaddingValues(6.dp),
-            src = QuackIcon.ArrowBack,
-            size = DpSize(24.dp, 24.dp),
-            rippleEnabled = false,
-            onClick = { activity.finish() },
+            modifier = Modifier
+                .padding(6.dp)
+                .size(DpSize(24.dp, 24.dp))
+                .quackClickable(
+                    onClick = { activity.finish() },
+                ),
+            src = QuackIcon.ArrowBack.drawableId,
         )
 
-        QuackCircleTag(
+        QuackTag(
+            modifier = Modifier.trailingIcon(
+                icon = QuackIcon.ArrowRight,
+                onClick = { onTagClick(state.mainTagNames) },
+            ),
             text = state.mainTagNames,
-            trailingIcon = QuackIcon.ArrowRight,
-            isSelected = false,
+            style = QuackTagStyle.Outlined,
+            selected = false,
             onClick = { onTagClick(state.mainTagNames) },
         )
     }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/DetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/DetailScreen.kt
@@ -26,19 +26,19 @@ import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import team.duckie.app.android.common.android.network.NetworkUtil
+import team.duckie.app.android.common.compose.activityViewModel
+import team.duckie.app.android.common.compose.ui.ErrorScreen
+import team.duckie.app.android.common.compose.ui.LoadingScreen
+import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableBottomSheetDialog
+import team.duckie.app.android.common.compose.ui.dialog.ReportDialog
 import team.duckie.app.android.feature.detail.common.DetailBottomLayout
 import team.duckie.app.android.feature.detail.common.TopAppCustomBar
 import team.duckie.app.android.feature.detail.screen.exam.ExamDetailContentLayout
 import team.duckie.app.android.feature.detail.screen.quiz.QuizDetailContentLayout
 import team.duckie.app.android.feature.detail.viewmodel.DetailViewModel
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.compose.ui.ErrorScreen
-import team.duckie.app.android.common.compose.ui.LoadingScreen
-import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableBottomSheetDialog
-import team.duckie.app.android.common.compose.ui.dialog.ReportDialog
-import team.duckie.app.android.common.android.network.NetworkUtil
-import team.duckie.app.android.common.compose.activityViewModel
-import team.duckie.quackquack.ui.color.QuackColor
+import team.duckie.quackquack.material.QuackColor
 
 @Composable
 internal fun DetailScreen(
@@ -148,7 +148,7 @@ internal fun ExamDetailScreen(
             DetailBottomLayout(
                 modifier = Modifier
                     .layoutId(DetailScreenBottomBarLayoutId)
-                    .background(color = QuackColor.White.composeColor),
+                    .background(color = QuackColor.White.value),
                 state = state,
                 onHeartClick = viewModel::heartExam,
                 onChallengeClick = viewModel::startExam,

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
@@ -154,7 +154,7 @@ private fun RankingContent(
                                 DpSize(44.dp, 44.dp),
                             )
                             .clip(SquircleShape),
-                        contentScale = ContentScale.FillBounds
+                        contentScale = ContentScale.FillBounds,
                     )
                 } ?: QuackImage(
                     src = QuackIcon.Profile.drawableId,
@@ -163,7 +163,7 @@ private fun RankingContent(
                             DpSize(44.dp, 44.dp),
                         )
                         .clip(SquircleShape),
-                    contentScale = ContentScale.FillBounds
+                    contentScale = ContentScale.FillBounds,
                 )
 
                 Spacer(space = 8.dp)

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
@@ -13,30 +13,31 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import team.duckie.app.android.common.compose.ui.Spacer
+import team.duckie.app.android.common.kotlin.fastForEachIndexed
 import team.duckie.app.android.domain.quiz.model.QuizInfo
 import team.duckie.app.android.feature.detail.R
 import team.duckie.app.android.feature.detail.common.DetailContentLayout
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.compose.ui.icon.v1.Crown
-import team.duckie.app.android.common.compose.ui.Spacer
-import team.duckie.app.android.common.kotlin.fastForEachIndexed
-import team.duckie.quackquack.ui.color.QuackColor
-import team.duckie.quackquack.ui.component.QuackBody2
-import team.duckie.quackquack.ui.component.QuackImage
-import team.duckie.quackquack.ui.component.QuackSubtitle
-import team.duckie.quackquack.ui.component.QuackTitle2
-import team.duckie.quackquack.ui.icon.QuackIcon
-import team.duckie.quackquack.ui.modifier.quackClickable
-import team.duckie.quackquack.ui.shape.SquircleShape
-import team.duckie.quackquack.ui.util.DpSize
+import team.duckie.quackquack.material.QuackColor
+import team.duckie.quackquack.material.QuackIcon
+import team.duckie.quackquack.material.QuackTypography
+import team.duckie.quackquack.material.quackClickable
+import team.duckie.quackquack.material.shape.SquircleShape
+import team.duckie.quackquack.ui.QuackImage
+import team.duckie.quackquack.ui.QuackText
 
 @Composable
 internal fun QuizDetailContentLayout(
@@ -76,11 +77,14 @@ private fun RankingSection(
             .fillMaxSize()
             .padding(top = 28.dp),
     ) {
-        QuackTitle2(
+        QuackText(
             modifier = Modifier.padding(horizontal = 16.dp),
             text = stringResource(id = R.string.quiz_ranking_title, state.mainTagNames),
+            typography = QuackTypography.Title2,
         )
+
         Spacer(space = 8.dp)
+
         quizRankings.fastForEachIndexed { index, item ->
             RankingContent(
                 rank = index + 1,
@@ -107,9 +111,9 @@ private fun RankingContent(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .quackClickable {
-                    onClick(user.id)
-                },
+                .quackClickable(
+                    onClick = { onClick(user.id) },
+                ),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -128,27 +132,48 @@ private fun RankingContent(
                 ) {
                     if (rank == 1) {
                         QuackImage(
-                            src = QuackIcon.Crown,
-                            size = DpSize(all = 12.dp),
+                            src = team.duckie.app.android.common.compose.R.drawable.ic_crown_12,
+                            modifier = Modifier.size(
+                                DpSize(12.dp, 12.dp),
+                            ),
                         )
                     }
-                    QuackSubtitle(
+                    QuackText(
                         text = "${rank}등",
-                        color = textColor,
+                        typography = QuackTypography.Subtitle.change(textColor),
                     )
                 }
+
                 Spacer(space = 12.dp)
-                QuackImage(
-                    src = user.profileImageUrl,
-                    shape = SquircleShape,
-                    size = DpSize(all = 44.dp),
+
+                user.profileImageUrl?.let {
+                    QuackImage(
+                        src = it,
+                        modifier = Modifier
+                            .size(
+                                DpSize(44.dp, 44.dp),
+                            )
+                            .clip(SquircleShape),
+                        contentScale = ContentScale.FillBounds
+                    )
+                } ?: QuackImage(
+                    src = QuackIcon.Profile.drawableId,
+                    modifier = Modifier
+                        .size(
+                            DpSize(44.dp, 44.dp),
+                        )
+                        .clip(SquircleShape),
+                    contentScale = ContentScale.FillBounds
                 )
+
                 Spacer(space = 8.dp)
-                QuackTitle2(
+
+                QuackText(
                     text = user.nickname,
-                    color = textColor,
+                    typography = QuackTypography.Title2.change(textColor),
                 )
             }
+
             Row(
                 modifier = Modifier
                     .padding(vertical = 12.dp)
@@ -156,11 +181,21 @@ private fun RankingContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                QuackBody2(text = "${correctProblemCount}덕")
-                QuackBody2(text = "|")
-                QuackBody2(text = "${time}초")
+                QuackText(
+                    text = "${correctProblemCount}덕",
+                    typography = QuackTypography.Body2,
+                )
+                QuackText(
+                    text = "|",
+                    typography = QuackTypography.Body2,
+                )
+                QuackText(
+                    text = "${time}초",
+                    typography = QuackTypography.Body2,
+                )
             }
         }
-        Divider(color = QuackColor.Gray4.composeColor)
+
+        Divider(color = QuackColor.Gray4.value)
     }
 }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/viewmodel/state/DetailState.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/viewmodel/state/DetailState.kt
@@ -5,11 +5,8 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
-@file:OptIn(ExperimentalMaterialApi::class)
-
 package team.duckie.app.android.feature.detail.viewmodel.state
 
-import androidx.compose.material.ExperimentalMaterialApi
 import team.duckie.app.android.domain.exam.model.Exam
 import team.duckie.app.android.domain.recommendation.model.ExamType
 import team.duckie.app.android.domain.tag.model.Tag

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/ranking/ExamineeSection.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/ranking/ExamineeSection.kt
@@ -26,12 +26,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemsIndexed
+import team.duckie.app.android.common.compose.itemsIndexedPagingKey
+import team.duckie.app.android.common.compose.ui.Spacer
+import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
+import team.duckie.app.android.common.compose.ui.skeleton
 import team.duckie.app.android.domain.user.model.User
 import team.duckie.app.android.feature.home.viewmodel.ranking.RankingViewModel
-import team.duckie.app.android.common.compose.ui.Spacer
-import team.duckie.app.android.common.compose.ui.skeleton
-import team.duckie.app.android.common.compose.itemsIndexedPagingKey
-import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody2
 import team.duckie.quackquack.ui.component.QuackImage


### PR DESCRIPTION
## 설명
resolve [시험 상세 서브태그 end쪽에 패딩 없애주기](https://www.notion.so/duckie-team/end-bc2d5450224c407792159260a214fa14?pvs=4)

- 이제 시험 상세 서브태그 우측에 패딩이 없어졌습니다.
- 상세 화면에 quack v2 를 적용하였습니다 (v1 은 제거했습니다)

## 기타
- 변환해보니 빨간줄이 엄청 많네요. (import 및 QuackImage 적용 시 등등)
- QuackCircleTag 는 매치되는 내용을 한참 찾았네요. (style = `QuackTagStyle.Outlined` 을 적용하니 되었습니다)
- common.compose 에서 quack v1 을 쓰고 있어서 그런지 
  ./gradlew build 에서는 잡히지만, IDE 에선 안 보이는 컴파일 에러도 있네요 (빨간줄이 안보입니다)
  ```
  Cannot access class 'kotlinx.collections.immutable.ImmutableList'. Check your module classpath for missing or conflicting dependencies
  ```
  이건 추후 quack v1 을 걷어내면서 해소될 것 같네요
