### PR TITLE
주관식 글자 제한 수 맞지 않는 문제 해결

### DIFF
--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/shortanswer/ShortAnswerForm.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/shortanswer/ShortAnswerForm.kt
@@ -76,7 +76,7 @@ internal fun ShortAnswerForm(
                 .background(Color.Transparent),
             value = myAnswer.value,
             onValueChange = {
-                if (it.length <= answer.length) {
+                if (it.length <= answer.replace(" ", "").length) {
                     myAnswer.value = it
                     onTextChanged(it)
                 }


### PR DESCRIPTION
## Issue

- 주관식 리디자인 버전에서 글자 제한수가 띄어쓰기가 포함된 String으로 걸려있는 것을 해결했습니다

## Overview (Required)

- replace()로 도배를 해놨는데 Util로 빼서 관리해도 좋을듯..

## Screenshot

| Before | After |
| :--: | :--: |
| <img src="" width="300" /> | <img src="" width="300" /> |
