### PR TITLE
총 문제수와, 응시자 수 덕력고사에서 보이도록 변경

### DIFF
--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/UserFollowingLayout.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/UserFollowingLayout.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import team.duckie.app.android.common.compose.R
 import team.duckie.app.android.common.compose.asLoose
 import team.duckie.app.android.common.compose.centerVertical
+import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
 import team.duckie.app.android.common.kotlin.fastFirstOrNull
 import team.duckie.app.android.common.kotlin.npe
 import team.duckie.quackquack.ui.color.QuackColor

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/icon/v1/DuckieIcon.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/icon/v1/DuckieIcon.kt
@@ -5,7 +5,7 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 
-package team.duckie.app.android.common.compose.ui
+package team.duckie.app.android.common.compose.ui.icon.v1
 
 import team.duckie.app.android.common.compose.R
 import team.duckie.quackquack.ui.icon.QuackIcon

--- a/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/icon/v2/DuckieIcon.kt
+++ b/common/compose/src/main/kotlin/team/duckie/app/android/common/compose/ui/icon/v2/DuckieIcon.kt
@@ -1,0 +1,13 @@
+/*
+ * Designed and developed by Duckie Team, 2022
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
+ */
+
+package team.duckie.app.android.common.compose.ui.icon.v2
+
+import team.duckie.app.android.common.compose.R
+import team.duckie.quackquack.material.QuackIcon
+
+val QuackIcon.Companion.Paper get() = QuackIcon(R.drawable.ic_paper_20)

--- a/common/compose/src/main/res/drawable/ic_paper_20.xml
+++ b/common/compose/src/main/res/drawable/ic_paper_20.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M5.2,16V4H11.371L14.8,7.333V16H5.2Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#222222"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M10.686,4V8H14.8"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#222222"/>
+</vector>

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/mapper/mapper.kt
@@ -76,6 +76,7 @@ internal fun ExamData.toDomain() = Exam(
     timer = timer,
     requirementPlaceholder = requirementPlaceholder,
     requirementQuestion = requirementQuestion,
+    problemCount = problemCount,
 )
 
 internal fun ExamsData.toDomain() = exams?.fastMap { examData -> examData.toDomain() }

