### PR TITLE
프로필 수정화면에서 empty string일 경우 null로 전달

### DIFF
--- a/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/viewmodel/ProfileEditViewModel.kt
+++ b/feature/profile/src/main/kotlin/team/duckie/app/android/feature/profile/viewmodel/ProfileEditViewModel.kt
@@ -213,7 +213,7 @@ class ProfileEditViewModel @Inject constructor(
                 tags = null,
                 status = null,
                 nickname = state.nickname,
-                introduction = state.introduce,
+                introduction = state.introduce.ifEmpty { null },
             ).onSuccess {
                 postSideEffect(ProfileEditSideEffect.NavigateBack)
             }.onFailure {


### PR DESCRIPTION
## Overview (Required)
- 서버에서 introduce라는 값이 비어있다는 것을 null로 관리하고 있어 맞게 저장하기 위함
