### PR TITLE
chore: update compose-foundation 1.6.0-alpha-03 to 1.6.0-alpha04

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ androidx-annotation = "1.6.0"
 
 # compose
 compose-core = "1.4.2"
-compose-foundation = "1.6.0-alpha03" # use alpha for HorizontalPager
+compose-foundation = "1.6.0-alpha04" # use alpha for HorizontalPager
 compose-material = "1.4.2"
 compose-runtime = "1.5.0-alpha03" # use alpha for SnapshotStateList#toList
 compose-lifecycle = "2.6.1" # use alpha for StateFlow#collectAsStateWithLifecycle


### PR DESCRIPTION
### 작업 내용
* 간혈적으로 앱이 터지는 현상이 발생([issueTracker](https://issuetracker.google.com/issues/295214720))
* 대응하기 위해 컴포즈 버전을 1.6.0-alpha03 에서 1.6.0-alpha04로 올렸습니다.