### PR TITLE
chore: update quack-ui '2.0.0-alpha14'

### DIFF
--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
         libs.paging.runtime,
         libs.paging.compose,
         libs.quack.v2.ui,
-        libs.quack.v2.ui.plugin.interceptor.textfield,
         libs.kotlin.collections.immutable,
     )
 }

--- a/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/screen/SearchActivity.kt
+++ b/feature/search/src/main/kotlin/team/duckie/app/android/feature/search/screen/SearchActivity.kt
@@ -87,8 +87,6 @@ import team.duckie.quackquack.material.icon.quackicon.outlined.ArrowBack
 import team.duckie.quackquack.material.quackClickable
 import team.duckie.quackquack.material.theme.QuackTheme
 import team.duckie.quackquack.ui.QuackIcon
-import team.duckie.quackquack.ui.plugin.interceptor.textfield.QuackTextFieldFontFamilyRemovalPlugin
-import team.duckie.quackquack.ui.plugin.rememberQuackPlugins
 import javax.inject.Inject
 
 internal val SearchHorizontalPadding = PaddingValues(horizontal = 16.dp)
@@ -140,12 +138,7 @@ class SearchActivity : BaseActivity() {
                     focusRequester.requestFocus()
                 }
             }
-
-            QuackTheme(
-                plugins = rememberQuackPlugins {
-                    +QuackTextFieldFontFamilyRemovalPlugin
-                },
-            ) {
+            QuackTheme {
                 ReportDialog(
                     visible = state.reportDialogVisible,
                     onClick = { vm.updateReportDialogVisible(false) },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,7 +114,7 @@ quack-lint-compose = "1.0.2"
 # TODO(sungbin): quack-lint-writing
 
 # quack v2
-quack-v2-ui = "2.0.0-alpha11"
+quack-v2-ui = "2.0.0-alpha14"
 quack-v2-ui-plugin-interceptor-textfield ="2.0.0-alpha01"
 
 # test
@@ -258,8 +258,8 @@ quack-lint-core = { module = "team.duckie.quack:quack-lint-core", version.ref = 
 quack-lint-quack = { module = "team.duckie.quack:quack-lint-quack", version.ref = "quack-lint-quack" }
 quack-lint-compose = { module = "team.duckie.quack:quack-lint-compose", version.ref = "quack-lint-compose" }
 
-quack-v2-ui = { module = "team.duckie.quackquack.ui:ui", version.ref = "quack-v2-ui" }
-quack-v2-ui-plugin-interceptor-textfield = { module = "team.duckie.quackquack.ui:ui-plugin-interceptor-textfield", version.ref = "quack-v2-ui-plugin-interceptor-textfield"}
+quack-v2-ui = { module = "io.github.duckie-team.ui:ui", version.ref = "quack-v2-ui" }
+#quack-v2-ui-plugin-interceptor-textfield = { module = "team.duckie.quackquack.ui:ui-plugin-interceptor-textfield", version.ref = "quack-v2-ui-plugin-interceptor-textfield"}
 
 test-strikt = { module = "io.strikt:strikt-core", version.ref = "test-strikt" }
 test-junit-core = { module = "junit:junit", version.ref = "test-junit-core" }


### PR DESCRIPTION
### 작업 내용
* TextField 문제 해결을 위해 꽥꽥 Material 에서 폰트를 pretendard로 수정 후 배포하였고, 이를 덕키 앱 내에서 꽥꽥 버전을 올려 적용했습ㄴ디ㅏ.