### PR TITLE
fix: change report clickable long to short

### DIFF
--- a/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
+++ b/feature/detail/src/main/kotlin/team/duckie/app/android/feature/detail/common/DetailContent.kt
@@ -103,9 +103,9 @@ internal fun DetailContentLayout(
                 modifier = Modifier
                     .width(24.dp)
                     .height(24.dp)
-                    .quackClickable {
-                        moreButtonClick()
-                    },
+                    .quackClickable(
+                        onClick = moreButtonClick,
+                    ),
             )
         }
 


### PR DESCRIPTION
## Issue

- [신고하기에서 미트볼을 오래 클릭해야 신고하기가 나옴](https://www.notion.so/duckie-team/c2429d82ca6d403c9b82355af02b82a4?pvs=4)

## Overview (Required)

- quackClickable이 휴먼 에러를 발생시킬 수 있어서 [이슈화](https://github.com/duckie-team/quack-quack-android/issues/764) 함
- 신고하기 람다를 onLongClick() 에서 onClick()으로 변경함
