### PR TITLE
앱 업데이트 알림이 나오지 않는 문제 해결

### DIFF
--- a/common/compose/src/main/res/values/strings.xml
+++ b/common/compose/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
 
 <resources>
     <!--riflockle7: 분명 더 잘 가져올 수 있는 방법이 있을꺼라 생각 추후 개선 필요-->
-    <string name="app_package_name">team.duckie.app.android(</string>
+    <string name="app_package_name">team.duckie.app.android</string>
 
     <string name="default_error">화면을 불러오지 못했어요 :(</string>
     <string name="default_network_error_title">네트워크 연결이 불안정해요 :(</string>

--- a/common/kotlin/src/main/kotlin/team/duckie/app/android/common/kotlin/exception/constant.kt
+++ b/common/kotlin/src/main/kotlin/team/duckie/app/android/common/kotlin/exception/constant.kt
@@ -62,6 +62,9 @@ val Throwable.isUserNotFound: Boolean
 val Throwable.isTokenExpired: Boolean
     get() = (this as? DuckieResponseException)?.code == ExceptionCode.TOKEN_EXPIRED
 
+val Throwable.isAppUpgradeRequire: Boolean
+    get() = (this as? DuckieResponseException)?.code == ExceptionCode.APP_UPGRADE_REQUIRED
+
 /** 앱 내에서 로그인이 필요한 [코드값][DuckieException.code]인 경우인지 체크한다. */
 val Throwable.isLoginRequireCode: Boolean
     get() = (this as? DuckieException)?.code in persistentListOf(
@@ -75,6 +78,3 @@ val Throwable.isKakaoTalkNotConnectedAccount: Boolean
 
 val Throwable.isKakaoTalkNotSupportAccount: Boolean
     get() = (this as? DuckieThirdPartyException)?.code == ExceptionCode.KAKAOTALK_NOT_SUPPORT_EXCEPTION
-
-val Throwable.isAppUpgradeRequire: Boolean
-    get() = (this as? DuckieThirdPartyException)?.code == ExceptionCode.APP_UPGRADE_REQUIRED


### PR DESCRIPTION
## Issue

- https://www.notion.so/duckie-team/4e780be0a8574c2ea8e2cd24c79cf36e?pvs=4

## Overview (Required)

- 앱 업데이트 알림 예외가 ThirdPartyException으로 되어있어 변경하였습니다
- 앱 패키지 네임이 잘못되어 있던 문제를 해결하였습니다.