### PR TITLE
feat: 팔로잉 페이지 프로필로 이동하기 구현

### DIFF
--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/MainActivity.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/MainActivity.kt
@@ -222,6 +222,15 @@ class MainActivity : BaseActivity() {
             is MainSideEffect.CopyExamIdDynamicLink -> {
                 DynamicLinkHelper.createAndShareLink(this, sideEffect.examId)
             }
+
+            is MainSideEffect.NavigateToProfile -> {
+                profileNavigator.navigateFrom(
+                    activity = this,
+                    intentBuilder = {
+                        putExtra(Extras.UserId, sideEffect.userId)
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/MainScreen.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/MainScreen.kt
@@ -139,6 +139,7 @@ internal fun MainScreen(
                             navigateToCreateProblem = {
                                 mainViewModel.navigateToCreateProblem()
                             },
+                            navigateToProfile = mainViewModel::navigateToProfile,
                             setTargetExamId = { examId ->
                                 mainViewModel.setTargetExamId(examId)
                             },

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/home/HomeRecommendFollowingExamScreen.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/home/HomeRecommendFollowingExamScreen.kt
@@ -63,7 +63,7 @@ import team.duckie.quackquack.ui.util.DpSize
 internal const val ThumbnailRatio = 4f / 3f
 
 private val HomeProfileSize: DpSize = DpSize(
-    all = 24.dp,
+    all = 32.dp,
 )
 
 @Composable
@@ -74,6 +74,7 @@ internal fun HomeRecommendFollowingExamScreen(
     state: HomeState,
     navigateToCreateProblem: () -> Unit,
     navigateToHomeDetail: (Int) -> Unit,
+    navigateToProfile: (Int) -> Unit,
 ) {
     val followingExam =
         vm.followingExam.collectAndHandleState(vm::handleLoadRecommendFollowingState)
@@ -106,6 +107,7 @@ internal fun HomeRecommendFollowingExamScreen(
             followingExam = followingExam,
             navigateToCreateProblem = navigateToCreateProblem,
             navigateToHomeDetail = navigateToHomeDetail,
+            navigateToProfile = navigateToProfile,
         )
     }
 }
@@ -119,6 +121,7 @@ private fun HomeRecommendFollowingSuccessScreen(
     followingExam: LazyPagingItems<HomeState.RecommendExam>,
     navigateToCreateProblem: () -> Unit,
     navigateToHomeDetail: (Int) -> Unit,
+    navigateToProfile: (Int) -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -149,10 +152,10 @@ private fun HomeRecommendFollowingSuccessScreen(
                     title = maker?.title ?: "",
                     tier = maker?.owner?.tier ?: "",
                     favoriteTag = maker?.owner?.favoriteTag ?: "",
-                    onClickUserProfile = {
-                        // TODO(limsaehyun): 마이페이지로 이동
+                    onUserProfileClick = {
+                        navigateToProfile(maker?.owner?.userId ?: 0)
                     },
-                    onClickTestCover = {
+                    onTestClick = {
                         navigateToHomeDetail(maker?.examId ?: 0)
                     },
                     cover = maker?.coverUrl ?: "",
@@ -177,9 +180,9 @@ private fun TestCoverWithMaker(
     name: String,
     tier: String,
     favoriteTag: String,
-    onClickTestCover: () -> Unit,
-    onClickUserProfile: () -> Unit,
+    onTestClick: () -> Unit,
     isLoading: Boolean,
+    onUserProfileClick: () -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -190,7 +193,7 @@ private fun TestCoverWithMaker(
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .quackClickable {
-                    onClickTestCover()
+                    onTestClick()
                 }
                 .skeleton(isLoading),
             model = cover,
@@ -204,8 +207,9 @@ private fun TestCoverWithMaker(
             name = name,
             tier = tier,
             favoriteTag = favoriteTag,
-            onClickUserProfile = onClickUserProfile,
             isLoading = isLoading,
+            onUserProfileClick = onUserProfileClick,
+            onLayoutClick = onTestClick,
         )
     }
 }
@@ -219,10 +223,15 @@ private fun TestMakerLayout(
     tier: String,
     favoriteTag: String,
     isLoading: Boolean,
-    onClickUserProfile: (() -> Unit)? = null,
+    onLayoutClick: () -> Unit,
+    onUserProfileClick: () -> Unit,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.quackClickable(
+            rippleEnabled = false,
+        ) {
+            onLayoutClick()
+        },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         QuackImage(
@@ -230,11 +239,7 @@ private fun TestMakerLayout(
             src = profile,
             size = HomeProfileSize,
             shape = SquircleShape,
-            onClick = {
-                if (onClickUserProfile != null) {
-                    onClickUserProfile()
-                }
-            },
+            onClick = onUserProfileClick,
         )
         Column(modifier = Modifier.padding(start = 8.dp)) {
             QuackSubtitle2(

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/screen/home/HomeScreen.kt
@@ -47,6 +47,7 @@ internal fun HomeScreen(
     navigateToCreateProblem: () -> Unit,
     navigateToHomeDetail: (Int) -> Unit,
     navigateToSearch: (String) -> Unit,
+    navigateToProfile: (Int) -> Unit,
 ) {
     val state = vm.collectAsState().value
     val bottomSheetDialogState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
@@ -113,6 +114,7 @@ internal fun HomeScreen(
                             state = state,
                             navigateToHomeDetail = navigateToHomeDetail,
                             navigateToCreateProblem = navigateToCreateProblem,
+                            navigateToProfile = navigateToProfile,
                         )
                     } else {
                         HomeRecommendFollowingScreen(

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/MainSideEffect.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/MainSideEffect.kt
@@ -41,6 +41,8 @@ internal sealed class MainSideEffect {
 
     object NavigateToNotification : MainSideEffect()
 
+    data class NavigateToProfile(val userId: Int) : MainSideEffect()
+
     object ClickRankingRetry : MainSideEffect()
 
     class NavigateToFriends(val friendType: FriendsType, val myUserId: Int, val nickname: String) :

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/MainViewModel.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/MainViewModel.kt
@@ -171,6 +171,10 @@ internal class MainViewModel @Inject constructor(
         postSideEffect(MainSideEffect.NavigateToNotification)
     }
 
+    fun navigateToProfile(userId: Int) = intent {
+        postSideEffect(MainSideEffect.NavigateToProfile(userId))
+    }
+
     /** 온보딩(가이드) 활성화 여부를 업데이트한다 */
     fun updateGuideVisible(visible: Boolean) = intent {
         reduce { state.copy(guideVisible = visible) }

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/home/HomeState.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/home/HomeState.kt
@@ -60,13 +60,14 @@ internal data class HomeState(
             val profileImgUrl: String,
             val favoriteTag: String,
             val tier: String,
+            val userId: Int,
         ) {
             /**
              * [User] 의 Empty Model 입니다.
              * 초기화 혹은 Skeleton UI 등에 필요한 Mock Data 로 쓰입니다.
              */
             companion object {
-                fun empty() = User("", "", "", "")
+                fun empty() = User("", "", "", "", 0)
             }
         }
 

--- a/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/mapper/mapper.kt
+++ b/feature/home/src/main/kotlin/team/duckie/app/android/feature/home/viewmodel/mapper/mapper.kt
@@ -50,5 +50,6 @@ internal fun Exam.toFollowingModel() =
             profileImgUrl = user?.profileImageUrl ?: "",
             favoriteTag = user?.duckPower?.tag?.name ?: "",
             tier = user?.duckPower?.tier ?: "",
+            userId = user?.id ?: 0,
         ),
     )


### PR DESCRIPTION
## Issue

- close [홈 팔로잉 탭에서 유저 프로필 클릭 시 유저 프로필로 이동하지 않음](https://www.notion.so/duckie-team/a153d08ed27e441796196a05fac301fe?pvs=4)

## Overview (Required)

- 홈 -> 팔로잉 탭에서 유저 프로필 클릭 시 ProfileActivity로 이동하도록 구현했습니다.
- 홈 팔로잉 프로필 사진의 크기를 스펙에 맞게 수정했습니다. (24.dp to 32.dp)

