### PR TITLE
덕퀴즈에서 뒤로가기했을 때 다이얼로그없이 바로 이탈됨

### DIFF
--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
@@ -13,6 +13,7 @@
 
 package team.duckie.app.android.feature.solve.problem.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
@@ -98,6 +99,10 @@ internal fun QuizScreen(
                 totalPage - 1,
             )
         }
+    }
+
+    BackHandler {
+        examExitDialogVisible = true
     }
 
     DuckieDialog(

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -9,6 +9,7 @@
 
 package team.duckie.app.android.feature.solve.problem.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
@@ -77,6 +78,10 @@ internal fun SolveProblemScreen(
                 init = { InputAnswer() },
             ),
         )
+    }
+
+    BackHandler {
+        examExitDialogVisible = true
     }
 
     // 시험 종료 다이얼로그


### PR DESCRIPTION
## Issue

- https://www.notion.so/duckie-team/c5c6eb083f3e4aa6bb5552c510873078?pvs=4

## Overview (Required)
- Backpress시 dialogVisible true로 위임하였음
