### PR TITLE
fix: change http log type error to info

### DIFF
--- a/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
+++ b/data/src/main/kotlin/team/duckie/app/android/data/_datasource/AuthorizationHeaderClient.kt
@@ -108,7 +108,7 @@ private object AuthorizationHeaderClient {
         install(plugin = Logging) {
             logger = object : Logger {
                 override fun log(message: String) {
-                    Timber.e(message)
+                    Timber.i(message)
                 }
             }
             level = LogLevel.ALL


### PR DESCRIPTION
## Overview (Required)

- Http 로그가 error로 표시되어, 실제 오류가 로그가 구별이 안 감
- Http 로그를 Timber.i 로 표시하도록 수정 함