--- a/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamData.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/exam/model/ExamData.kt
@@ -82,6 +82,9 @@ internal data class ExamData(
 
     @field:JsonProperty("requirementPlaceholder")
     val requirementPlaceholder: String? = null,
+
+    @field:JsonProperty("problemCount")
+    val problemCount: Int? = null,
 )
 
 internal data class ExamsData(

--- a/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
+++ b/data/src/test/kotlin/team/duckie/app/android/data/dummy/ExamDummyResponse.kt
@@ -64,7 +64,8 @@ object ExamDummyResponse {
             "perfectScoreImageUrl": null,
             "timer": 0,
             "requirementQuestion": "",
-            "requirementPlaceholder": ""
+            "requirementPlaceholder": "",
+            "problemCount": null,
         }
     """
 
@@ -112,5 +113,6 @@ object ExamDummyResponse {
         timer = 0,
         requirementQuestion = "",
         requirementPlaceholder = "",
+        problemCount = null,
     )
 }

--- a/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
+++ b/domain/src/main/kotlin/team/duckie/app/android/domain/exam/model/Exam.kt
@@ -42,6 +42,7 @@ data class Exam(
     val timer: Int?,
     val requirementQuestion: String?,
     val requirementPlaceholder: String?,
+    val problemCount: Int?,
 ) {
     companion object {
         /*
@@ -72,6 +73,7 @@ data class Exam(
             timer = null,
             requirementQuestion = null,
             requirementPlaceholder = null,
+            problemCount = null,
         )
     }
 }

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
         libs.compose.ui.material, // needs for Scaffold
         libs.compose.lifecycle.runtime,
         libs.quack.ui.components,
+        libs.quack.v2.ui,
         libs.compose.ui.coil,
     )
 }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import team.duckie.app.android.feature.detail.R
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.compose.ui.DefaultProfile
+import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
 import team.duckie.app.android.common.compose.GetHeightRatioW328H240
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackBody2
@@ -132,9 +132,6 @@ internal fun DetailContentLayout(
         // 구분선
         QuackDivider()
         additionalInfo()
-        // 점수 분포도 Layout
-        // TODO(riflockle7): 기획 정해질 시 활성화
-        // DetailScoreDistributionLayout(state)
     }
 }
 

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/exam/ExamDetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/exam/ExamDetailScreen.kt
@@ -9,11 +9,27 @@
 
 package team.duckie.app.android.feature.detail.screen.exam
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.persistentListOf
+import team.duckie.app.android.common.compose.ui.icon.v2.Paper
+import team.duckie.app.android.common.kotlin.AllowMagicNumber
+import team.duckie.app.android.feature.detail.R
 import team.duckie.app.android.feature.detail.common.DetailContentLayout
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.kotlin.AllowMagicNumber
+import team.duckie.quackquack.material.QuackIcon
+import team.duckie.quackquack.ui.QuackIcon
+import team.duckie.quackquack.ui.sugar.QuackBody2
+import team.duckie.quackquack.ui.sugar.QuackTitle2
 
 @Composable
 internal fun ExamDetailContentLayout(
@@ -24,6 +40,9 @@ internal fun ExamDetailContentLayout(
     followButtonClick: () -> Unit,
     profileClick: (Int) -> Unit,
 ) {
+    val totalExamCount = remember { (state.exam.problems ?: persistentListOf()).size }
+    val solvedCount = remember { state.exam.solvedCount ?: 0 }
+
     DetailContentLayout(
         modifier = modifier,
         state = state,
@@ -32,7 +51,50 @@ internal fun ExamDetailContentLayout(
         followButtonClick = followButtonClick,
         profileClick = profileClick,
         additionalInfo = {
-            // TODO(EvergreenTree97) 시험 정보 추후 삽입
+            MetadataSection(
+                totalExamCount = totalExamCount,
+                totalExaminee = solvedCount,
+            )
         },
     )
+}
+
+@Composable
+private fun MetadataSection(
+    totalExamCount: Int,
+    totalExaminee: Int,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .padding(top = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        QuackTitle2(text = stringResource(id = R.string.detail_exam_info))
+        IconText(
+            icon = QuackIcon.Paper,
+            text = stringResource(id = R.string.detail_total_exam_count, totalExamCount),
+        )
+        IconText(
+            icon = QuackIcon.Profile,
+            text = stringResource(id = R.string.detail_total_examinee, totalExaminee),
+        )
+    }
+}
+
+@Composable
+private fun IconText(
+    modifier: Modifier = Modifier,
+    icon: QuackIcon,
+    text: String,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        QuackIcon(icon = icon)
+        QuackBody2(text = text)
+    }
 }

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/exam/ExamDetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/exam/ExamDetailScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.persistentListOf
 import team.duckie.app.android.common.compose.ui.icon.v2.Paper
 import team.duckie.app.android.common.kotlin.AllowMagicNumber
 import team.duckie.app.android.feature.detail.R
@@ -40,7 +39,7 @@ internal fun ExamDetailContentLayout(
     followButtonClick: () -> Unit,
     profileClick: (Int) -> Unit,
 ) {
-    val totalExamCount = remember { (state.exam.problems ?: persistentListOf()).size }
+    val totalExamCount = remember { state.exam.problemCount ?: 0 }
     val solvedCount = remember { state.exam.solvedCount ?: 0 }
 
     DetailContentLayout(

--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/screen/quiz/QuizDetailScreen.kt
@@ -25,7 +25,7 @@ import team.duckie.app.android.domain.quiz.model.QuizInfo
 import team.duckie.app.android.feature.detail.R
 import team.duckie.app.android.feature.detail.common.DetailContentLayout
 import team.duckie.app.android.feature.detail.viewmodel.state.DetailState
-import team.duckie.app.android.common.compose.ui.Crown
+import team.duckie.app.android.common.compose.ui.icon.v1.Crown
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.kotlin.fastForEachIndexed
 import team.duckie.quackquack.ui.color.QuackColor

--- a/feature/detail/src/main/res/values/strings.xml
+++ b/feature/detail/src/main/res/values/strings.xml
@@ -18,4 +18,7 @@
     <string name="report">신고하기</string>
     <string name="check">확인</string>
     <string name="quiz_ranking_title">%s 덕퀴즈 랭킹</string>
+    <string name="detail_exam_info">시험정보</string>
+    <string name="detail_total_exam_count">총 문제 수 : %d개</string>
+    <string name="detail_total_examinee">응시자 : %d명</string>
 </resources>

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/component/HomeTopAppBar.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/component/HomeTopAppBar.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toImmutableList
 import okhttp3.internal.immutableListOf
 import team.duckie.app.android.feature.home.R
-import team.duckie.app.android.common.compose.ui.Create
+import team.duckie.app.android.common.compose.ui.icon.v1.Create
 import team.duckie.app.android.common.compose.ui.TextTabLayout
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackImage

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/ranking/RankingScreen.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/ranking/RankingScreen.kt
@@ -50,7 +50,7 @@ import team.duckie.app.android.feature.home.component.HomeIconSize
 import team.duckie.app.android.feature.home.constants.RankingPage
 import team.duckie.app.android.feature.home.viewmodel.ranking.RankingSideEffect
 import team.duckie.app.android.feature.home.viewmodel.ranking.RankingViewModel
-import team.duckie.app.android.common.compose.ui.Create
+import team.duckie.app.android.common.compose.ui.icon.v1.Create
 import team.duckie.app.android.common.compose.ui.ErrorScreen
 import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableBottomSheetDialog
 import team.duckie.app.android.common.kotlin.AllowMagicNumber

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/MyProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/MyProfileScreen.kt
@@ -30,9 +30,9 @@ import team.duckie.app.android.feature.profile.screen.section.EditSection
 import team.duckie.app.android.feature.profile.screen.section.ExamSection
 import team.duckie.app.android.feature.profile.screen.section.FavoriteTagSection
 import team.duckie.app.android.feature.profile.viewmodel.state.mapper.toUiModel
-import team.duckie.app.android.common.compose.ui.Create
+import team.duckie.app.android.common.compose.ui.icon.v1.Create
 import team.duckie.app.android.common.compose.ui.DuckTestCoverItem
-import team.duckie.app.android.common.compose.ui.Notice
+import team.duckie.app.android.common.compose.ui.icon.v1.Notice
 import team.duckie.app.android.common.kotlin.FriendsType
 import team.duckie.quackquack.ui.component.QuackImage
 import team.duckie.quackquack.ui.component.QuackLargeButton

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/OtherProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/OtherProfileScreen.kt
@@ -37,7 +37,7 @@ import team.duckie.app.android.feature.profile.screen.section.FollowSection
 import team.duckie.app.android.feature.profile.viewmodel.ProfileViewModel
 import team.duckie.app.android.feature.profile.viewmodel.state.mapper.toUiModel
 import team.duckie.app.android.common.compose.ui.BackPressedHeadLineTopAppBar
-import team.duckie.app.android.common.compose.ui.Create
+import team.duckie.app.android.common.compose.ui.icon.v1.Create
 import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableType
 import team.duckie.app.android.common.compose.ui.dialog.IgnoreCheckDialog
 import team.duckie.app.android.common.compose.ui.dialog.DuckieSelectableBottomSheetDialog

--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/section/ProfileSection.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/screen/section/ProfileSection.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import team.duckie.app.android.feature.profile.R
-import team.duckie.app.android.common.compose.ui.DefaultProfile
+import team.duckie.app.android.common.compose.ui.icon.v1.DefaultProfile
 import team.duckie.app.android.common.compose.ui.Divider
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.compose.ui.skeleton

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/common/TopBar.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/common/TopBar.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import team.duckie.app.android.common.compose.ui.Clock
+import team.duckie.app.android.common.compose.ui.icon.v1.Clock
 import team.duckie.app.android.common.compose.ui.LinearProgressBar
 import team.duckie.quackquack.ui.color.QuackColor
 import team.duckie.quackquack.ui.component.QuackImage


### PR DESCRIPTION
## Issue

- https://www.notion.so/duckie-team/93419287906a4bdbb083c851cc05c332?pvs=4

## Overview (Required)
- 총 문제수와, 응시자 수가 이제 덕력고사에서 출력됩니다
 
## Screenshot
![image](https://github.com/duckie-team/duckie-android/assets/70064912/5ae7f41f-e529-4fb6-8c84-1d0103c4f6c9)

