### PR TITLE
키보드 올라올 때 텍스트필드 잘리지 않도록, 텍스트필드 크기를 사진 크기 조절에 적용

### DIFF
--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/AnswerSection.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/AnswerSection.kt
@@ -92,13 +92,8 @@ internal fun ColumnScope.AnswerSection(
 
         is Answer.Short -> {
             ShortAnswerForm(
-                modifier = Modifier.padding(paddingValues = HorizontalPadding),
                 answer = answer.correctAnswer,
-                text = inputAnswers[pageIndex].answer,
                 onTextChanged = { inputText ->
-                    updateInputAnswers(pageIndex, InputAnswer(0, inputText))
-                },
-                onDone = { inputText ->
                     updateInputAnswers(pageIndex, InputAnswer(0, inputText))
                 },
                 requestFocus = requestFocus,

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/shortanswer/ShortAnswerForm.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/answer/shortanswer/ShortAnswerForm.kt
@@ -5,7 +5,6 @@
  * Please see full license: https://github.com/duckie-team/duckie-android/blob/develop/LICENSE
  */
 @file:OptIn(ExperimentalComposeUiApi::class)
-@file:Suppress("unused")
 
 package team.duckie.app.android.feature.solve.problem.answer.shortanswer
 
@@ -20,8 +19,10 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
@@ -48,10 +49,8 @@ import team.duckie.quackquack.ui.component.QuackBody1
 @Composable
 internal fun ShortAnswerForm(
     modifier: Modifier = Modifier,
-    text: String,
     onTextChanged: (String) -> Unit,
     answer: String,
-    onDone: (String) -> Unit,
     keyboardController: SoftwareKeyboardController?,
     requestFocus: Boolean,
 ) {
@@ -66,9 +65,9 @@ internal fun ShortAnswerForm(
         }
     }
 
-    Box {
+    Box(modifier) {
         TextField(
-            modifier = modifier
+            modifier = Modifier
                 .focusRequester(focusRequester)
                 .onFocusChanged {
                     hasFocus.value = it.hasFocus
@@ -129,8 +128,8 @@ private fun ShortAnswerOneTextForm(
     Column {
         Box(
             modifier = Modifier
-                .width(30.dp)
-                .height(40.dp)
+                .widthIn(30.dp)
+                .heightIn(40.dp)
                 .clip(RoundedCornerShape(4.dp))
                 .quackBorder(
                     border = QuackBorder(color = if (isFocused) QuackColor.DuckieOrange else QuackColor.Gray3),

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/common/FlexibleSubjectiveQuestionSection.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/common/FlexibleSubjectiveQuestionSection.kt
@@ -9,7 +9,6 @@
 
 package team.duckie.app.android.feature.solve.problem.common
 
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -22,14 +21,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.ImmutableList
 import team.duckie.app.android.common.compose.ui.Spacer
 import team.duckie.app.android.common.kotlin.AllowMagicNumber
 import team.duckie.app.android.domain.exam.model.Problem
@@ -49,7 +53,12 @@ private fun getFlexibleImageHeight(): Dp {
     return ((configuration.screenWidthDp / 4) * 3).dp
 }
 
-private val FlexiableImageMargin: Dp = 96.dp
+private object TextFieldMargin {
+    val Top = 24.dp
+    val Bottom = 16.dp
+    val Vertical get() = Top + Bottom
+}
+
 
 /**
  * 키보드 상태에 따라서 이미지의 높이가 유동적으로 변하는 주관식 문제를 위한 섹션
@@ -58,13 +67,14 @@ private val FlexiableImageMargin: Dp = 96.dp
 fun FlexibleSubjectiveQuestionSection(
     problem: Problem,
     pageIndex: Int,
-    inputAnswers: ImmutableList<InputAnswer>,
     updateInputAnswers: (page: Int, inputAnswer: InputAnswer) -> Unit,
     requestFocus: Boolean,
     keyboardController: SoftwareKeyboardController?,
 ) {
+    val density = LocalDensity.current
     val question = problem.question as Question.Image
     val flexibleImageHeight = getFlexibleImageHeight()
+    var textFieldHeight by remember { mutableStateOf(Dp.Unspecified) }
 
     Column(
         modifier = Modifier
@@ -83,15 +93,17 @@ fun FlexibleSubjectiveQuestionSection(
         )
         Spacer(space = 12.dp)
         BoxWithConstraints {
-            val actualWidth = animateDpAsState(
-                targetValue = if (maxHeight >= flexibleImageHeight) flexibleImageHeight else maxHeight - FlexiableImageMargin,
-                label = "",
-            )
+            val actualHeight =
+                if (maxHeight - textFieldHeight - TextFieldMargin.Vertical >= flexibleImageHeight) {
+                    flexibleImageHeight
+                } else {
+                    maxHeight - textFieldHeight - TextFieldMargin.Vertical
+                }
 
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(max = actualWidth.value)
+                    .heightIn(max = actualHeight)
                     .padding(horizontal = 16.dp)
                     .background(
                         color = QuackColor.Black.value,
@@ -105,21 +117,20 @@ fun FlexibleSubjectiveQuestionSection(
                 )
             }
         }
-
-        Spacer(space = 24.dp)
+        Spacer(space = TextFieldMargin.Top)
         ShortAnswerForm(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            answer = problem.correctAnswer ?: "",
-            text = inputAnswers[pageIndex].answer,
-            onTextChanged = { inputText ->
-                updateInputAnswers(pageIndex, InputAnswer(0, inputText))
+            modifier = Modifier.onSizeChanged {
+                with(density) {
+                    textFieldHeight = it.height.toDp()
+                }
             },
-            onDone = { inputText ->
+            answer = problem.correctAnswer ?: "",
+            onTextChanged = { inputText ->
                 updateInputAnswers(pageIndex, InputAnswer(0, inputText))
             },
             requestFocus = requestFocus,
             keyboardController = keyboardController,
         )
-        Spacer(space = 16.dp)
+        Spacer(space = TextFieldMargin.Bottom)
     }
 }

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/QuizScreen.kt
@@ -202,7 +202,6 @@ private fun ContentSection(
             problem.isSubjective() && problem.question.isImage() -> FlexibleSubjectiveQuestionSection(
                 problem = problem,
                 pageIndex = pageIndex,
-                inputAnswers = inputAnswers,
                 updateInputAnswers = updateInputAnswers,
                 requestFocus = requestFocus,
                 keyboardController = keyboardController,

--- a/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
+++ b/feature/solve-problem/src/main/kotlin/team/duckie/app/android/feature/solve/problem/screen/SolveProblemScreen.kt
@@ -198,7 +198,6 @@ private fun ContentSection(
             problem.isSubjective() && problem.question.isImage() -> FlexibleSubjectiveQuestionSection(
                 problem = problem,
                 pageIndex = pageIndex,
-                inputAnswers = inputAnswers,
                 updateInputAnswers = updateInputAnswers,
                 requestFocus = requestFocus,
                 keyboardController = keyboardController,


### PR DESCRIPTION
## Issue

- https://duckie-team.slack.com/archives/C059X8287FD/p1689492174303079
