### PR TITLE
fix: 시험 검색 화면에서 문구 padding 잘못된 버그 수정

### DIFF
--- a/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/screen/SearchResultScreen.kt
+++ b/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/screen/SearchResultScreen.kt
@@ -72,7 +72,6 @@ internal fun SearchResultScreen(
         )
         when (state.tagSelectedTab) {
             SearchResultStep.DuckExam -> {
-                Spacer(space = 20.dp)
                 SearchResultForExam(
                     searchExams = searchExams,
                     navigateDetail = navigateDetail,
@@ -106,7 +105,7 @@ private fun SearchResultForUser(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 68.dp),
+                .padding(top = 60.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             QuackHeadLine1(
@@ -149,7 +148,7 @@ private fun SearchResultForExam(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 68.dp),
+                .padding(top = 60.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             QuackHeadLine1(


### PR DESCRIPTION
- 검색 화면에서 덕력고사 시험 없음과, 사용자 없음 문구가 padding이 같아야 하는데, 다르게 나오는 문제 수정하였음